### PR TITLE
feat(contact-center): add agent handoff summary APIs

### DIFF
--- a/packages/@webex/contact-center/ai-docs/ARCHITECTURE.md
+++ b/packages/@webex/contact-center/ai-docs/ARCHITECTURE.md
@@ -1,0 +1,189 @@
+# ARCHITECTURE - @webex/contact-center
+
+> Start here after [AGENTS.md](../AGENTS.md) and [SPEC_INDEX.md](SPEC_INDEX.md). Module detail lives in source-local specs.
+
+## Design Overview
+`@webex/contact-center` is a Webex JS SDK package that embeds a Contact Center plugin into Webex Core. Consumers enter through package exports in `src/index.ts` and through the registered `webex.cc` facade in `src/cc.ts`.
+
+The package is intentionally a client-side orchestration layer. It owns runtime state, task collections, WebSocket connections, pending AQM request correlation, cache entries, metrics queues, and Web Calling mappings. It does not own WCC data persistence, schema migrations, or backend domain storage.
+
+The architecture keeps public consumer operations in `ContactCenter`, splits WCC route construction into service modules, centralizes realtime/request mechanics under `src/services/core/`, and routes task-specific state transitions through `TaskManager` and `Task`.
+
+## Component Inventory & Responsibilities
+| Component | Responsibility | Docs |
+|---|---|---|
+| `src/` | Package exports, plugin registration, `ContactCenter` public facade, bootstrap config | [contact-center-plugin-spec.md](../src/ai-docs/contact-center-plugin-spec.md) |
+| `src/services/agent/` | AQM-backed agent session operations and agent event types | [agent-session-spec.md](../src/services/agent/ai-docs/agent-session-spec.md) |
+| `src/services/task/` | Task object behavior, task event hydration, contact controls, dialer/campaign routes, generated handoff summary helpers/events | [task-lifecycle-spec.md](../src/services/task/ai-docs/task-lifecycle-spec.md) |
+| `src/services/core/` | Webex request wrapper, AQM correlation, WebSocket subscription, keepalive, connection recovery, error utilities | [realtime-request-core-spec.md](../src/services/core/ai-docs/realtime-request-core-spec.md) |
+| `src/services/config/` and lookup files | User/org/profile/team/aux-code config and paginated lookup APIs | [configuration-lookup-apis-spec.md](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) |
+| `src/services/WebCallingService.ts` | Web Calling registration, call control, and call-to-task mapping | [web-calling-spec.md](../src/services/ai-docs/web-calling-spec.md) |
+| `src/services/ApiAiAssistant.ts` | AI Assistant events for transcripts and generated handoff summaries plus historic transcript retrieval | [ai-assistant-spec.md](../src/services/ai-docs/ai-assistant-spec.md) |
+| `src/metrics/`, `src/logger-proxy.ts` | Metrics event submission, taxonomy, timing, common fields, logging proxy | [metrics-observability-spec.md](../src/metrics/ai-docs/metrics-observability-spec.md) |
+
+## Component Interaction
+```mermaid
+flowchart TD
+  SDK[SDK consumer] --> CC[ContactCenter facade]
+  WebexCore[Webex Core] --> CC
+  CC --> Services[Services singleton]
+  Services --> Agent[Agent routes]
+  Services --> Contact[Contact task routes]
+  Services --> Dialer[Dialer routes]
+  Services --> AQM[AqmReqs]
+  Services --> WS[WebSocketManager]
+  CC --> Config[AgentConfigService]
+  CC --> Lookups[AddressBook / EntryPoint / Queue]
+  CC --> TM[TaskManager]
+  TM --> Task[Task instances]
+  Task --> Contact
+  Task --> AI[ApiAIAssistant]
+  Task --> Calling[WebCallingService]
+  CC --> AI[ApiAIAssistant]
+  CC --> Metrics[MetricsManager]
+  AQM --> WS
+  WS --> WCCWS[WCC WebSocket]
+  Config --> WCCREST[WCC REST]
+  Lookups --> WCCREST
+  AI --> WCCREST
+  Calling --> CallingSDK[@webex/calling]
+```
+
+`ContactCenter.register()` initializes profile/config state, services, WebSocket subscriptions, TaskManager, Web Calling, AI Assistant, lookup facades, and metrics. Agent and task operations usually issue a WCC request and wait for corresponding realtime notification through `AqmReqs`. Task lifecycle events hydrate or update `Task` instances and emit SDK events to consumers.
+
+## Init & Call Flow
+```mermaid
+sequenceDiagram
+  participant App as SDK consumer
+  participant Core as Webex Core
+  participant CC as ContactCenter
+  participant Config as AgentConfigService
+  participant WS as WebSocketManager
+  participant TM as TaskManager
+  participant WCC as WCC services
+  App->>Core: Webex.init(config)
+  Core->>CC: registerPlugin('cc')
+  App->>CC: register()
+  CC->>Config: fetch agent/org/profile/team config
+  Config->>WCC: REST requests through WebexRequest
+  CC->>WS: subscribe(connectionConfig)
+  WS->>WCC: WebSocket subscribe
+  CC->>TM: create/register task listeners
+  CC-->>App: Profile
+  WCC-->>WS: routing notification
+  WS-->>TM: event
+  TM-->>App: task:* or agent:* event
+```
+
+Failure paths include WCC REST request rejection, WebSocket welcome timeout, connection-lost events, AQM notification timeout, Web Calling registration timeout, and agent relogin failure. Those are detailed in module specs.
+
+## Dependencies
+| Dependency | Type | How used | Failure / version handling |
+|---|---|---|---|
+| `@webex/webex-core` | internal workspace peer | plugin host, credentials, request/services plumbing | workspace dependency; public facade fails if host credentials/services are unavailable |
+| `@webex/calling` | internal workspace dependency | browser calling registration and media call control | `WebCallingService` rejects registration timeout and cleans call state |
+| `@webex/internal-plugin-metrics` | internal workspace dependency | behavioral, operational, and business metric submission | `MetricsManager` queues pending events until metrics instance exists |
+| `@webex/internal-plugin-support` | internal workspace dependency | diagnostic log upload | `WebexRequest.uploadLogs()` wraps submitLogs response/error |
+| `@webex/plugin-logger` | internal workspace dependency | package logging through logger proxy | SECURITY rules forbid token/header logging |
+| `@webex/internal-plugin-mercury` | internal workspace dependency | SDK realtime context | workspace dependency; WCC realtime uses package WebSocketManager |
+| WCC API gateway | external service | WCC REST resources for config, AQM, lookup, AI Assistant, outdial | request errors are normalized and surfaced to callers |
+| WCC WebSocket | external service | realtime routing/task/agent notifications and request correlation | keepalive worker, welcome timeout, reconnect/relogin paths |
+| Browser APIs | runtime | WebSocket, Worker, Blob, URL, navigator.onLine, MediaStream, crypto.randomUUID | tests mock browser/runtime APIs; callers must run in supported browser-like context for media |
+
+## State Model
+| State | Owner | Trigger | Notes |
+|---|---|---|---|
+| Agent profile/config | `ContactCenter`, `AgentConfigService` | `register()`, `updateAgentProfile()` | in-memory; source is WCC config resources |
+| WebSocket connection state | `WebSocketManager`, `ConnectionService` | subscribe, welcome, close, keepalive, network status | in-memory and event-driven |
+| Pending AQM requests | `AqmReqs` | route request until success/failure/cancel/timeout notification | keyed by bind data; cleared on settle |
+| Task collection | `TaskManager` | WCC task notifications and realtime transcript events | in-memory map of active `Task` objects |
+| Task object data | `Task` | task event updates, handoff summary events, and reconcileData | preserves nested fields when partial updates omit them |
+| AI feature flags | `ApiAIAssistant` | config load and optional feature enablement events | gates generated handoff summary requests and transcript behavior |
+| Page lookup cache | `PageCache` | AddressBook, EntryPoint, Queue page fetches | in-memory, 5 minute default TTL |
+| Web Calling task mapping | `WebCallingService` | call events and task operations | maps call id to task id in memory |
+| Metrics pending queues | `MetricsManager` | event submit before metrics instance exists | flushed when metrics becomes available |
+
+## Cross-Cutting Concerns
+- Security: credentials come from Webex SDK credentials; WCC requests use SDK request plumbing; raw Authorization headers are masked before logging; org/agent/task identifiers are diagnostic data and must not be expanded beyond existing conventions.
+- Observability: package code uses LoggerProxy and MetricsManager. Important operations emit success/failure metric pairs and include tracking fields from AQM responses where available.
+
+## Footprint & Compatibility
+This is a published SDK package. Backward compatibility applies to package exports, `webex.cc` methods, event enums, TypeScript types, and documented runtime behavior. Breaking changes require a versioning and consumer migration plan.
+
+## Dependency / Interaction Topology
+| From | To | Kind | Purpose |
+|---|---|---|---|
+| `src/index.ts` | Webex Core | registration | installs `cc` plugin |
+| `src/cc.ts` | `Services` | call/composition | creates WCC route clients and WebSocket managers |
+| `src/cc.ts` | `AgentConfigService` | call | builds runtime profile/config |
+| `src/cc.ts` | `TaskManager` | call/event | owns task event subscription and task collection |
+| `Task` | `routingContact` / `aqmDialer` | call | performs task operations through AQM |
+| `Task` | `ApiAIAssistant` | call | sends generated handoff summary request/response events |
+| `AqmReqs` | `WebSocketManager` | event | resolves request promises from realtime notifications |
+| `WebSocketManager` | WCC WebSocket | network | subscribes and receives routing events |
+| `WebexRequest` | WCC REST | network | service/resource HTTP calls |
+| `WebCallingService` | `@webex/calling` | call/event | registers line and controls media calls |
+| `MetricsManager` | internal metrics plugin | call | submits telemetry |
+
+## Object / Data Ownership
+| Domain object | System-of-record | Read/write by this package |
+|---|---|---|
+| Agent profile, team, aux code, org metadata | WCC backend | read and compose into in-memory Profile |
+| Task/contact interaction | WCC backend and realtime events | read, update through AQM operations, cache active task object, emit summary payloads |
+| Generated handoff summary | AI Assistant/WCC backend | request/respond through AI Assistant event API; pass backend payload through task events |
+| Address book entries, entry points, queues | WCC backend | read with in-memory page cache |
+| Web Calling call | Calling SDK / WebRTC runtime | mapped to Contact Center task id |
+| Metrics events | internal metrics plugin/backend | created/submitted by package |
+
+## Caching Catalog
+| Cache | Backend | What it holds | TTL | Invalidation trigger |
+|---|---|---|---|---|
+| `PageCache<T>` | in-memory `Map` | paginated lookup responses keyed by org/page/pageSize/search/filter/attributes/sort | 5 minutes default | time expiry, `clearCache()`, cache size handling |
+| Task collection | in-memory object/map in TaskManager | active task instances by task id | event-driven | task end, wrapup, cleanup, disconnect/removal events |
+| Pending metrics queues | arrays in MetricsManager singleton | event payloads waiting for metrics plugin instance | until flush | metrics instance availability and submit attempt |
+| AQM pending requests | objects in `AqmReqs` | promise resolvers keyed by notification bind | until settle/timeout | success, failure, cancel, or timeout notification |
+
+## Observability Patterns
+- Logging: use `LoggerProxy` or module logger; never log raw credentials or Authorization values.
+- Metrics: use `MetricsManager` and constants from `src/metrics/constants.ts`; preserve success/failure event pairs and timed duration handling.
+- Diagnostics: log upload runs through `WebexRequest.uploadLogs()` and the internal support plugin.
+
+## Shared / Base Libraries
+| Library | What every module inherits | Version floor |
+|---|---|---|
+| `@webex/legacy-tools` | build/test conventions and package command shape | workspace dependency |
+| `@webex/babel-config-legacy` | Babel TypeScript/env build behavior | workspace dependency |
+| `@webex/jest-config-legacy` | Jest defaults | workspace dependency |
+| `@webex/eslint-config-legacy` | TypeScript lint conventions | workspace dependency |
+| TypeScript | declaration output and public type surface | package dev dependency `4.9.5` |
+
+## Package Map & Inter-Package Dependencies
+The repository root is a Yarn workspace with packages under `packages/@webex/*`. This package is one workspace member and depends on workspace packages including `@webex/calling`, `@webex/internal-plugin-metrics`, `@webex/internal-plugin-support`, `@webex/plugin-authorization`, `@webex/plugin-logger`, and `@webex/webex-core`.
+
+## Release & Versioning
+- Publish target: package script `deploy:npm` runs `yarn npm publish`.
+- Public package entry: `dist/webex.js`; type entry: `dist/types/index.d.ts`.
+- Compatibility applies to exports in `src/index.ts`, generated declaration output, event names, and documented method behavior.
+
+## Host Integration & Theming
+The host is Webex Core, not a UI theme provider. `src/index.ts` registers `ContactCenter` as the `cc` plugin. Consumers access it as `webex.cc` after Webex SDK initialization and readiness.
+
+## Cross-Repo Dependency Graph
+- Internal same workspace: Webex Core, Calling, Metrics, Support, Logger, Authorization, Mercury.
+- External services: WCC API gateway REST resources, WCC WebSocket, AI Assistant URLs discovered from WCC config.
+- External read-only references: README and generated TypeDoc; exact behavior remains in code/tests.
+
+## Security Architecture
+Trust boundary is between SDK consumer/browser runtime and WCC services. Credentials are provided by Webex SDK credentials and used through SDK request plumbing. WCC WebSocket subscription uses service-discovered endpoints and conditionally sends `X-ORGANIZATION-ID` only for integration environments. AQM requests and notifications include tracking identifiers; logs must mask Authorization header values and avoid widening sensitive payload logging.
+
+## Architecture Reference Links
+| Reference | Location | When to read |
+|---|---|---|
+| Architecture decisions | [adr/](adr/) | before changing major design tradeoffs |
+| Patterns | [patterns/contact-center-patterns.md](patterns/contact-center-patterns.md) | before adding similar code |
+| Enforceable rules | [RULES.md](RULES.md) and [rules/typescript.md](rules/typescript.md) | before implementation |
+
+## WS6 References
+| Artifact | Relevance | Link |
+|---|---|---|
+| None discovered during bootstrap | No local authoritative WS6 doc was found in package scope | N/A |

--- a/packages/@webex/contact-center/ai-docs/CONTRACTS.md
+++ b/packages/@webex/contact-center/ai-docs/CONTRACTS.md
@@ -1,0 +1,70 @@
+# Contracts Catalog - @webex/contact-center
+
+> Public-surface index for the package. Detailed behavior lives in owning module specs and TypeDoc generated from `src/index.ts`.
+
+## Exported API & Types
+| Contract ID | Owner | Symbol | Signature / shape | Stability / deprecation | Detail link | Defined at |
+|---|---|---|---|---|---|---|
+| `cc.package.default` | `src/` | default export | `ContactCenter` | public package surface | [plugin spec](../src/ai-docs/contact-center-plugin-spec.md) | `src/index.ts` |
+| `cc.package.ContactCenter` | `src/` | `ContactCenter` | class export | public package surface | [plugin spec](../src/ai-docs/contact-center-plugin-spec.md) | `src/index.ts`, `src/cc.ts` |
+| `cc.package.Task` | `src/services/task/` | `Task` | class export | public package surface | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/index.ts`, `src/services/task/index.ts` |
+| `cc.package.routingAgent` | `src/services/agent/` | `routingAgent` | route factory | exported; treat as compatibility-sensitive | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/index.ts`, `src/services/agent/index.ts` |
+| `cc.package.AddressBook` | lookup APIs | `AddressBook` | class export | public package surface | [config/lookup spec](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) | `src/index.ts`, `src/services/AddressBook.ts` |
+| `cc.package.ApiAIAssistant` | AI Assistant | `ApiAIAssistant` | class export | public package surface | [AI Assistant spec](../src/services/ai-docs/ai-assistant-spec.md) | `src/index.ts`, `src/services/ApiAiAssistant.ts` |
+| `cc.events.task` | task | `TASK_EVENTS` | enum of `task:*` events | additive events are compatible; renames/removals are breaking | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/services/task/types.ts` |
+| `cc.task.handoffSummary` | task | `HANDOFF_SUMMARY_ACTION`, `HandoffSummary*` payload/action types, `Task.requestHandoffSummary`, `Task.respondToHandoffSummary` | generated handoff summary request/response API | additive public task API and types | [handoff task contract](../features/cai-7974-agent-handoff-summary/design/contracts/handoff-summary-task-api.md) | `src/index.ts`, `src/services/task/index.ts`, `src/services/task/types.ts` |
+| `cc.events.agent` | agent | `AGENT_EVENTS` | enum of `agent:*` events | additive events are compatible; renames/removals are breaking | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/services/agent/types.ts` |
+| `cc.events.config` | config/task/agent bridge | `CC_EVENTS`, `CC_TASK_EVENTS`, `CC_AGENT_EVENTS` | WCC event enum bridge | compatibility-sensitive because TaskManager maps these | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/services/config/types.ts` |
+| `cc.types` | package | exported TypeScript types | agent, task, config, lookup, SDK interfaces | generated declaration output is public | TypeDoc and owning specs | `src/index.ts`, `src/types.ts`, module `types.ts` files |
+
+## ContactCenter Public Methods
+| Contract ID | Owner | Method | Purpose | Detail link | Defined at |
+|---|---|---|---|---|---|
+| `cc.register` | plugin facade | `register(): Promise<Profile>` | initialize config/services/WebSocket/task/calling/metrics state | [plugin spec](../src/ai-docs/contact-center-plugin-spec.md) | `src/cc.ts` |
+| `cc.deregister` | plugin facade | `deregister(): Promise<void>` | clean up registration/session resources | [plugin spec](../src/ai-docs/contact-center-plugin-spec.md) | `src/cc.ts` |
+| `cc.stationLogin` | agent | `stationLogin(data)` | login agent to station/device type | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/cc.ts`, `src/services/agent/index.ts` |
+| `cc.stationLogout` | agent | `stationLogout(data)` | logout agent | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/cc.ts`, `src/services/agent/index.ts` |
+| `cc.setAgentState` | agent | `setAgentState(data)` | change availability/aux state | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/cc.ts`, `src/services/agent/index.ts` |
+| `cc.getBuddyAgents` | agent | `getBuddyAgents(data)` | fetch buddy agents by profile/media/state filter | [agent spec](../src/services/agent/ai-docs/agent-session-spec.md) | `src/cc.ts`, `src/services/agent/index.ts` |
+| `cc.startOutdial` | task/dialer | `startOutdial(data)` | initiate outbound task/call | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/cc.ts`, `src/services/task/dialer.ts` |
+| `cc.acceptPreviewContact` | task/dialer | `acceptPreviewContact(data)` | accept campaign preview reservation | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/cc.ts`, `src/services/task/dialer.ts` |
+| `cc.skipPreviewContact` | task/dialer | `skipPreviewContact(data)` | skip campaign preview contact | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/cc.ts`, `src/services/task/dialer.ts` |
+| `cc.removePreviewContact` | task/dialer | `removePreviewContact(data)` | remove campaign preview contact | [task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) | `src/cc.ts`, `src/services/task/dialer.ts` |
+| `cc.getOutdialAniEntries` | config | `getOutdialAniEntries(params)` | fetch outdial ANI options | [config spec](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) | `src/cc.ts`, `src/services/config/index.ts` |
+| `cc.getEntryPoints` | lookup | `getEntryPoints(params)` | fetch entry point pages | [config spec](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) | `src/cc.ts`, `src/services/EntryPoint.ts` |
+| `cc.getQueues` | lookup | `getQueues(params)` | fetch queue pages | [config spec](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) | `src/cc.ts`, `src/services/Queue.ts` |
+| `cc.uploadLogs` | core/observability | `uploadLogs(...)` | submit diagnostic logs through support plugin | [core spec](../src/services/core/ai-docs/realtime-request-core-spec.md) | `src/cc.ts`, `src/services/core/WebexRequest.ts` |
+| `cc.updateAgentProfile` | plugin facade/config | `updateAgentProfile(...)` | update local profile/device configuration | [plugin spec](../src/ai-docs/contact-center-plugin-spec.md) | `src/cc.ts` |
+
+## Events
+| Contract ID | Owner | Event / topic | Direction | Payload schema link | Delivery guarantees | Compatibility / deprecation | Defined at |
+|---|---|---|---|---|---|---|---|
+| `task.events` | task | `task:*` enum values including incoming, assigned, media, hold/resume, consult, transfer, wrapup, campaign preview, handoff summary, multi-login hydrate | emit | `src/services/task/types.ts` | best effort from WCC realtime into local EventEmitter | additive only without deprecation plan | `src/services/task/types.ts`, `src/services/task/TaskManager.ts` |
+| `task.handoffSummary.events` | task | `task:handoffSummary`, `task:handoffSummaryResponse`, `task:handoffSummaryFeatureEnablement` | emit | [handoff task contract](../features/cai-7974-agent-handoff-summary/design/contracts/handoff-summary-task-api.md) | same best-effort ordering as WCC websocket delivery | additive only without deprecation plan | `src/services/task/types.ts`, `src/services/task/TaskManager.ts` |
+| `agent.events` | agent | `agent:*` enum values for state/login/logout/relogin/multi-login | emit | `src/services/agent/types.ts` | best effort from WCC realtime/AQM response | additive only without deprecation plan | `src/services/agent/types.ts`, `src/services/agent/index.ts` |
+| `cc.events.bridge` | config/task | `CC_EVENTS`, `CC_TASK_EVENTS`, `CC_AGENT_EVENTS` | consume/emit bridge | `src/services/config/types.ts` | maps WCC messages to SDK events | mapping changes are breaking unless compatibility is preserved | `src/services/config/types.ts`, `src/services/task/TaskManager.ts` |
+| `webcalling.events` | Web Calling | call events from `@webex/calling` | consume/emit | `@webex/calling` types | dependent on Calling SDK event delivery | do not rename local task mapping behavior silently | `src/services/WebCallingService.ts` |
+
+## Requires - what this package depends on
+| Dependency | What is consumed | Schema / detail link | Availability assumption | Fallback on failure | Version floor |
+|---|---|---|---|---|---|
+| Webex Core | plugin registration, credentials, request/services | `src/index.ts`, `src/cc.ts` | host initialized before use | public calls reject/fail if credentials/services missing | workspace |
+| WCC REST resources | agent config, org/profile/team/aux codes, AQM, lookups, AI, outdial ANI | owning module specs | available through service discovery | caller-visible errors from `WebexRequest`/module handlers | service contract |
+| WCC WebSocket | task/agent/routing realtime events | core/task/agent specs | subscribe returns welcome and events | welcome timeout, connection lost, relogin paths | service contract |
+| AI Assistant service | `/event` handling for transcripts and generated handoff summaries | [AI Assistant handoff contract](../features/cai-7974-agent-handoff-summary/design/contracts/ai-assistant-handoff-event.md) | URL mapping and feature flags available from WCC config | helper promises reject on request/base URL failure | service contract |
+| `@webex/calling` | WebRTC line registration and call control | Web Calling spec | browser media runtime available | registration timeout and cleanup | workspace |
+| Internal metrics/support/logger plugins | metrics submission, log upload, logging | metrics/core/security specs | host plugin available in Webex SDK | queue or reject depending operation | workspace |
+
+## Compatibility & Deprecation Policy
+- Breaking-change rule: no removal or semantic change to exports, `webex.cc` methods, event names, payload expectations, or public TypeScript types without a versioning and migration plan.
+- Deprecation: mark in TypeDoc/source comments and this catalog, keep transition notes in the owning module spec.
+- Additive events/types/options are compatible only when existing behavior remains unchanged.
+
+## Detailed Interface Docs
+- Package API detail: `src/index.ts`, `typedoc.json`, generated TypeDoc output.
+- Task operation detail: [task-lifecycle-spec.md](../src/services/task/ai-docs/task-lifecycle-spec.md).
+- WCC REST/WebSocket detail is code-owned in route builders and type files; no OpenAPI/AsyncAPI file was found in package scope.
+
+## Maintenance
+- Public surface changes update this file and the owning module spec in the same change.
+- Tests live under `test/unit/spec/` and should mirror the source module being changed.

--- a/packages/@webex/contact-center/ai-docs/GLOSSARY.md
+++ b/packages/@webex/contact-center/ai-docs/GLOSSARY.md
@@ -1,0 +1,22 @@
+# Glossary - @webex/contact-center
+
+| Term | Meaning | Code location |
+|---|---|---|
+| AQM | Agent Queue Management request/notification path used for agent and task operations | `src/services/core/aqm-reqs.ts`, `src/services/agent/index.ts`, `src/services/task/contact.ts` |
+| ContactCenter | Main SDK plugin facade exposed as `webex.cc` | `src/cc.ts`, `src/index.ts` |
+| CC_EVENTS | WCC event bridge enum used by agent/task/config flows | `src/services/config/types.ts` |
+| TASK_EVENTS | SDK task EventEmitter event enum | `src/services/task/types.ts` |
+| AGENT_EVENTS | SDK agent EventEmitter event enum | `src/services/agent/types.ts` |
+| Task | Client-side representation of an active contact/task interaction | `src/services/task/index.ts` |
+| TaskManager | Maintains active tasks and routes incoming WCC events to SDK task events | `src/services/task/TaskManager.ts` |
+| WebSocketManager | Subscribes to WCC realtime endpoint and emits parsed events | `src/services/core/websocket/WebSocketManager.ts` |
+| ConnectionService | Tracks connection-loss and online/offline signals | `src/services/core/websocket/connection-service.ts` |
+| PageCache | In-memory cache for paginated lookup APIs | `src/utils/PageCache.ts` |
+| Web Calling | Browser calling integration through `@webex/calling` | `src/services/WebCallingService.ts` |
+| AI Assistant | WCC AI Assistant events and historic transcript API | `src/services/ApiAiAssistant.ts` |
+| Handoff summary | Generated mid-call summary used during consult/transfer handoff flows | `src/services/task/index.ts`, `src/services/task/TaskManager.ts` |
+| FEATURE_ENABLEMENT | Optional backend event carrying runtime AI feature enablement state such as `consultTransferSummariesEnabled` | `src/services/config/types.ts`, `src/services/task/TaskManager.ts` |
+| Wrapup | Post-contact completion/disposition state and payload | `src/services/task/index.ts`, `src/services/config/types.ts` |
+| Campaign preview | Dialer preview reservation flow for accept/skip/remove | `src/cc.ts`, `src/services/task/dialer.ts`, `src/services/task/types.ts` |
+| Relogin | Automated or explicit agent session recovery after connection/session disruption | `src/cc.ts`, `src/services/agent/index.ts` |
+| Tracking fields | Response identifiers captured for metrics/diagnostics | `src/metrics/MetricsManager.ts`, `src/services/core/Utils.ts` |

--- a/packages/@webex/contact-center/ai-docs/SERVICE_STATE.md
+++ b/packages/@webex/contact-center/ai-docs/SERVICE_STATE.md
@@ -1,0 +1,32 @@
+# Service State - @webex/contact-center
+
+## Current As-Built Registry
+| Surface / component | Current state | Owner doc |
+|---|---|---|
+| Package export map | `.` exports `dist/webex.js` and `dist/types/index.d.ts`; `./package` exports package metadata | [Contracts](CONTRACTS.md) |
+| `webex.cc` plugin | registered in `src/index.ts` with config from `src/config.ts` | [Plugin spec](../src/ai-docs/contact-center-plugin-spec.md) |
+| Agent operations | AQM-backed station login/logout/state/buddy agents through `routingAgent` | [Agent spec](../src/services/agent/ai-docs/agent-session-spec.md) |
+| Task operations | Task methods plus contact/dialer route builders and generated handoff summary helpers/events | [Task spec](../src/services/task/ai-docs/task-lifecycle-spec.md) |
+| Realtime connection | WCC WebSocket subscription, keepalive worker, connection-loss events | [Core spec](../src/services/core/ai-docs/realtime-request-core-spec.md) |
+| Config lookup | Profile/config fetches plus address book, entry point, queue, outdial ANI | [Config spec](../src/services/config/ai-docs/configuration-lookup-apis-spec.md) |
+| Web Calling | Web Calling registration and media/call task mapping | [Web Calling spec](../src/services/ai-docs/web-calling-spec.md) |
+| AI Assistant | event send for transcripts and generated handoff summaries plus historic transcript fetch | [AI Assistant spec](../src/services/ai-docs/ai-assistant-spec.md) |
+| Metrics/logging | singleton metrics manager, taxonomy, logger proxy | [Metrics spec](../src/metrics/ai-docs/metrics-observability-spec.md) |
+
+## Runtime State Inventory
+| State | Owner | Lifetime |
+|---|---|---|
+| profile and config | `ContactCenter` | register until deregister/update |
+| WebSocket subscription | `WebSocketManager` | register until close/deregister/recovery |
+| pending AQM promises | `AqmReqs` | request until notification, cancel, failure, or timeout |
+| active tasks | `TaskManager` | task assignment until cleanup/removal |
+| task data snapshots | `Task` | task lifetime |
+| page lookup cache | `PageCache` | 5 minute default TTL or clear |
+| call-to-task map | `WebCallingService` | call/task lifetime |
+| AI feature flags | `ApiAIAssistant` | register/update until changed by config or feature enablement event |
+| pending metrics queues | `MetricsManager` | until metrics plugin submit |
+
+## Known Bootstrap Gaps
+- No package-owned datastore or migration files were found.
+- No native OpenAPI/AsyncAPI schemas were found in package scope.
+- Independent two-runtime spec validation has not been run by this Codex generation pass.

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/contracts/ai-assistant-handoff-event.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/contracts/ai-assistant-handoff-event.md
@@ -1,0 +1,73 @@
+# Contract - AI Assistant Handoff Summary Events
+
+> Belongs to [`feature-design.md`](../feature-design.md). Standing catalog: [`CONTRACTS.md`](../../../../ai-docs/CONTRACTS.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Interface | AI Assistant `/event` handoff summary usage |
+| Kind | network API / SDK transport |
+| Change type | modify |
+| Producer | `ApiAIAssistant` client |
+| Consumer(s) | WCC AI Assistant service |
+| Canonical schema / API source | `src/services/ApiAiAssistant.ts`; backend machine-readable schema not present in this repo |
+| Feature | `../feature-design.md` |
+| Generated from | `contract` @ SDLC template library `0.2.0` |
+
+## Summary
+Extends the existing AI Assistant `/event` helper so task flows can send `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE` events with optional additional event details while preserving transcript `START`/`STOP` behavior.
+
+## Definition
+- **Canonical source:** `src/services/ApiAiAssistant.ts`
+- **Inline definition if no canonical source exists:**
+
+```ts
+sendEvent(
+  agentId: string,
+  interactionId: string,
+  eventType: AIAssistantEventType,
+  eventName: AIAssistantEventName,
+  action?: AIAssistantEventAction,
+  eventData?: Record<string, unknown>
+): Promise<Record<string, unknown>>
+```
+
+Body shape remains the existing `/event` envelope:
+
+```ts
+{
+  agentId,
+  orgId,
+  eventType,
+  eventName,
+  eventDetails: {
+    data: {
+      interactionId,
+      action?,          // present for transcript start/stop and handoff responses
+      actionTimeStamp,
+      ...eventData
+    }
+  }
+}
+```
+
+## Error / Failure Catalog
+| Condition | Code / signal | Meaning | Consumer action |
+|---|---|---|---|
+| WCC API gateway URL not mapped | `AI_ASSISTANT_BASE_URL_NOT_AVAILABLE` | AI Assistant base URL cannot be derived. | Treat as environment/service discovery failure. |
+| `/event` request rejects | detailed SDK error | AI Assistant service rejected or network request failed. | Surface operation failure and allow retry when user action is retryable. |
+
+## Backward Compatibility
+- **Compatible?** yes - existing transcript callers still pass `START`/`STOP`; action is now optional for request events that do not need one.
+- **Consumer transition / deprecation:** none.
+
+## Delivery & Ordering Guarantees
+- `/event` delivery follows existing Webex SDK request semantics. The SDK does not add retry, de-duplication, or ordering guarantees.
+
+## Validation
+- Unit tests in `test/unit/spec/services/ApiAiAssistant.ts` cover existing transcript body shape and optional event detail behavior.
+
+## References
+- Feature design: `../feature-design.md`
+- Owning module spec: `../../../../src/services/ai-docs/ai-assistant-spec.md`
+- Baseline: package SDD baseline.

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/contracts/handoff-summary-task-api.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/contracts/handoff-summary-task-api.md
@@ -1,0 +1,66 @@
+# Contract - Handoff Summary Task API
+
+> Belongs to [`feature-design.md`](../feature-design.md). Standing catalog: [`CONTRACTS.md`](../../../../ai-docs/CONTRACTS.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Interface | Handoff Summary Task API |
+| Kind | SDK public API / event |
+| Change type | new |
+| Producer | `src/services/task/index.ts`, `src/services/task/types.ts` |
+| Consumer(s) | SDK consumers/widgets |
+| Canonical schema / API source | TypeScript source and generated TypeDoc/API report |
+| Feature | `../feature-design.md` |
+| Generated from | `contract` @ SDLC template library `0.2.0` |
+
+## Summary
+Adds task-level helpers and events so consumers can request a mid-call handoff summary, receive backend summary payloads, and respond with a typed handoff action.
+
+## Definition
+- **Canonical source:** `src/services/task/index.ts`, `src/services/task/types.ts`
+- **Inline definition if no canonical source exists:**
+
+```ts
+type HandoffSummaryAction = 'CANCEL' | 'CONSULT' | 'TRANSFER';
+
+type HandoffSummaryRequestPayload = {
+  interactionId?: string;
+  eventData?: Record<string, unknown>;
+};
+
+type HandoffSummaryResponsePayload = {
+  action: HandoffSummaryAction;
+  interactionId?: string;
+  eventData?: Record<string, unknown>;
+};
+
+interface ITask {
+  requestHandoffSummary(payload?: HandoffSummaryRequestPayload): Promise<Record<string, unknown>>;
+  respondToHandoffSummary(payload: HandoffSummaryResponsePayload): Promise<Record<string, unknown>>;
+}
+```
+
+## Error / Failure Catalog
+| Condition | Code / signal | Meaning | Consumer action |
+|---|---|---|---|
+| Feature flag absent or false | rejected promise / task error | Generated consult-transfer summaries are not enabled for this agent/session. | Do not show summary request affordance; wait for config or enablement update. |
+| AI Assistant service missing | rejected promise / task error | SDK cannot resolve AI Assistant transport. | Treat as transient setup/config failure and surface fallback UI. |
+| AI Assistant `/event` request fails | rejected promise from helper | Backend rejected or transport failed. | Follow existing SDK error handling and retry policy for user action. |
+
+## Backward Compatibility
+- **Compatible?** yes - additive public helpers/events; no existing task method or event is removed.
+- **Consumer transition / deprecation:** no deprecation. Consumers opt into new helpers/events.
+
+## Delivery & Ordering Guarantees
+- Task events are emitted from existing WCC websocket message processing. Ordering is the same as the websocket stream order observed by `TaskManager`.
+- No replay or exactly-once guarantee is added by the SDK.
+
+## Validation
+- Unit tests in `test/unit/spec/services/task/index.ts` cover helper request/response behavior.
+- Unit tests in `test/unit/spec/services/task/TaskManager.ts` cover emitted task events.
+
+## References
+- Feature design: `../feature-design.md`
+- Owning module spec: `../../../../src/services/task/ai-docs/task-lifecycle-spec.md`
+- Baseline: package SDD baseline.

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/feature-design.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/design/feature-design.md
@@ -1,0 +1,227 @@
+# Feature Design - Agent Handoff Summary events and public APIs
+
+> Serves the spec [`feature-spec.md`](../spec/feature-spec.md); feeds decomposition [`../tasks/`](../tasks/) and test plan [`test-strategy.md`](../test-strategy.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Feature / ticket key | `cai-7974-agent-handoff-summary` / `CAI-7974` |
+| Title | Agent Handoff Summary events and public APIs |
+| Feature Spec | `../spec/feature-spec.md` |
+| Status | soft-committed |
+| Change class | `contract-affecting` |
+| created_by / approved_by / date | Codex generator / user chat approval / 2026-06-30 |
+| Generated from | `feature-design` @ SDLC template library `0.2.0` |
+
+## Executive Summary
+This design adds a package-local handoff summary slice to `@webex/contact-center`: `Task` exposes request/response helpers, `ApiAIAssistant` carries the AI Assistant `/event` calls, and `TaskManager` routes WCC handoff summary websocket events to SDK task events. The implementation is additive and flag-gated by `generatedSummaries.consultTransferSummariesEnabled` (R-1..R-7).
+
+## Scenario -> Design Map
+| Requirement / scenario | Design element that satisfies it |
+|---|---|
+| R-1 request summary helper | `Task.requestHandoffSummary()` -> `ApiAIAssistant.sendEvent(GET_MID_CALL_SUMMARY)` |
+| R-2 response helper | `Task.respondToHandoffSummary()` -> `ApiAIAssistant.sendEvent(MID_CALL_SUMMARY_RESPONSE)` |
+| R-3 flag gate | `Task.isHandoffSummaryEnabled()` checks `apiAIAssistant.aiFeature.generatedSummaries.consultTransferSummariesEnabled` |
+| R-4 `MID_CALL_SUMMARY` routing | `TaskManager.registerTaskListeners()` maps backend event to `TASK_EVENTS.TASK_HANDOFF_SUMMARY` |
+| R-5 subsequent-agent response routing | `TaskManager.registerTaskListeners()` maps backend event to `TASK_EVENTS.TASK_HANDOFF_SUMMARY_RESPONSE` |
+| R-6 `FEATURE_ENABLEMENT` | `TaskManager.handleHandoffSummaryFeatureEnablement()` updates AI feature flags when boolean state is present |
+| R-7 docs/types | `src/services/task/types.ts`, `src/types.ts`, module specs, and root contracts docs |
+
+# Feature Architecture
+
+## System Context
+```mermaid
+flowchart LR
+  Widget[SDK consumer / widget] --> Task[Task public API]
+  Task --> AI[ApiAIAssistant]
+  AI --> WCCAI[WCC AI Assistant /event]
+  WCCWS[WCC WebSocket] --> TM[TaskManager]
+  TM --> TaskEvent[Task events]
+  TaskEvent --> Widget
+  Config[AgentConfig aiFeature] --> Task
+```
+
+Inside this package: task helpers, task events, AI Assistant transport usage, feature-flag checks, and websocket routing. Outside this package: backend summary generation, backend schema ownership, and widget UI rendering.
+
+## Functional-Block Decomposition
+```mermaid
+flowchart TB
+  RequestHelper[Task.requestHandoffSummary] --> FlagGate[Generated summary flag gate]
+  ResponseHelper[Task.respondToHandoffSummary] --> ActionPayload[Typed handoff action payload]
+  FlagGate --> SendEvent[ApiAIAssistant.sendEvent]
+  ActionPayload --> SendEvent
+  WebSocket[WCC websocket message] --> Router[TaskManager event router]
+  Router --> Enablement[Feature enablement updater]
+  Router --> SummaryEvent[Task handoff summary event]
+  Router --> ResponseEvent[Task handoff summary response event]
+```
+
+| Block | Responsibility | New or existing | Touches module(s) |
+|---|---|---|---|
+| Task handoff helper block | Public request/response methods and flag checks | new | `src/services/task/index.ts`, `src/services/task/types.ts` |
+| AI Assistant event transport | Builds `/event` body and sends through Webex request | existing extended | `src/services/ApiAiAssistant.ts`, `src/types.ts` |
+| Websocket handoff router | Maps backend handoff events to task events | existing extended | `src/services/task/TaskManager.ts`, `src/services/config/types.ts` |
+| Public event/type catalog | Names SDK events/actions/payloads | existing extended | `src/services/task/types.ts`, `src/index.ts` |
+
+## Object-Model Changes
+| Object / entity | New / changed / removed | Fields / shape change | Owning module |
+|---|---|---|---|
+| `HandoffSummaryAction` | new | `'CANCEL' | 'CONSULT' | 'TRANSFER'` | `src/services/task/types.ts` |
+| `HandoffSummaryRequestPayload` | new | optional `interactionId`, optional generic `eventData` | `src/services/task/types.ts` |
+| `HandoffSummaryResponsePayload` | new | required `action`, optional `interactionId`, optional generic `eventData` | `src/services/task/types.ts` |
+| `HandoffSummaryPayload` | new | generic payload pass-through with optional `interactionId`/`data` | `src/services/task/types.ts` |
+| `AIAssistantEventAction` | new | transcript or handoff action union | `src/types.ts` |
+| `AIFeatureFlags.generatedSummaries.consultTransferSummariesEnabled` | existing | reused as boolean gate | `src/services/config/types.ts` |
+
+## Design Decisions & Rationale
+- **D-1 Keep backend payloads generic:** use `Record<string, unknown>` pass-through for summary payload details - **why:** CAI-7974 names events but does not provide a machine-readable schema.
+- **D-2 Put public helpers on `Task`:** request/response operations belong to the active interaction object - **why:** consumers already perform consult/transfer actions on `Task`.
+- **D-3 Reuse `ApiAIAssistant.sendEvent`:** generalize its optional event data instead of adding another transport method - **why:** PR #4794 already established `/event` URL mapping, metrics, and error handling.
+- **D-4 Emit both semantic SDK events and raw backend event names:** new `TASK_EVENTS.*` names give stable SDK semantics while existing raw event re-emission stays compatible - **why:** current TaskManager emits backend event names after task handling.
+
+## Alternatives Explored
+| Alternative | Pros | Cons | Why not chosen |
+|---|---|---|---|
+| Add a separate handoff summary service | Isolates code | Duplicates AI Assistant URL mapping, metrics, and errors | Existing `ApiAIAssistant` is the intended reusable service. |
+| Require exact backend summary schema now | Stronger compile-time shape | Contract not present in Jira/source | Would invent fields; use generic pass-through until backend schema exists. |
+| Expose only raw websocket events | Minimal code | Consumers still need direct transport knowledge for requests/responses | Ticket asks for public APIs/helpers. |
+
+## Dependencies & Assumptions
+- **Assumes:** `ApiAIAssistant.aiFeature` is set during registration from agent config, as existing code does in `src/cc.ts`.
+- **Assumes:** Backend sends one of `interactionId`, `conversationId`, or nested `data.conversationId` so TaskManager can find the task.
+- **Depends on:** WCC AI Assistant supporting `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE`.
+
+## Architecture Views
+- **Logical view:** covered by Functional-Block Decomposition.
+- **Deployment view:** N/A - this is an SDK package change shipped in the existing package.
+- **Data-flow view:** covered by System Context and Sequence Diagrams.
+
+## Feature-Toggle Strategy
+| Toggle | Gates | Behavior when OFF | Default | Owner | Removal trigger |
+|---|---|---|---|---|---|
+| `generatedSummaries.consultTransferSummariesEnabled` | `Task.requestHandoffSummary()` | reject without sending AI Assistant event | disabled unless true | WCC config/backend | no planned removal |
+| `FEATURE_ENABLEMENT` | optional runtime update to generated summary flag | no effect when payload lacks a boolean | backend controlled | WCC backend | no planned removal |
+
+## Impacted Services / Modules & Task Split
+
+### Contact Center SDK handoff summary
+- **Deployment target:** `@webex/contact-center` package in `webex/webex-js-sdk`.
+- **Epic:** `tasks/sdk-handoff-summary/epic.md`.
+- **Changes:**
+  - Extend task public API and task event enum.
+  - Generalize AI Assistant event payloads.
+  - Add websocket routing for handoff summary events.
+  - Update tests and SDD docs.
+
+## Service Impact Matrix
+| Service / module | Changes? | What changes (or why not) | Owner |
+|---|---|---|---|
+| `src/services/task/` | yes | public helpers, payload/action types, task events, websocket routing | CCSDK |
+| `src/services/ApiAiAssistant.ts` | yes | optional action and generic event data for `/event` helper | CCSDK |
+| `src/services/config/` | yes | adds consumed event names and uses existing generated summary flag | CCSDK |
+| `src/metrics/` | no | existing AI Assistant send-event metrics reused | CCSDK |
+| WCC AI Assistant backend | no package code | must support named events and payloads | WCC backend |
+| Widget UI | no package code | consumes new helpers/events | Widget owner |
+
+## Interface & Contract Definitions
+| Interface | Producer | Consumer(s) | Change type | Contract doc | Schema / API source | Compatibility / deprecation |
+|---|---|---|---|---|---|---|
+| Task handoff summary helpers/events | `@webex/contact-center` | SDK consumers/widgets | new | `contracts/handoff-summary-task-api.md` | `src/services/task/index.ts`; `src/services/task/types.ts` | additive/minor |
+| AI Assistant `/event` handoff usage | `ApiAIAssistant` | WCC AI Assistant service | modify | `contracts/ai-assistant-handoff-event.md` | `src/services/ApiAiAssistant.ts` | additive; transcript behavior preserved |
+
+> Per-interface contract documents live in `contracts/*.md`.
+
+## Protocol / Wire-Format Design
+- Websocket event names consumed: `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`.
+- AI Assistant event names sent: `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE`.
+- Exact backend payload fields are backend-owned and not present in this repo; SDK passes payload objects through and only reads interaction id and optional enablement boolean.
+
+## HA & Failure-Condition Matrix
+| Failure condition | Probability | Impact | Mitigation / fallback |
+|---|---|---|---|
+| Feature flag false/missing | medium | helper cannot request summary | reject before network call; consumer can hide/disable UI. |
+| AI Assistant base URL unavailable | low | request/response helper fails | reuse existing detailed error path. |
+| Backend summary websocket arrives before task exists | low | no task event emitted | log task-not-found behavior consistent with current realtime handling. |
+| Backend payload schema changes | medium | typed fields unavailable | payload is pass-through generic; only interaction-id extraction is SDK-owned. |
+
+## Sequence Diagrams
+Sequence coverage:
+
+| Operation group | Diagram | Failure / recovery coverage |
+|---|---|---|
+| Request and receive handoff summary | Handoff summary request flow | disabled flag and transport failure branches |
+| Respond to handoff summary | Handoff summary response flow | transport failure branch |
+| Runtime enablement | Feature enablement update flow | malformed/no-boolean branch |
+
+```mermaid
+sequenceDiagram
+  participant Widget
+  participant Task
+  participant AI as ApiAIAssistant
+  participant Backend as WCC AI Assistant
+  participant WS as WCC WebSocket
+  participant TM as TaskManager
+
+  Widget->>Task: requestHandoffSummary()
+  alt consultTransferSummariesEnabled is false
+    Task-->>Widget: reject without network call
+  else enabled
+    Task->>AI: sendEvent(GET_MID_CALL_SUMMARY)
+    AI->>Backend: POST /event
+    Backend-->>AI: accepted
+    AI-->>Task: response
+    Backend-->>WS: MID_CALL_SUMMARY
+    WS->>TM: message
+    TM->>Task: emit task:handoffSummary
+    Task-->>Widget: summary payload
+  end
+
+  Widget->>Task: respondToHandoffSummary({action})
+  Task->>AI: sendEvent(MID_CALL_SUMMARY_RESPONSE, action)
+  AI->>Backend: POST /event
+  Backend-->>AI: accepted or rejected
+```
+
+## Rollout / Migration Interlock
+| Step / wave | What ships | Depends on | Toggle state | Owner |
+|---|---|---|---|---|
+| 1 | SDK additive helpers/events and docs | none | backend/config controls flag | CCSDK |
+| 2 | Backend sends enablement and summary events | backend readiness | enable only for ready tenants/agents | WCC backend |
+| 3 | Widget adopts helpers/events | SDK release available | enable per rollout | Widget owner |
+
+## Test Strategy
+Full plan: `../test-strategy.md`. Key scenarios: enabled/disabled helper behavior, response action send, websocket summary event routing, enablement update, existing transcript regression.
+
+## Design Coverage Summary
+| Concern | In-scope / N/A / Out-of-scope | Where addressed |
+|---|---|---|
+| System context | In-scope | System Context |
+| Functional decomposition | In-scope | Functional-Block Decomposition |
+| Object model | In-scope | Object-Model Changes |
+| Alternatives | In-scope | Alternatives Explored |
+| Feature toggle | In-scope | Feature-Toggle Strategy |
+| Scale | N/A | not perf-critical |
+| Service impact | In-scope | Service Impact Matrix |
+| Interfaces / contracts | In-scope | Interface & Contract Definitions |
+| Data model | N/A | no owned datastore/schema |
+| Security / RBAC | N/A | no new authn/authz surface; existing Webex request auth reused |
+| HA / failure | In-scope | HA & Failure-Condition Matrix |
+| Rollout / migration | In-scope | Rollout / Migration Interlock |
+| Test strategy | In-scope | Test Strategy |
+
+## Reviewer Sign-Off
+| Role | Reviewer | Status | Date |
+|---|---|---|---|
+| Architect | CCSDK architect | pending | 2026-06-30 |
+| Tech Lead | CCSDK maintainer | pending | 2026-06-30 |
+| Product | CAI-7974 owner | pending | 2026-06-30 |
+| UX | Widget owner | pending | 2026-06-30 |
+| QA | CCSDK QA | pending | 2026-06-30 |
+| Delivery / SRE | N/A | N/A - SDK package only | 2026-06-30 |
+
+## References / Traceability
+- Feature Spec: `../spec/feature-spec.md`
+- Repo architecture: `../../../ai-docs/ARCHITECTURE.md`
+- Per-interface contracts: `contracts/*.md`
+- Test strategy: `../test-strategy.md`
+- Coverage / contracts baseline: package SDD baseline.

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/intake-summary.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/intake-summary.md
@@ -1,0 +1,99 @@
+# Intake Summary - cai-7974-agent-handoff-summary
+
+## Source
+- Jira: `CAI-7974`
+- GitHub: `webex/webex-js-sdk#4794` (`feat(contact-center): real time transcript`; merged 2026-03-26)
+- Local code: `packages/@webex/contact-center`
+
+## WHAT (user language)
+Add Contact Center SDK support for Agent Handoff Summary flows by handling handoff summary websocket events, exposing task-level delivery events, and adding public helpers to request and respond to mid-call summaries.
+
+## WHY (problem / goal)
+PR #4794 added the reusable AI Assistant transport, feature flags, generic AI Assistant event names, and transcript plumbing, but the handoff summary flow remains unavailable to SDK consumers. Widgets need a typed SDK path to request a consult/transfer handoff summary, receive the summary payload, and send cancel/consult/transfer responses without bypassing package-level task and AI Assistant conventions.
+
+## Scope
+**In scope:**
+- Reuse the existing `ApiAIAssistant` service and `/event` transport for handoff summary requests and responses.
+- Gate summary requests on `agentConfig.aiFeature.generatedSummaries.consultTransferSummariesEnabled`.
+- Handle optional backend `FEATURE_ENABLEMENT` messages if they are sent for handoff summary enablement.
+- Handle `MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` websocket messages.
+- Emit task-level event(s) for mid-call summary delivery so SDK consumers can receive the payload from task flows.
+- Expose typed task helper(s) for requesting mid-call summaries and responding with cancel, consult, or transfer actions.
+- Add or update TypeScript types, event constants, unit tests, and SDK/SDD documentation for the new public surface.
+
+**Out of scope:**
+- Implementing or changing backend AI summary generation.
+- Owning datastore, schema, migration, or durable summary storage changes in this package.
+- Building widget UI flows outside the SDK package; sample/demo updates are secondary documentation, not the core feature.
+- Changing real-time transcript behavior except where shared AI Assistant plumbing must coexist with handoff summary behavior.
+- Repository migration is out of scope; the confirmed source repo for CCSDK is `webex/webex-js-sdk`.
+
+## Change Class
+`contract-affecting`
+
+Rationale: the feature adds or modifies public SDK task helpers, public TypeScript/event surface, consumed websocket messages, and AI Assistant `/event` request semantics. It does not add owned persistence, package UI screens, or CI/CD changes.
+
+Derived feature profile keys from the section question bank:
+- `changes_api=true`
+- `changes_public_api=true`
+- `nontrivial_interface=true`
+- `feature_nontrivial=true`
+- `feature_interactions=true`
+- `backward_compat=true`
+- `needs_rollout=true`
+- `serviceability=true`
+- `doc_obligations=true`
+- `wire_protocol=true`
+- `changes_events=true`
+
+## Touched Modules
+| Module | Coverage | Why touched | Impact (one line) |
+|---|---|---|---|
+| `src/` | Specced | Public package exports and shared TypeScript types live here. | Add/adjust exported task, AI Assistant, and event types without breaking existing consumers. |
+| `src/services/task/` | Specced | TaskManager owns websocket-to-task event routing and task helpers. | Add handoff summary message handling, task event emission, and task helper entrypoints. |
+| `src/services/ApiAiAssistant.ts` | Specced | Existing AI Assistant service owns `/event` transport and feature flags. | Reuse or generalize `sendEvent` for handoff summary request/response flows. |
+| `src/services/config/` | Specced | Agent config owns `aiFeature.generatedSummaries.consultTransferSummariesEnabled`. | Ensure handoff summary requests honor the generated summary flag and any backend enablement event. |
+| `src/metrics/` | Specced | AI Assistant service calls already emit success/failure metrics. | Preserve observability for new handoff summary request/response operations. |
+| `src/services/core/` | Specced | Core owns websocket parsing and event propagation. | Watch module only unless discovery shows top-level websocket parsing needs additional support beyond PR #4794. |
+
+## Acceptance Signals
+- When `consultTransferSummariesEnabled` is false or absent, the SDK does not request a handoff summary.
+- When the feature is enabled and a consult or transfer flow requests a summary, the SDK sends a typed AI Assistant event through the existing `ApiAIAssistant` `/event` transport.
+- If backend sends `FEATURE_ENABLEMENT` for handoff summaries, the SDK handles it without breaking existing config or transcript behavior.
+- On `MID_CALL_SUMMARY`, the SDK emits a task-level event with the summary payload for the owning interaction.
+- On `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, the SDK handles the subsequent-agent response path and exposes it consistently to task consumers.
+- A public helper sends the appropriate `MID_CALL_SUMMARY_RESPONSE` action for cancel, consult, and transfer responses.
+- Unit tests cover disabled flag behavior, enabled request behavior, websocket event routing, helper responses, error/logging behavior, and exported typings/constants.
+- SDK docs and SDD docs describe the added public surface and contract deltas.
+
+## Open Questions
+- **Q-1 Exact message payload shape** - owner: WCC backend / product - status: deferred-to-capture. Jira names `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and `FEATURE_ENABLEMENT`, but does not define full payload schemas.
+- **Q-2 Public helper and event names** - owner: CCSDK maintainers / product - status: deferred-to-capture. Code evidence confirms where helpers and event enums belong, but final names should be frozen in the feature spec before implementation.
+- **Q-3 Enablement state semantics** - owner: WCC backend / CCSDK maintainers - status: deferred-to-discovery. Need to confirm whether `FEATURE_ENABLEMENT` updates package-level `agentConfig`, per-task state, or only gates the current flow.
+- **Q-4 Sample app/docs outside package** - owner: CCSDK maintainers - status: deferred-to-capture. Core SDK docs are in scope; external sample updates should be confirmed before expanding beyond `packages/@webex/contact-center`.
+
+## Contracts Delta (preliminary)
+**Provides:**
+- ADDED public task helper(s) for requesting mid-call handoff summaries and responding with cancel, consult, or transfer actions.
+- ADDED task event(s) and TypeScript payload types for mid-call summary delivery.
+- MODIFIED exported event/type surface in `src/types.ts` and package entrypoints as needed.
+
+**Requires:**
+- ADDED or MODIFIED WCC websocket event contracts for `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`.
+- MODIFIED AI Assistant `/event` usage for `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE`.
+- REUSES existing WCC API gateway and AI Assistant service discovery from `ApiAIAssistant`.
+
+## Stakeholders
+| Role | Interest | Sign-off needed? |
+|---|---|---|
+| CCSDK maintainers | Public SDK API, task event shape, typings, tests, and package compatibility | yes |
+| WCC AI Assistant/backend owners | `/event` semantics and websocket payload contracts | yes |
+| Widget / SDK consumers | Event delivery and helper ergonomics for consult/transfer handoff summary flows | yes |
+| QA / release validation | Disabled/enabled feature behavior, event routing, and regression coverage | yes |
+
+## Provenance
+- Created by: Codex generator runtime
+- Created at: 2026-06-30T10:58:42Z
+- Source: `CAI-7974`, `webex/webex-js-sdk#4794`, local `packages/@webex/contact-center` code at `f4fd57010e`
+- Run record: local-only SDD run record, not included in this Task 1 PR.
+- Approved by: user approval in chat (`go ahead`) on 2026-06-30

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/spec/feature-spec.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/spec/feature-spec.md
@@ -1,0 +1,191 @@
+# Feature Spec - Agent Handoff Summary events and public APIs
+
+> Start here: repo root [`AGENTS.md`](../../../AGENTS.md) -> router [`SPEC_INDEX.md`](../../../ai-docs/SPEC_INDEX.md) -> system [`ARCHITECTURE.md`](../../../ai-docs/ARCHITECTURE.md). This spec captures WHAT and WHY; the design lives in [`feature-design.md`](../design/feature-design.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Feature / ticket key | `cai-7974-agent-handoff-summary` / `CAI-7974` |
+| Title | Agent Handoff Summary events and public APIs |
+| Status | groomed |
+| Change class | `contract-affecting` |
+| created_by / approved_by / date | Codex generator / user chat approval / 2026-06-30 |
+| Generated from | `feature-spec` @ SDLC template library `0.2.0` |
+
+## Problem & Goal (WHAT + WHY)
+**What:** Add Contact Center SDK support for Agent Handoff Summary flows by handling handoff summary websocket events, exposing task-level delivery events, and adding public helpers to request and respond to mid-call summaries.
+
+**Why:** PR #4794 added the reusable AI Assistant transport, feature flags, generic AI Assistant event names, and transcript plumbing, but the handoff summary flow remains unavailable to SDK consumers. Widgets need a typed SDK path to request a consult/transfer handoff summary, receive the summary payload, and send cancel/consult/transfer responses without bypassing package-level task and AI Assistant conventions.
+
+## Stakeholders & Open Questions
+| Stakeholder / role | Interest in this feature | Sign-off needed? |
+|---|---|---|
+| CCSDK maintainers | Public SDK API, task event shape, typings, tests, and package compatibility | yes |
+| WCC AI Assistant/backend owners | `/event` semantics and websocket payload contracts | yes |
+| Widget / SDK consumers | Event delivery and helper ergonomics for consult/transfer handoff summary flows | yes |
+| QA / release validation | Disabled/enabled feature behavior, event routing, and regression coverage | yes |
+
+**Open questions:**
+- **Q-1 Exact backend message fields** - owner: WCC backend/product - blocks: fixed schema docs only - status: deferred to backend contract. The SDK will pass through backend payloads as typed generic records until a canonical schema exists.
+- **Q-2 Sample app scope** - owner: CCSDK maintainers - blocks: optional demo updates only - status: deferred. Core SDK docs/tests are in scope for this PR.
+
+## Scope
+**In scope:**
+- Reuse `ApiAIAssistant` and `/event` for handoff summary request and response events.
+- Gate summary requests on `agentConfig.aiFeature.generatedSummaries.consultTransferSummariesEnabled`.
+- Handle optional `FEATURE_ENABLEMENT` messages if backend sends handoff summary enablement state.
+- Handle `MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` websocket messages.
+- Emit task-level event(s) for summary delivery and subsequent-agent responses.
+- Add typed task helper(s) for requesting a handoff summary and responding with cancel, consult, or transfer actions.
+- Add TypeScript types, unit tests, and SDD documentation for the new public surface.
+
+**Out of scope:**
+- Backend AI summary generation or schema ownership.
+- Datastore, schema, migration, or durable summary storage changes in this package.
+- Widget UI implementation outside SDK APIs/events.
+- Real-time transcript behavior changes beyond coexistence with shared AI Assistant plumbing.
+- Repository host migration; CCSDK source is `webex/webex-js-sdk`.
+
+**Open decisions:** exact backend payload fields remain backend-owned; the SDK contract is additive and payload-pass-through until a machine-readable schema is supplied.
+
+## Requirements
+| Req ID | Requirement (WHAT) | Rationale (WHY) | Acceptance (how proven) | State |
+|---|---|---|---|---|
+| R-1 | The task API must expose a public helper to request a mid-call handoff summary for the task interaction. | SDK consumers need one supported entrypoint instead of calling AI Assistant transport directly. | Calling the helper with the feature enabled sends `GET_MID_CALL_SUMMARY` through `ApiAIAssistant`; disabled state rejects without sending. | Agreed |
+| R-2 | The task API must expose a public helper to respond to a handoff summary with cancel, consult, or transfer actions. | The widget needs a typed SDK response path that matches backend handoff decisions. | Calling the helper sends `MID_CALL_SUMMARY_RESPONSE` with a typed action and interaction id. | Agreed |
+| R-3 | Summary request helpers must honor `generatedSummaries.consultTransferSummariesEnabled`. | Existing config flags decide whether generated summary behavior is available to the agent. | Unit tests cover enabled and disabled flag states. | Agreed |
+| R-4 | `TaskManager` must route `MID_CALL_SUMMARY` websocket messages to the owning task. | Widgets consume task events, not raw websocket manager events. | A websocket message with matching conversation/interaction id emits the new task summary event. | Agreed |
+| R-5 | `TaskManager` must route `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` websocket messages to the owning task. | Subsequent-agent handoff responses must be observable through the same task event surface. | A websocket message with matching conversation/interaction id emits the new task response event. | Agreed |
+| R-6 | `TaskManager` must process optional `FEATURE_ENABLEMENT` messages without breaking existing transcript/task routing. | Backend may send enablement separately from static config. | Unit tests verify enablement updates the AI feature flag and preserves existing event routing. | Agreed |
+| R-7 | Public events/types and SDD docs must describe the new additive SDK surface. | Public SDK changes must be discoverable and spec-current. | `TASK_EVENTS`, task types, `CONTRACTS.md`, module specs, and feature docs include the delta. | Agreed |
+
+## Acceptance Criteria
+- `task.requestHandoffSummary()` sends `GET_MID_CALL_SUMMARY` only when `consultTransferSummariesEnabled` is true (R-1, R-3).
+- `task.respondToHandoffSummary({action})` sends `MID_CALL_SUMMARY_RESPONSE` with one of cancel, consult, or transfer actions (R-2).
+- `MID_CALL_SUMMARY` websocket messages emit a task-level handoff summary event with the backend payload (R-4).
+- `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` websocket messages emit a task-level response event with the backend payload (R-5).
+- `FEATURE_ENABLEMENT` updates the SDK's AI feature flag when it carries `consultTransferSummariesEnabled` and otherwise remains non-disruptive (R-6).
+- Unit tests cover enabled, disabled, websocket routing, response helper, and generalized `/event` payload behavior (R-1..R-7).
+- SDD and contract docs are updated in the same change as code (R-7).
+
+## Success & Guardrail Metrics
+| Metric | Type | Baseline | Target / bound | How measured |
+|---|---|---|---|---|
+| Handoff summary request helper sends correct AI Assistant event | success | no helper | covered by unit test | `test/unit/spec/services/task/index.ts` |
+| Handoff summary websocket delivery emits task event | success | no routed event | covered by unit test | `test/unit/spec/services/task/TaskManager.ts` |
+| Disabled flag suppresses request | guardrail | transcript flag already suppresses transcript requests | no AI Assistant request when disabled | `test/unit/spec/services/task/index.ts` |
+| Existing transcript start/stop routing | guardrail | PR #4794 behavior | existing TaskManager transcript tests still pass | `test/unit/spec/services/task/TaskManager.ts` |
+| Existing `ApiAIAssistant.sendEvent` transcript shape | guardrail | `GET_TRANSCRIPTS` with `START`/`STOP` | existing ApiAIAssistant tests still pass | `test/unit/spec/services/ApiAiAssistant.ts` |
+
+## Prior-Work Register
+| Existing artifact | How it relates | Reuse / extend / supersede |
+|---|---|---|
+| `src/services/ApiAiAssistant.ts` | Existing AI Assistant `/event` transport and feature flag holder | extend |
+| `src/types.ts` | Existing generic AI Assistant event names include `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE` | reuse/extend |
+| `src/services/config/types.ts` | Existing `generatedSummaries.consultTransferSummariesEnabled` config flag | reuse |
+| `src/services/task/TaskManager.ts` | Existing websocket-to-task event router and transcript request trigger | extend |
+| `src/services/task/types.ts` | Public task event enum and `ITask` interface | extend |
+
+## Contracts Delta
+**Provides:**
+- ADDED `ITask.requestHandoffSummary(...)` public helper.
+- ADDED `ITask.respondToHandoffSummary(...)` public helper.
+- ADDED `TASK_EVENTS.TASK_HANDOFF_SUMMARY`, `TASK_EVENTS.TASK_HANDOFF_SUMMARY_RESPONSE`, and `TASK_EVENTS.TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT`.
+- ADDED public handoff summary action/payload types.
+- MODIFIED `ApiAIAssistant.sendEvent(...)` to support optional action and additional event detail fields while preserving transcript usage.
+
+**Requires:**
+- ADDED consumed websocket event names: `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`.
+- MODIFIED AI Assistant `/event` usage for `GET_MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE`.
+- REUSES existing WCC API gateway, AI Assistant URL mapping, and SDK request plumbing.
+
+## Impacted Modules / Repos
+| Module / repo | Impact | Manifest coverage state |
+|---|---|---|
+| `src/` | Shared AI Assistant action type and public package exports/types | Specced |
+| `src/services/task/` | Public task helpers, events, websocket routing, unit tests | Specced |
+| `src/services/ApiAiAssistant.ts` | Generalized event payload transport | Specced |
+| `src/services/config/` | Adds optional backend enablement websocket event name handling | Specced |
+| `src/metrics/` | Existing AI Assistant send-event metrics continue to cover request/response sends | Specced |
+
+## Feasibility & Risks
+- **Feasibility:** Buildable in this package by extending existing AI Assistant transport and task event routing. Backend exact payload fields are unknown, so SDK payload types stay generic and additive.
+- **Spikes needed:** none for SDK mechanics; backend schema follow-up remains external.
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Backend sends different payload nesting for summary events | medium | medium | Resolve task id from `interactionId`, `conversationId`, and nested `data.conversationId`; pass payload through unchanged. |
+| Backend expects lower/upper-case response actions differently | medium | high | Expose constants and centralize action typing; backend owners must confirm before GA. |
+| New event routing disrupts transcript routing | low | high | Keep transcript map unchanged and cover existing transcript tests. |
+
+## Interaction / Scenario Matrix
+| Scenario / condition combination | Expected behavior | Covered by |
+|---|---|---|
+| feature flag true x task helper request | AI Assistant `GET_MID_CALL_SUMMARY` event sent | R-1/R-3 |
+| feature flag false or absent x task helper request | helper rejects and does not send event | R-3 |
+| `FEATURE_ENABLEMENT` says enabled x existing config disabled | SDK feature flag holder updates to enabled | R-6 |
+| `MID_CALL_SUMMARY` x known task id | task emits handoff summary event and raw backend event | R-4 |
+| `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` x known task id | task emits response event and raw backend event | R-5 |
+| existing transcript-mapped events x realtime transcripts enabled | existing transcript request behavior remains | guardrail |
+
+## Migration Expectations
+- Additive public API and event surface only. Existing task methods, task events, transcript events, and AI Assistant transcript calls remain compatible.
+- Consumers may opt into the new helpers/events when backend handoff summary support is enabled.
+
+## Rollout & Flags
+| Flag | Purpose | Default | New/Existing |
+|---|---|---|---|
+| `agentConfig.aiFeature.generatedSummaries.consultTransferSummariesEnabled` | Gates handoff summary helper requests | backend/config controlled; treated as disabled unless true | existing |
+| `FEATURE_ENABLEMENT` websocket payload | Optional runtime enablement update if backend sends it | no effect unless payload includes a boolean enablement value | backend event |
+
+## Serviceability
+- Reuse `ApiAIAssistant` send-event success/failure metrics for handoff request and response sends.
+- Log disabled/missing AI Assistant service conditions through task helper error paths without logging tokens or sensitive payloads.
+- Keep websocket payloads pass-through; no raw Authorization or credential fields are logged.
+
+## Documentation Obligations
+- Update feature spec/design/task docs.
+- Update `src/services/task/ai-docs/task-lifecycle-spec.md`.
+- Update `src/services/ai-docs/ai-assistant-spec.md`.
+- Update `ai-docs/CONTRACTS.md`, `ai-docs/SERVICE_STATE.md`, `ai-docs/GLOSSARY.md`, and `ai-docs/ARCHITECTURE.md` where the public/event surface changes.
+
+## API / Event Contract
+- `task.requestHandoffSummary(payload?)` -> `design/contracts/handoff-summary-task-api.md`; source: `src/services/task/index.ts`, `src/services/task/types.ts`.
+- `task.respondToHandoffSummary(payload)` -> `design/contracts/handoff-summary-task-api.md`; source: `src/services/task/index.ts`, `src/services/task/types.ts`.
+- `ApiAIAssistant.sendEvent(...)` generalized event details -> `design/contracts/ai-assistant-handoff-event.md`; source: `src/services/ApiAiAssistant.ts`.
+
+## Event Contract
+- Consumes backend websocket event `MID_CALL_SUMMARY`; emits SDK task event `task:handoffSummary`.
+- Consumes backend websocket event `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`; emits SDK task event `task:handoffSummaryResponse`.
+- Consumes optional backend websocket event `FEATURE_ENABLEMENT`; emits SDK task event/manager event `task:handoffSummaryFeatureEnablement` when routed.
+- Delivery/ordering follows existing task websocket event delivery; no new replay/idempotency guarantee is added.
+
+## Public API & Semver Impact
+- Adds public task helper methods and task event enum values.
+- Adds public types for handoff summary actions and payloads.
+- Semver impact: minor/additive for SDK consumers.
+
+## Spec State
+| Section | State |
+|---|---|
+| Problem & Goal | complete |
+| Stakeholders & Open Questions | complete |
+| Scope | complete |
+| Requirements | complete |
+| Acceptance Criteria | complete |
+| Success & Guardrail Metrics | complete |
+| Prior-Work Register | complete |
+| Contracts Delta | complete |
+| Impacted Modules | complete |
+| Conditional sections | complete; backend payload schema remains intentionally generic |
+
+## Change Log
+| Date | Change | By | Why |
+|---|---|---|---|
+| 2026-06-30 | Created groomed feature spec from CAI-7974 intake | Codex | Advance SDLC lifecycle to Discovery/Implementation |
+
+## References
+- Intake summary: `../intake-summary.md`
+- Feature design: `../design/feature-design.md`
+- Test plan: `../test-strategy.md`
+- Jira: `CAI-7974`
+- Prior work: `webex/webex-js-sdk#4794`

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/epic.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/epic.md
@@ -1,0 +1,63 @@
+# Epic - SDK handoff summary API and event routing
+
+## Metadata
+| Field | Value |
+|---|---|
+| Epic title | SDK handoff summary API and event routing |
+| Parent feature | `../../design/feature-design.md` and `../../spec/feature-spec.md` |
+| Service group / capability | `@webex/contact-center` task and AI Assistant SDK surface |
+| Tracker / Epic key | `CAI-7974` |
+| Status | ready |
+| created_by / approved_by / date | Codex generator / user chat approval / 2026-06-30 |
+| Generated from | `epic` @ SDLC template library `0.2.0` |
+
+## Scope - the slice of the design this epic delivers
+This epic delivers the package-local SDK capability for handoff summary request, response, and event delivery. It owns public task helpers/events/types, AI Assistant `/event` payload support, websocket routing, tests, and SDD spec currency for `packages/@webex/contact-center`.
+
+## Mapped Design Sections
+| Feature design section | What this epic delivers from it |
+|---|---|
+| Functional-Block Decomposition | Task helper block, AI Assistant transport extension, websocket handoff router |
+| Interface & Contract Definitions | Task API contract and AI Assistant event contract |
+| Protocol / Wire-Format Design | Event names and pass-through payload handling |
+| Sequence Diagrams | Request/receive/respond/enablement flows |
+| Test Strategy | Unit coverage for helpers, websocket routing, and transport shape |
+
+## Summary of Changes
+- **`src/services/task/`:** add task helper methods, public types/events, websocket summary routing, unit tests, and module spec updates.
+- **`src/services/ApiAiAssistant.ts`:** allow optional action and additional event detail data in `sendEvent`.
+- **`src/types.ts`:** add shared AI Assistant event action type.
+- **`src/services/config/types.ts`:** add backend handoff summary event names.
+- **`ai-docs/`:** update contracts, service state, glossary, architecture, and module specs.
+
+## Baseline vs This Epic
+| Capability | Already shipped (baseline) | Added by this epic |
+|---|---|---|
+| AI Assistant `/event` transport | transcript start/stop events | handoff summary request/response events |
+| Generated summaries config | `consultTransferSummariesEnabled` typed in config | task helper gate and optional runtime enablement handling |
+| Task websocket routing | task lifecycle and transcript events | handoff summary delivery and subsequent-agent response events |
+
+## Child Tasks
+| Task | One-line | PR-sized? | Task doc | Tracker key |
+|---|---|---|---|---|
+| T1 | Implement SDK handoff summary helpers, event routing, tests, and docs | yes | `task-1.md` | `CAI-7974` |
+
+## Sequencing & Dependencies
+| Task / epic | Depends on | Parallel-safe with | Wave |
+|---|---|---|---|
+| T1 | feature spec/design soft-commit | N/A - only task | wave 1 |
+
+## Rollout Order
+1. Ship SDK code and docs with additive APIs.
+2. Backend enables generated summaries for selected agents/tenants.
+3. Widget consumes new task helpers/events.
+
+## Exit Criteria
+- [ ] Public helper methods and task events are implemented.
+- [ ] Unit tests pass for task helper, TaskManager routing, and ApiAIAssistant event payloads.
+- [ ] SDD/docs and contract catalog are updated in the same merge.
+
+## References
+- Feature design: `../../design/feature-design.md`
+- Feature spec: `../../spec/feature-spec.md`
+- Child task: `./task-1.md`

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/implementation-plan-1.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/implementation-plan-1.md
@@ -1,0 +1,97 @@
+# Implementation Plan - Implement SDK handoff summary helpers and events
+
+## Task Context
+| Field | Value |
+|---|---|
+| Task | `./task-1.md` |
+| Parent epic / feature | `./epic.md` / `../../design/feature-design.md` |
+| Target repo(s) / module(s) | `webex/webex-js-sdk` / `packages/@webex/contact-center` |
+| Execution stream / wave | wave 1 |
+| created_by / date | Codex / 2026-06-30 |
+| Generated from | `implementation-plan` @ SDLC template library `0.2.0` |
+
+## Current Context (code-grounded)
+- `Task` currently exposes consult, transfer, and conference methods, but no handoff summary helper - evidence: `src/services/task/index.ts`.
+- `ITask` and `TASK_EVENTS` currently expose task lifecycle events, but no handoff summary event - evidence: `src/services/task/types.ts`.
+- `TaskManager` currently routes task websocket events and transcript request triggers, but has no `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, or `FEATURE_ENABLEMENT` handling - evidence: `src/services/task/TaskManager.ts`.
+- `ApiAIAssistant.sendEvent` currently always includes an action and types it as `TranscriptAction` - evidence: `src/services/ApiAiAssistant.ts`, `src/types.ts`.
+- Agent config already has `generatedSummaries.consultTransferSummariesEnabled` - evidence: `src/services/config/types.ts`.
+
+## Proposed Approach & Sequencing
+1. Add public handoff action/payload types and task event enum values.
+2. Inject `ApiAIAssistant` into newly created `Task` instances so helper methods can reuse existing transport.
+3. Add `requestHandoffSummary()` and `respondToHandoffSummary()` on `Task`.
+4. Generalize `ApiAIAssistant.sendEvent()` to allow optional actions and generic event detail fields.
+5. Add backend event names and route summary/response/enablement websocket messages in `TaskManager`.
+6. Add unit tests for helper, transport, websocket routing, and enablement.
+7. Update module specs and standing docs for spec currency.
+
+## API / Interface Changes
+- Adds `ITask.requestHandoffSummary(payload?)`.
+- Adds `ITask.respondToHandoffSummary(payload)`.
+- Adds handoff summary task event enum values.
+- Extends `ApiAIAssistant.sendEvent(...)` with optional action and optional event data.
+
+## Contract Changes
+- Provides ADDED task public API and task events -> `../../design/contracts/handoff-summary-task-api.md`.
+- Requires MODIFIED AI Assistant `/event` usage -> `../../design/contracts/ai-assistant-handoff-event.md`.
+- Requires consumed backend websocket events `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`.
+
+## Backward-Compat / Rollback
+- **Compatibility:** additive SDK surface; no existing method/event removed.
+- **Consumer transition / deprecation:** none.
+- **Rollback:** revert helper/event additions and docs; backend flag can remain disabled to avoid consumer exposure.
+
+## Logs / Metrics / Alerting
+- Reuse existing `AI_ASSISTANT_SEND_EVENT_SUCCESS` and `AI_ASSISTANT_SEND_EVENT_FAILED` metrics.
+- Log disabled/missing service failures through task helper error paths without credential payloads.
+
+## Implementation Caveats
+- Backend summary payload schema is not available in repo; do not hard-code summary body fields.
+- `FEATURE_ENABLEMENT` payload may be nested differently; read only a boolean `consultTransferSummariesEnabled` from common top-level/nested locations.
+
+## Anticipated PR Split
+| PR | Scope | Depends on |
+|---|---|---|
+| PR1 | SDK helpers/events/routing/tests/docs | none |
+
+## Manual Validation
+- [ ] With backend feature enabled, request a consult-transfer summary from a widget and confirm `task:handoffSummary` is emitted.
+- [ ] With backend feature disabled, confirm helper rejects and widget can hide/disable affordance.
+
+## AI Docs Impact
+
+### `webex/webex-js-sdk` - `packages/@webex/contact-center`
+| Field | Value |
+|---|---|
+| Manifest | package SDD baseline |
+| Standing docs root | `ai-docs/` |
+
+| Doc / source | Decision | Reason / trigger | Required update or no-impact reason |
+|---|---|---|---|
+| Touched module spec(s) | required | public surface, event routing, protocol, tests | update task and AI Assistant specs; config/metrics if needed |
+| `ai-docs/SPEC_INDEX.md` | not required | module registry and routing paths unchanged | no routing change |
+| `ai-docs/CONTRACTS.md` | required | public helper/event and AI Assistant event contract delta | add handoff summary task/API entries |
+| Native schema/API source | required | package entry point/type source changes | update TypeScript source; generated API docs built by existing tooling |
+| `ai-docs/SERVICE_STATE.md` | required | current event/helper/flag surface changes | add handoff summary surface |
+| `ai-docs/DATA_MODEL.md` | not required | no owned datastore/data model | no file exists/needed for this package |
+| `ai-docs/SECURITY.md` | not required | existing authenticated request path reused; no new auth scope | no security posture change |
+| `ai-docs/GLOSSARY.md` | required | new handoff summary terms/events | add terms |
+| `ai-docs/ARCHITECTURE.md` | required | interaction flow adds handoff summary block | update AI/task flow summary |
+| `ai-docs/RULES.md` | not required | no new enforceable coding rule | existing public-surface/doc rule applies |
+| README / public API / help / release docs | not required | package docs/specs cover API; release notes not requested | leave to release process |
+
+## Documentation Updates
+### `webex/webex-js-sdk`
+- Update `src/services/task/ai-docs/task-lifecycle-spec.md`.
+- Update `src/services/ai-docs/ai-assistant-spec.md`.
+- Update `src/services/config/ai-docs/configuration-lookup-apis-spec.md` if event constants are documented there.
+- Update `ai-docs/CONTRACTS.md`.
+- Update `ai-docs/SERVICE_STATE.md`.
+- Update `ai-docs/GLOSSARY.md`.
+- Update `ai-docs/ARCHITECTURE.md`.
+
+## References
+- Task: `./task-1.md`
+- Epic: `./epic.md`
+- Feature design: `../../design/feature-design.md`

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/task-1.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/tasks/sdk-handoff-summary/task-1.md
@@ -1,0 +1,92 @@
+# Task - Implement SDK handoff summary helpers and events
+
+## Metadata
+| Field | Value |
+|---|---|
+| Task title | Implement SDK handoff summary helpers and events |
+| Parent epic | `./epic.md` |
+| Parent feature | `../../design/feature-design.md` and `../../spec/feature-spec.md` |
+| Task type | API / observability / docs |
+| Target repo(s) / module(s) | `webex/webex-js-sdk` / `packages/@webex/contact-center` |
+| Tracker key | `CAI-7974` |
+| State | implemented |
+| created_by / approved_by / date | Codex generator / user chat approval / 2026-06-30 |
+| Generated from | `task` @ SDLC template library `0.2.0` |
+
+## Source Mapping
+- Implements Feature Architecture -> Task handoff helper block, AI Assistant event transport, websocket handoff router, public event/type catalog.
+
+## Primary Code Touchpoints
+- `src/services/task/index.ts` - add public helper methods and feature flag gate.
+- `src/services/task/types.ts` - add task events, payload/action types, and `ITask` methods.
+- `src/services/task/TaskManager.ts` - route handoff summary websocket events and enablement messages.
+- `src/services/task/constants.ts` - add method names if needed.
+- `src/services/ApiAiAssistant.ts` - allow optional action and generic event details.
+- `src/types.ts` - add shared AI Assistant action type.
+- `src/services/config/types.ts` - add backend handoff summary event names.
+- `test/unit/spec/services/task/index.ts` - test task helpers.
+- `test/unit/spec/services/task/TaskManager.ts` - test websocket routing and enablement handling.
+- `test/unit/spec/services/ApiAiAssistant.ts` - test generalized event details.
+- `ai-docs/CONTRACTS.md`, `ai-docs/SERVICE_STATE.md`, `ai-docs/GLOSSARY.md`, `ai-docs/ARCHITECTURE.md`, module specs - spec currency.
+
+## Ownership Boundary
+- Owns: the files listed in Primary Code Touchpoints and the feature package under `features/cai-7974-agent-handoff-summary/`.
+- Must NOT touch: unrelated packages under `packages/@webex/*`, backend repositories, widget UI code outside optional docs/samples, and unrelated task lifecycle behavior.
+
+## Multi-Repo Scope
+| Target repo | Module/component | Why included in this task | Manifest / standing docs root |
+|---|---|---|---|
+| `webex/webex-js-sdk` | `packages/@webex/contact-center` | single target package | `ai-docs/` |
+
+## Dependencies / Execution Stream
+| This task | Depends on | Parallel-safe with | Wave / stream |
+|---|---|---|---|
+| T1 | soft-committed design | N/A | wave 1 |
+
+## Acceptance Criteria
+- [x] `Task.requestHandoffSummary()` sends `GET_MID_CALL_SUMMARY` through `ApiAIAssistant` when enabled.
+- [x] `Task.requestHandoffSummary()` rejects without sending when `consultTransferSummariesEnabled` is false or absent.
+- [x] `Task.respondToHandoffSummary()` sends `MID_CALL_SUMMARY_RESPONSE` with a typed action.
+- [x] `TaskManager` emits semantic task events for `MID_CALL_SUMMARY` and `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`.
+- [x] `TaskManager` updates generated summary enablement when `FEATURE_ENABLEMENT` contains a boolean flag.
+- [x] Existing transcript tests still pass.
+- [x] SDD docs/specs/contracts are updated in the same change.
+
+## Verifier Exit Criteria
+- [x] Unit tests pass for `services/task/index.ts`, `services/task/TaskManager.ts`, and `services/ApiAiAssistant.ts` assertions; targeted commands exit non-zero only because repo global coverage thresholds apply to single-target runs.
+- [x] No edits outside the ownership boundary are intended for PR staging.
+- [x] Public surface changes are reflected in task and AI Assistant module specs plus `ai-docs/CONTRACTS.md`.
+- [ ] Feature review is run on a different runtime from Codex or explicitly handed off.
+
+## Traceability
+| Requirement / rule id | Code symbol | Test that proves it |
+|---|---|---|
+| R-1/R-3 | `Task.requestHandoffSummary` | `test/unit/spec/services/task/index.ts` |
+| R-2 | `Task.respondToHandoffSummary` | `test/unit/spec/services/task/index.ts` |
+| R-4/R-5 | `TaskManager.registerTaskListeners` | `test/unit/spec/services/task/TaskManager.ts` |
+| R-6 | `TaskManager.handleHandoffSummaryFeatureEnablement` | `test/unit/spec/services/task/TaskManager.ts` |
+| R-7 | docs/types/specs | changed docs plus build/unit import coverage |
+
+## Coverage Expectation
+- Changed-line coverage >= 80%; evidence: package unit tests and CI coverage report.
+
+## Cross-Cutting Prompts
+- **Logging:** use existing logger conventions; do not log tokens or sensitive payloads.
+- **Metrics:** reuse `ApiAIAssistant` send-event success/failure metrics.
+- **Security:** no new auth surface; use existing Webex SDK authenticated request path.
+- **Idempotency:** helpers are user-action sends; SDK does not retry or de-duplicate.
+- **Rollout:** gated by existing generated summary feature flag and optional backend enablement event.
+
+## Non-Goals / Out-of-Scope
+- Backend summary generation.
+- Durable summary storage.
+- Widget UI implementation.
+- Cross-package changes outside `@webex/contact-center`.
+
+## Feature-Flag & Rollout Assumptions
+- Flag: `generatedSummaries.consultTransferSummariesEnabled` - default: disabled unless true - assumption: backend/product owns enablement.
+
+## References
+- Epic: `./epic.md`
+- Implementation plan: `./implementation-plan-1.md`
+- Feature design: `../../design/feature-design.md`

--- a/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/test-strategy.md
+++ b/packages/@webex/contact-center/features/cai-7974-agent-handoff-summary/test-strategy.md
@@ -1,0 +1,75 @@
+# Test Strategy - Agent Handoff Summary events and public APIs
+
+## Metadata
+| Field | Value |
+|---|---|
+| Feature / ticket key | `cai-7974-agent-handoff-summary` / `CAI-7974` |
+| Feature Spec | `spec/feature-spec.md` |
+| Feature Design | `design/feature-design.md` |
+| Generated from | `test-strategy` @ SDLC template library `0.2.0` |
+
+## References
+- Feature Spec: `spec/feature-spec.md`
+- Repo architecture: `../../ai-docs/ARCHITECTURE.md`
+
+## Test Config Variables
+| Variable | Possible values |
+|---|---|
+| `apiAIAssistant.aiFeature.generatedSummaries.consultTransferSummariesEnabled` | `true`, `false`, `undefined` |
+| websocket message type | `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, `FEATURE_ENABLEMENT`, existing transcript events |
+| handoff response action | `CANCEL`, `CONSULT`, `TRANSFER` |
+
+## Use Cases -> Tests
+| # | Use case / acceptance criterion | Positive case | Negative case | Status |
+|---|---|---|---|---|
+| 1 | Request handoff summary sends AI Assistant event | enabled flag sends `GET_MID_CALL_SUMMARY` | disabled flag rejects and sends nothing | planned |
+| 2 | Respond to handoff summary sends typed action | `TRANSFER` action sends `MID_CALL_SUMMARY_RESPONSE` | missing/invalid action fails type or runtime guard | planned |
+| 3 | Summary websocket routes to task | `MID_CALL_SUMMARY` emits `task:handoffSummary` | unknown task id does not emit on any task | planned |
+| 4 | Subsequent-agent response routes to task | `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT` emits `task:handoffSummaryResponse` | unrelated event does not emit response event | planned |
+| 5 | Feature enablement updates flag | boolean enablement updates `aiFeature.generatedSummaries.consultTransferSummariesEnabled` | malformed payload is ignored without throwing | planned |
+| 6 | Existing transcript routing is preserved | existing transcript start/stop tests still pass | disabled realtime transcript flag suppresses transcript sends | existing + planned regression |
+
+## Contract Tests
+| Scenario / interface | Consumer | Producer | CI stage |
+|---|---|---|---|
+| Task handoff helper signatures and event enum | SDK consumer typings | `src/services/task/types.ts` | package unit/build |
+| AI Assistant `/event` body | WCC AI Assistant service | `src/services/ApiAiAssistant.ts` | package unit |
+
+## Integration Tests
+| Scenario | Suite | Automated | In CI |
+|---|---|---|---|
+| Websocket event to task event routing | `test/unit/spec/services/task/TaskManager.ts` with EventEmitter websocket mock | yes | package unit |
+| Task helper to AI Assistant transport | `test/unit/spec/services/task/index.ts` with mocked ApiAIAssistant | yes | package unit |
+
+## Resiliency Tests
+| Failure injected | Expected behavior | Suite | In CI |
+|---|---|---|---|
+| Disabled generated summary flag | helper rejects before network call | unit | yes |
+| AI Assistant request rejection | helper propagates detailed task error path | unit | yes |
+| Malformed enablement payload | TaskManager ignores without throwing | unit | yes |
+
+## QA Dependencies
+| Dependency | Needed for | Ready? |
+|---|---|---|
+| Backend payload schema for summary events | contract hardening beyond generic payload pass-through | not in this repo |
+| Tenant/agent with generated summaries enabled | manual or integration validation outside package unit tests | pending backend/product |
+
+## E2E Framework & Location
+- Framework: Jest 27 via `@webex/jest-config-legacy`
+- Test directory: `packages/@webex/contact-center/test/unit/spec/`
+- Target invocation: `yarn workspace @webex/contact-center test:unit --targets services/task/index.ts` and related target files
+- Runs in CI: package unit test stage
+
+## Coverage Summary
+| Test type | Scenarios | Automated | In CI | Status |
+|---|---|---|---|---|
+| Unit | 6 | yes | yes | planned |
+| Contract/typing | 2 | yes via TypeScript/build/unit import coverage | yes | planned |
+| Integration | 2 with mocked websocket/request layers | yes | yes | planned |
+| E2E/manual | backend-enabled tenant smoke | no | no | dependency pending |
+
+## Gaps / Risks
+| Gap | Impact | Mitigation |
+|---|---|---|
+| No backend machine-readable schema in repo | SDK cannot validate summary body fields | generic payload pass-through; document schema follow-up with backend owners |
+| No live backend test in this repo | Unit tests cannot prove tenant rollout behavior | manual QA dependency before GA |

--- a/packages/@webex/contact-center/src/index.ts
+++ b/packages/@webex/contact-center/src/index.ts
@@ -49,7 +49,7 @@ export type {
  * @enum {string}
  * @category Enums
  */
-export {TASK_EVENTS} from './services/task/types';
+export {HANDOFF_SUMMARY_ACTION, TASK_EVENTS} from './services/task/types';
 export type {TASK_EVENTS as TaskEvents} from './services/task/types';
 
 /**
@@ -134,6 +134,10 @@ export type {
   ConsultPayload,
   ConsultEndPayload,
   ConsultTransferPayLoad,
+  HandoffSummaryAction,
+  HandoffSummaryPayload,
+  HandoffSummaryRequestPayload,
+  HandoffSummaryResponsePayload,
   /** Dialer payload */
   DialerPayload,
   TransferPayLoad,

--- a/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
@@ -6,7 +6,7 @@ import {
   HTTP_METHODS,
   WebexSDK,
   IHttpResponse,
-  TranscriptAction,
+  AIAssistantEventAction,
   AIAssistantEventType,
   AIAssistantEventName,
   HistoricTranscriptsResponse,
@@ -76,14 +76,16 @@ export class ApiAIAssistant {
    * @param interactionId - interaction/conversation identifier
    * @param eventType - the type of event (e.g. 'CUSTOM_EVENT')
    * @param eventName - the name of the event (e.g. 'GET_TRANSCRIPTS')
-   * @param action - action within eventDetails (e.g. 'START' or 'STOP')
+   * @param action - optional action within eventDetails (e.g. 'START', 'STOP', 'TRANSFER')
+   * @param eventData - optional additional backend-owned event details
    */
   public async sendEvent(
     agentId: string,
     interactionId: string,
     eventType: AIAssistantEventType,
     eventName: AIAssistantEventName,
-    action: TranscriptAction
+    action?: AIAssistantEventAction,
+    eventData: Record<string, unknown> = {}
   ): Promise<Record<string, unknown>> {
     LoggerProxy.info('Sending event', {
       module: CC_FILE,
@@ -110,8 +112,9 @@ export class ApiAIAssistant {
           eventName,
           eventDetails: {
             data: {
+              ...eventData,
               interactionId,
-              action,
+              ...(action ? {action} : {}),
               actionTimeStamp: String(Date.now()),
             },
           },

--- a/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-spec.md
+++ b/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-spec.md
@@ -1,0 +1,165 @@
+# AI Assistant - SPEC
+
+> Canonical spec for `src/services/ApiAiAssistant.ts`. Router: [SPEC_INDEX.md](../../../ai-docs/SPEC_INDEX.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Module id | `ai-assistant` |
+| Source path(s) | `src/services/ApiAiAssistant.ts`; `src/services/config/types.ts`; `src/services/task/TaskManager.ts` |
+| Doc kind | Module spec |
+| Coverage score | 81%; bootstrap coverage review |
+| Generated from | `module-spec` @ SDLC template library `0.2.0` |
+| generated_by / approved_by / updated_at | Codex / user questionnaire / 2026-06-30 |
+| Validation status | local conformance pass; independent validator not-run |
+
+## Evidence Rules
+Requirements cite source/test files. AI Assistant backend schema is external and represented only by local request/response types.
+
+## Source Material Register
+| Source doc | Scope | Decision | Detail location or disposition |
+|---|---|---|---|
+| None found | none | none | N/A |
+
+## Overview
+`ApiAIAssistant` wraps AI Assistant service calls for sending events and fetching historic transcripts. It receives AI feature flags/config from Contact Center config, resolves service base URL through Webex SDK services, and is used by task flows for transcript and generated handoff summary behavior.
+
+## Purpose / Responsibility
+Own client-side AI Assistant request construction and feature-flag-aware service URL behavior.
+
+## Stack
+TypeScript service over Webex SDK request/services; Jest tests in `test/unit/spec/services/ApiAiAssistant.ts`.
+
+## Folder / Package Structure
+```text
+src/services/ApiAiAssistant.ts # AI feature flags, base URL, sendEvent, historic transcripts
+```
+
+## Key Files
+| File | Holds |
+|---|---|
+| `src/services/ApiAiAssistant.ts` | AI Assistant service class |
+| `src/services/config/types.ts` | AI feature flag types |
+| `src/services/task/TaskManager.ts` | transcript trigger integration |
+| `test/unit/spec/services/ApiAiAssistant.ts` | AI Assistant tests |
+
+## Public Surface
+| Contract ID | Type | Surface | Purpose | Compatibility / deprecation | Schema / detail link | Root index |
+|---|---|---|---|---|---|---|
+| `ai.service` | SDK class export | `ApiAIAssistant` | AI Assistant helper | exported from package | `src/services/ApiAiAssistant.ts` | `../../../ai-docs/CONTRACTS.md` |
+| `ai.flags` | method | `setAIFeatureFlags(aiFeature)` | set AI feature config | behavior-visible | `src/services/ApiAiAssistant.ts` | `../../../ai-docs/CONTRACTS.md` |
+| `ai.sendEvent` | method | `sendEvent(agentId, interactionId, eventType, eventName, action?, eventData?)` | send transcript and handoff summary AI events | public helper; optional action/eventData are additive | `src/services/ApiAiAssistant.ts`; `../../../features/cai-7974-agent-handoff-summary/design/contracts/ai-assistant-handoff-event.md` | `../../../ai-docs/CONTRACTS.md` |
+| `ai.fetchHistoricTranscripts` | method | `fetchHistoricTranscripts(...)` | retrieve historic transcript data | public helper | `src/services/ApiAiAssistant.ts` | `../../../ai-docs/CONTRACTS.md` |
+
+## Requires
+- Webex SDK request/services.
+- AI Assistant URL/config from WCC config.
+- Agent, session, task, or interaction identifiers supplied by caller/task manager.
+
+## Requirements
+| ID | WHAT | WHY | Source Evidence | Test / Example Evidence | Assumptions / Gaps | Confidence |
+|---|---|---|---|---|---|---|
+| AIA-R-001 | The service must store AI feature flags/config through `setAIFeatureFlags`. | Base URL and feature behavior depend on WCC config. | `src/services/ApiAiAssistant.ts`; `src/services/config/types.ts` | `test/unit/spec/services/ApiAiAssistant.ts` | exact flag schema external | PRESENT |
+| AIA-R-002 | `sendEvent()` must build and send AI Assistant event requests through Webex SDK request plumbing. | Consumers and task flows need event delivery to AI Assistant backend. | `src/services/ApiAiAssistant.ts` | `test/unit/spec/services/ApiAiAssistant.ts` | backend schema external | PRESENT |
+| AIA-R-003 | `fetchHistoricTranscripts()` must call the configured AI Assistant transcript resource and return caller-visible errors. | Transcript retrieval is user-visible and failure must not be swallowed. | `src/services/ApiAiAssistant.ts`; `src/services/task/TaskManager.ts` | `test/unit/spec/services/ApiAiAssistant.ts`; `test/unit/spec/services/task/TaskManager.ts` | backend schema external | PRESENT |
+| AIA-R-004 | TaskManager may request realtime/historic transcript behavior only from mapped task events and interaction ids. | Avoids incorrect AI calls for unrelated task events. | `src/services/task/TaskManager.ts`; `src/services/ApiAiAssistant.ts` | `test/unit/spec/services/task/TaskManager.ts` | none | PRESENT |
+| AIA-R-005 | `sendEvent()` must allow request events without an action and must merge backend-owned `eventData` into `eventDetails.data`. | Handoff summary request events do not require `START`/`STOP`, while response events carry `CANCEL`/`CONSULT`/`TRANSFER` and optional backend details. | `src/services/ApiAiAssistant.ts`; `src/types.ts`; `src/services/task/index.ts` | `test/unit/spec/services/ApiAiAssistant.ts`; `test/unit/spec/services/task/index.ts` | backend handoff summary schema external | PRESENT |
+
+## Design Overview
+The AI Assistant service is intentionally small. It keeps backend URL/feature configuration local and exposes request methods without pushing AI endpoint knowledge into TaskManager or ContactCenter.
+
+## Data Flow
+```mermaid
+flowchart LR
+  Config[AgentConfigService] --> AI[ApiAIAssistant]
+  TaskManager --> AI
+  Consumer[SDK consumer] --> AI
+  AI --> WebexSDK[Webex SDK request/services]
+  WebexSDK --> Backend[AI Assistant service]
+```
+
+## Sequence Diagrams
+| Operation group | Diagram | Failure / recovery coverage |
+|---|---|---|
+| transcript fetch | task/consumer to AI backend | request failure |
+
+```mermaid
+sequenceDiagram
+  participant TM as TaskManager
+  participant AI as ApiAIAssistant
+  participant SDK as Webex SDK
+  participant Backend as AI Assistant
+  TM->>AI: fetchHistoricTranscripts(interaction)
+  AI->>SDK: request(service/resource)
+  SDK->>Backend: HTTP request
+  alt success
+    Backend-->>SDK: transcript response
+    SDK-->>AI: response
+    AI-->>TM: transcript data
+  else failure
+    Backend-->>SDK: error
+    SDK-->>AI: reject
+    AI-->>TM: reject
+  end
+```
+
+## Class / Component Relationships
+```mermaid
+classDiagram
+  ApiAIAssistant --> WebexSDK
+  ContactCenter --> ApiAIAssistant
+  TaskManager --> ApiAIAssistant
+  AgentConfigService --> ApiAIAssistant
+```
+
+## Use Cases
+- UC-1 Configure AI Assistant: ContactCenter/config calls `setAIFeatureFlags`. Evidence: `src/services/ApiAiAssistant.ts`, `src/services/config/types.ts`.
+- UC-2 Send AI event: consumer/task flow calls `sendEvent`. Evidence: `src/services/ApiAiAssistant.ts`.
+- UC-3 Fetch transcripts: TaskManager triggers transcript fetch for mapped event/interaction. Evidence: `src/services/task/TaskManager.ts`.
+- UC-4 Handoff summary events: Task calls `sendEvent()` with `GET_MID_CALL_SUMMARY` or `MID_CALL_SUMMARY_RESPONSE`; action is omitted for request and present for responses. Evidence: `src/services/task/index.ts`, `src/services/ApiAiAssistant.ts`.
+
+## State Model
+- Service stores AI feature flag/config state in memory.
+- No transcripts are persisted by the package.
+
+## Business Rules & Invariants
+- Do not hardcode AI backend URLs when config/service discovery provides them.
+- Do not request transcripts without a valid interaction id.
+- Do not swallow backend request errors.
+
+## Concurrency & Reactive Flow
+- Transcript requests are asynchronous and may be triggered by task events.
+- Callers must handle rejection; module must not block task event processing indefinitely.
+
+## Protocol / Wire Format
+- AI Assistant REST payloads are owned by `ApiAiAssistant.ts` local request construction and remote backend contract. `sendEvent()` always includes `interactionId` and `actionTimeStamp`, includes `action` only when supplied, and merges optional `eventData` into `eventDetails.data`.
+
+## Error Handling & Failure Modes
+| Condition | Signal | Caller recovery |
+|---|---|---|
+| feature config missing | request construction/base URL failure | wait for register/config completion |
+| backend request fails | rejected promise | retry only when user flow permits |
+| missing interaction id | no request or error | verify task event mapping |
+| request event has no action | action omitted from payload | expected for `GET_MID_CALL_SUMMARY` |
+
+## Pitfalls
+- Do not move AI URL logic into TaskManager.
+- Do not log transcript payloads unless existing diagnostics explicitly allow it.
+- Do not assume AI feature flags are always enabled.
+
+## Key Design Trade-off
+- A small dedicated service avoids leaking AI endpoint details into task handling. The cost is another service dependency that must be configured during registration.
+
+## Test-Case Strategy
+Tests should cover feature flag setting, base URL selection, request construction, success/failure responses, and TaskManager transcript trigger integration.
+
+| Behavior / Requirement | Existing test evidence | Gap |
+|---|---|---|
+| AIA-R-001 to AIA-R-003 | `test/unit/spec/services/ApiAiAssistant.ts` | backend schema external |
+| AIA-R-004 | `test/unit/spec/services/task/TaskManager.ts` | none |
+| AIA-R-005 | `test/unit/spec/services/ApiAiAssistant.ts`; `test/unit/spec/services/task/index.ts` | backend handoff schema external |
+
+## Traceability
+- Repo architecture: `../../../ai-docs/ARCHITECTURE.md`
+- Registry: `../../../ai-docs/SPEC_INDEX.md`
+- Coverage state and contracts baseline: package SDD baseline.

--- a/packages/@webex/contact-center/src/services/config/ai-docs/configuration-lookup-apis-spec.md
+++ b/packages/@webex/contact-center/src/services/config/ai-docs/configuration-lookup-apis-spec.md
@@ -1,0 +1,197 @@
+# Configuration And Lookup APIs - SPEC
+
+> Canonical spec for `src/services/config/`, lookup service files, and `PageCache`. Router: [SPEC_INDEX.md](../../../../ai-docs/SPEC_INDEX.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Module id | `configuration-lookup-apis` |
+| Source path(s) | `src/services/config/`; `src/services/AddressBook.ts`; `src/services/EntryPoint.ts`; `src/services/Queue.ts`; `src/utils/PageCache.ts`; `src/cc.ts` |
+| Doc kind | Module spec |
+| Coverage score | 84%; bootstrap coverage review |
+| Generated from | `module-spec` @ SDLC template library `0.2.0` |
+| generated_by / approved_by / updated_at | Codex / user questionnaire / 2026-06-30 |
+| Validation status | local conformance pass; independent validator not-run |
+
+## Evidence Rules
+Requirements cite source and tests by path. WCC response schemas are represented by local TypeScript types; no native schema file was found.
+
+## Source Material Register
+| Source doc | Scope | Decision | Detail location or disposition |
+|---|---|---|---|
+| `typedoc.md` | lookup examples | reference-only | public lookup methods indexed in `CONTRACTS.md` |
+
+## Overview
+This module gathers package configuration and lookup behavior. `AgentConfigService` fetches user, org, desktop profile, multimedia profile, site, team, aux-code, tenant, URL mapping, AI feature, dial plan, and outdial ANI data. `AddressBook`, `EntryPoint`, and `Queue` expose paginated lookup APIs. `PageCache` provides simple in-memory pagination caching used by lookup services.
+
+The module reads remote WCC configuration and lookup data. It does not own or persist those records.
+
+## Purpose / Responsibility
+Own client-side retrieval, composition, and caching of WCC configuration and lookup data needed by Contact Center flows.
+
+## Stack
+TypeScript services over `WebexRequest`; Jest tests under `test/unit/spec/services/config/` and service lookup tests.
+
+## Folder / Package Structure
+```text
+src/services/config/
+|- index.ts       # AgentConfigService and WCC config fetches
+|- Util.ts        # config parsing helpers
+|- constants.ts   # config constants
+`- types.ts       # config, events, and lookup types
+src/services/
+|- AddressBook.ts # address book paginated lookup
+|- EntryPoint.ts  # entry point paginated lookup
+`- Queue.ts       # queue paginated lookup
+src/utils/PageCache.ts # reusable in-memory page cache
+```
+
+## Key Files
+| File | Holds |
+|---|---|
+| `src/services/config/index.ts` | config fetch orchestration and endpoint calls |
+| `src/services/config/types.ts` | Profile, events, config, and lookup types |
+| `src/services/AddressBook.ts` | address book API |
+| `src/services/EntryPoint.ts` | entry point API |
+| `src/services/Queue.ts` | queue API |
+| `src/utils/PageCache.ts` | pagination defaults, cache keys, TTL, cache operations |
+| `test/unit/spec/services/config/index.ts` | config tests |
+| `test/unit/spec/services/AddressBook.ts`; `EntryPoint.ts`; `Queue.ts` | lookup tests |
+
+## Public Surface
+| Contract ID | Type | Surface | Purpose | Compatibility / deprecation | Schema / detail link | Root index |
+|---|---|---|---|---|---|---|
+| `config.AgentConfigService` | internal class | config fetch methods | compose profile/config for registration | behavior-visible through `register()` | `src/services/config/index.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `lookup.AddressBook` | SDK class | `getEntries(params)` | fetch address book entries | public export | `src/services/AddressBook.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `lookup.EntryPoint` | facade/class | `getEntryPoints(params)` | fetch entry points | public facade through `ContactCenter` | `src/services/EntryPoint.ts`; `src/cc.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `lookup.Queue` | facade/class | `getQueues(params)` | fetch queues | public facade through `ContactCenter` | `src/services/Queue.ts`; `src/cc.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `config.outdialAni` | facade method | `getOutdialAniEntries(params)` | fetch outdial ANI entries | public facade | `src/services/config/index.ts`; `src/cc.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `config.events` | event enums | `CC_EVENTS`, `CC_TASK_EVENTS`, `CC_AGENT_EVENTS` | WCC bridge event names, including transcript and handoff summary bridge events | compatibility-sensitive | `src/services/config/types.ts` | `../../../../ai-docs/CONTRACTS.md` |
+
+## Requires
+- `WebexRequest` and Webex credentials/org context.
+- WCC API gateway resources for user config, org info/settings, tenant data, URL mapping, profiles, teams, aux codes, AI features, dial plan, outdial ANI, address book, entry points, and queues.
+- Page/search/filter/sort inputs from SDK consumers.
+
+## Requirements
+| ID | WHAT | WHY | Source Evidence | Test / Example Evidence | Assumptions / Gaps | Confidence |
+|---|---|---|---|---|---|---|
+| CFG-R-001 | `AgentConfigService` must compose profile/config by fetching user, org, tenant, URL mapping, AI feature, aux codes, desktop profile, site, dial plan, team, and multimedia profile data as applicable. | `ContactCenter.register()` depends on a complete profile/config snapshot. | `src/services/config/index.ts`; `src/services/config/Util.ts`; `src/services/config/types.ts` | `test/unit/spec/services/config/index.ts` | WCC schema external | PRESENT |
+| CFG-R-002 | Config list fetches must handle pagination for teams and aux codes where total pages are reported. | Agent profile setup needs full lists, not only first page. | `src/services/config/index.ts` | `test/unit/spec/services/config/index.ts` | backend page metadata external | PRESENT |
+| CFG-R-003 | Outdial ANI entries must preserve query parameter support for page, pageSize, search, filter, and attributes. | Consumers need filtered ANI selection. | `src/services/config/index.ts`; `src/cc.ts` | `test/unit/spec/services/config/index.ts`; `test/unit/spec/cc.ts` | none | PRESENT |
+| CFG-R-004 | AddressBook, EntryPoint, and Queue lookups must use PageCache keying that includes query-shaping parameters. | Prevents serving stale/wrong page data for different filters/searches. | `src/services/AddressBook.ts`; `src/services/EntryPoint.ts`; `src/services/Queue.ts`; `src/utils/PageCache.ts` | `test/unit/spec/services/AddressBook.ts`; `EntryPoint.ts`; `Queue.ts` | none | PRESENT |
+| CFG-R-005 | PageCache must remain in-memory, TTL-bound, and non-durable. | The package does not own backend data or persistence. | `src/utils/PageCache.ts` | lookup tests | none | PRESENT |
+| CFG-R-006 | Config event enums must remain stable because task and agent modules map WCC messages through them. | Event renames break consumers and TaskManager routing. | `src/services/config/types.ts`; `src/services/task/TaskManager.ts`; `src/services/agent/index.ts` | `test/unit/spec/services/task/TaskManager.ts`; `test/unit/spec/services/agent/index.ts` | none | PRESENT |
+| CFG-R-007 | `CC_TASK_EVENTS` must include backend handoff summary bridge event names used by TaskManager: `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`. | Handoff summary websocket messages need stable enum keys before they can be routed to SDK task events. | `src/services/config/types.ts`; `src/services/task/TaskManager.ts` | `test/unit/spec/services/task/TaskManager.ts` | backend payload schema external | PRESENT |
+
+## Design Overview
+The module splits broad profile/config composition from individual lookup APIs. `AgentConfigService` is a sequential/concurrent orchestrator that fetches remote resources and parses a profile. Lookup classes focus on one resource each and share `PageCache` behavior.
+
+This avoids a durable local model and keeps WCC as system-of-record.
+
+## Data Flow
+```mermaid
+flowchart LR
+  CC[ContactCenter] --> Config[AgentConfigService]
+  Config --> Request[WebexRequest]
+  Request --> WCC[WCC REST]
+  CC --> Lookup[AddressBook/EntryPoint/Queue]
+  Lookup --> Cache[PageCache]
+  Lookup --> Request
+```
+
+## Sequence Diagrams
+| Operation group | Diagram | Failure / recovery coverage |
+|---|---|---|
+| register config load | multi-resource fetch | request failure |
+| paginated lookup | cache then fetch | cache miss/expiry and request failure |
+
+```mermaid
+sequenceDiagram
+  participant CC as ContactCenter
+  participant Config as AgentConfigService
+  participant Req as WebexRequest
+  participant WCC
+  CC->>Config: getAgentConfig(orgId, agentId)
+  Config->>Req: user/org/settings/tenant/url/ai/aux requests
+  Req->>WCC: REST requests
+  WCC-->>Req: responses
+  Config->>Req: profile/site/team/dialplan requests
+  Req->>WCC: REST requests
+  alt any request fails
+    Req-->>Config: reject
+    Config-->>CC: reject
+  else success
+    Config-->>CC: Profile/config
+  end
+```
+
+## Class / Component Relationships
+```mermaid
+classDiagram
+  AgentConfigService --> WebexRequest
+  AddressBook --> PageCache
+  EntryPoint --> PageCache
+  Queue --> PageCache
+  AddressBook --> WebexSDK
+  EntryPoint --> WebexSDK
+  Queue --> WebexSDK
+```
+
+## Use Cases
+- UC-1 Register profile load: ContactCenter asks AgentConfigService for full config and profile. Evidence: `src/cc.ts`, `src/services/config/index.ts`.
+- UC-2 Fetch entry points/queues: consumer calls facade method; lookup service checks cache and requests WCC when needed. Evidence: `src/cc.ts`, `src/services/EntryPoint.ts`, `src/services/Queue.ts`.
+- UC-3 Fetch address book entries: consumer creates/uses AddressBook and calls `getEntries`. Evidence: `src/services/AddressBook.ts`.
+- UC-4 Fetch outdial ANI: facade calls config service with query params. Evidence: `src/cc.ts`, `src/services/config/index.ts`.
+
+## State Model
+- `PageCache` holds cache entries with timestamp and paginated response data.
+- `AgentConfigService` does not persist state beyond method-local composition.
+- Lookup classes own their cache instance for the resource.
+
+## Business Rules & Invariants
+- WCC remains system-of-record for config and lookup data.
+- Cache keys must include every query parameter that changes response identity.
+- Cache TTL default is 5 minutes unless code changes the constant and tests/specs together.
+
+## Concurrency & Reactive Flow
+- AgentConfigService fetches independent config resources concurrently where code uses `Promise` composition.
+- Pagination fan-out for teams/aux codes uses concurrent page requests after first page metadata.
+
+## Protocol / Wire Format
+- WCC REST resource paths are owned by endpoint maps in config/lookup implementation.
+- SDK-facing config events are TypeScript enums in `config/types.ts`.
+
+## Data Model
+- Profile includes agent, team, profile, site, aux-code, dial-plan, tenant, URL, and feature-flag data assembled from WCC resources.
+- Lookup responses are paginated response objects with metadata represented by local TypeScript types.
+
+## Error Handling & Failure Modes
+| Condition | Signal | Caller recovery |
+|---|---|---|
+| WCC config request fails | rejected promise | register should fail and surface error |
+| page request fails | rejected promise | retry with same query after network/service check |
+| stale cache | entry expires by TTL | fetch fresh page |
+| wrong cache key | wrong data served | preserve key construction tests |
+
+## Pitfalls
+- Do not add a query parameter without adding it to cache key construction.
+- Do not treat cached lookup data as authoritative after TTL.
+- Do not invent local schema ownership for WCC config resources.
+
+## Key Design Trade-off
+- Simple in-memory page caching reduces repeated lookup calls without introducing durable state. It costs callers strong consistency until TTL expiry.
+
+## Test-Case Strategy
+Tests should cover config fetch composition, paginated list behavior, query string construction, cache hit/miss/expiry, and error propagation.
+
+| Behavior / Requirement | Existing test evidence | Gap |
+|---|---|---|
+| CFG-R-001 to CFG-R-003 | `test/unit/spec/services/config/index.ts`; `test/unit/spec/cc.ts` | WCC schema variants external |
+| CFG-R-004, CFG-R-005 | `test/unit/spec/services/AddressBook.ts`; `EntryPoint.ts`; `Queue.ts` | direct PageCache unit file not present |
+| CFG-R-006 | `test/unit/spec/services/task/TaskManager.ts`; `test/unit/spec/services/agent/index.ts` | none |
+
+## Traceability
+- Repo architecture: `../../../../ai-docs/ARCHITECTURE.md`
+- Registry: `../../../../ai-docs/SPEC_INDEX.md`
+- Coverage state and contracts baseline: package SDD baseline.

--- a/packages/@webex/contact-center/src/services/config/types.ts
+++ b/packages/@webex/contact-center/src/services/config/types.ts
@@ -123,6 +123,12 @@ export const CC_TASK_EVENTS = {
   CAMPAIGN_PREVIEW_REMOVE_FAILED: 'CampaignPreviewRemoveFailed',
   /** Event emitted when a real-time transcript chunk is received */
   REAL_TIME_TRANSCRIPTION: 'REAL_TIME_TRANSCRIPTION',
+  /** Event emitted when backend sends a handoff summary payload */
+  MID_CALL_SUMMARY: 'MID_CALL_SUMMARY',
+  /** Event emitted when backend sends a handoff summary response for the subsequent agent */
+  MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT: 'MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT',
+  /** Event emitted when backend sends runtime feature enablement state */
+  FEATURE_ENABLEMENT: 'FEATURE_ENABLEMENT',
 } as const;
 
 /**

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -142,20 +142,22 @@ export default class TaskManager extends EventEmitter {
   private registerTaskListeners() {
     this.webSocketManager.on('message', (event) => {
       const payload = JSON.parse(event);
+      const payloadType = payload.data?.type || payload.type;
       // Re-emit the task events to the task object
       let task: ITask;
-      if (payload.data?.type || payload.type) {
-        if (Object.values(CC_TASK_EVENTS).includes(payload.data.type || payload.type)) {
+      if (payloadType) {
+        if (Object.values(CC_TASK_EVENTS).includes(payloadType)) {
           task =
             this.taskCollection[payload.data?.interactionId] ||
+            this.taskCollection[payload.data?.conversationId] ||
             this.taskCollection[payload.data?.data?.conversationId];
         }
-        LoggerProxy.info(`Handling task event ${payload.data?.type}`, {
+        LoggerProxy.info(`Handling task event ${payloadType}`, {
           module: TASK_MANAGER_FILE,
           method: METHODS.REGISTER_TASK_LISTENERS,
           interactionId: payload.data?.interactionId,
         });
-        switch (payload.data.type) {
+        switch (payloadType) {
           case CC_EVENTS.AGENT_CONTACT:
             // Case1 : Task is already present in taskCollection
             if (this.taskCollection[payload.data.interactionId]) {
@@ -192,7 +194,8 @@ export default class TaskManager extends EventEmitter {
                   isAutoAnswering: shouldAutoAnswer, // Set flag before emitting
                 },
                 this.wrapupData,
-                this.agentId
+                this.agentId,
+                this.apiAIAssistant
               );
               this.taskCollection[payload.data.interactionId] = task;
               // Condition 1: The state is=new i.e it is a incoming task
@@ -239,7 +242,8 @@ export default class TaskManager extends EventEmitter {
                 isAutoAnswering: shouldAutoAnswerReserved, // Set flag before emitting
               },
               this.wrapupData,
-              this.agentId
+              this.agentId,
+              this.apiAIAssistant
             );
             this.taskCollection[payload.data.interactionId] = task;
             if (
@@ -661,7 +665,8 @@ export default class TaskManager extends EventEmitter {
                   isAutoAnswering: false,
                 },
                 this.wrapupData,
-                this.agentId
+                this.agentId,
+                this.apiAIAssistant
               );
               this.taskCollection[payload.data.interactionId] = task;
             } else {
@@ -672,11 +677,25 @@ export default class TaskManager extends EventEmitter {
             break;
           }
 
+          case CC_EVENTS.FEATURE_ENABLEMENT:
+            this.handleHandoffSummaryFeatureEnablement(payload.data || {}, task);
+            break;
+          case CC_EVENTS.MID_CALL_SUMMARY:
+            if (task) {
+              task.emit(TASK_EVENTS.TASK_HANDOFF_SUMMARY, payload.data);
+            }
+            break;
+          case CC_EVENTS.MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT:
+            if (task) {
+              task.emit(TASK_EVENTS.TASK_HANDOFF_SUMMARY_RESPONSE, payload.data);
+            }
+            break;
+
           default:
             break;
         }
         if (task) {
-          task.emit(payload.data.type, payload.data);
+          task.emit(payloadType, payload.data);
         }
 
         const transcriptInteractionId =
@@ -684,8 +703,8 @@ export default class TaskManager extends EventEmitter {
           payload.data?.data?.conversationId ||
           task?.data?.interactionId;
 
-        if (TRANSCRIPT_EVENT_MAP[payload.data.type] && transcriptInteractionId) {
-          this.requestRealTimeTranscripts(payload.data.type, transcriptInteractionId);
+        if (TRANSCRIPT_EVENT_MAP[payloadType] && transcriptInteractionId) {
+          this.requestRealTimeTranscripts(payloadType, transcriptInteractionId);
         }
       }
     });
@@ -716,6 +735,34 @@ export default class TaskManager extends EventEmitter {
       });
 
       return task;
+    }
+  }
+
+  private handleHandoffSummaryFeatureEnablement(
+    payloadData: Record<string, any>,
+    task?: ITask
+  ): void {
+    const consultTransferSummariesEnabled =
+      payloadData?.consultTransferSummariesEnabled ??
+      payloadData?.generatedSummaries?.consultTransferSummariesEnabled ??
+      payloadData?.data?.consultTransferSummariesEnabled ??
+      payloadData?.data?.generatedSummaries?.consultTransferSummariesEnabled;
+
+    if (typeof consultTransferSummariesEnabled === 'boolean' && this.apiAIAssistant) {
+      const currentAiFeature = this.apiAIAssistant.aiFeature || ({} as any);
+      this.apiAIAssistant.setAIFeatureFlags({
+        ...currentAiFeature,
+        generatedSummaries: {
+          ...currentAiFeature.generatedSummaries,
+          consultTransferSummariesEnabled,
+        },
+      });
+    }
+
+    if (task) {
+      task.emit(TASK_EVENTS.TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT, payloadData);
+    } else {
+      this.emit(TASK_EVENTS.TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT, payloadData);
     }
   }
 
@@ -757,7 +804,8 @@ export default class TaskManager extends EventEmitter {
           isConferenceInProgress: getIsConferenceInProgress(taskData),
         },
         this.wrapupData,
-        this.agentId
+        this.agentId,
+        this.apiAIAssistant
       );
       this.taskCollection[taskData.interactionId] = task;
     }

--- a/packages/@webex/contact-center/src/services/task/ai-docs/task-lifecycle-spec.md
+++ b/packages/@webex/contact-center/src/services/task/ai-docs/task-lifecycle-spec.md
@@ -1,0 +1,257 @@
+# Task Lifecycle - SPEC
+
+> Canonical spec for `src/services/task/`. Router: [SPEC_INDEX.md](../../../../ai-docs/SPEC_INDEX.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Module id | `task-lifecycle` |
+| Source path(s) | `src/services/task/`; `src/cc.ts`; `src/services/WebCallingService.ts` |
+| Doc kind | Module spec |
+| Coverage score | 88%; bootstrap coverage review |
+| Generated from | `module-spec` @ SDLC template library `0.2.0` |
+| generated_by / approved_by / updated_at | Codex / user questionnaire / 2026-06-30 |
+| Validation status | local conformance pass; independent validator not-run |
+
+## Evidence Rules
+Task requirements must cite source/test files because this is the highest-blast-radius module. Commit history can support WHY for recent bug fixes, but source/tests remain primary.
+
+## Source Material Register
+| Source doc | Scope | Decision | Detail location or disposition |
+|---|---|---|---|
+| `typedoc.md` | Task API examples | reference-only | public methods indexed here and in `CONTRACTS.md` |
+
+## Overview
+The task module owns client-side task objects, task collection management, contact control route builders, dialer/campaign routes, task event taxonomy, and task-data reconciliation. `TaskManager` consumes realtime WCC task notifications and creates/updates/removes `Task` instances. `Task` exposes consumer methods for accepting, declining, holding, resuming, ending, wrapping up, recording, consulting, transferring, conferencing, generated handoff summary request/response, and media mute/unmute behavior.
+
+Task operations are asynchronous and usually combine an HTTP/AQM request with a later WebSocket notification. Voice tasks also integrate with `WebCallingService` for browser calling behavior.
+
+## Purpose / Responsibility
+Own Contact Center task lifecycle behavior in the SDK. It does not own backend interaction state or WebRTC internals.
+
+## Stack
+TypeScript EventEmitter classes and route factories; Jest tests under `test/unit/spec/services/task/`.
+
+## Folder / Package Structure
+```text
+src/services/task/
+|- index.ts        # Task class and public task methods
+|- TaskManager.ts  # task collection and realtime event routing
+|- TaskUtils.ts    # task helpers
+|- AutoWrapup.ts   # auto-wrapup timer helper
+|- contact.ts      # contact operation route factory
+|- dialer.ts       # outdial and campaign preview route factory
+|- constants.ts    # task constants and timeouts
+`- types.ts        # task public types and TASK_EVENTS enum
+```
+
+## Key Files
+| File | Holds |
+|---|---|
+| `src/services/task/index.ts` | `Task` class, task methods, data reconciliation, Web Calling listener hooks |
+| `src/services/task/TaskManager.ts` | task collection, event hydration/update/removal, transcript event requests |
+| `src/services/task/contact.ts` | contact control AQM routes |
+| `src/services/task/dialer.ts` | outdial and campaign preview routes |
+| `src/services/task/types.ts` | public task event enum and task types |
+| `src/services/task/constants.ts` | timeouts and task constants |
+| `test/unit/spec/services/task/` | task module tests |
+
+## Public Surface
+| Contract ID | Type | Surface | Purpose | Compatibility / deprecation | Schema / detail link | Root index |
+|---|---|---|---|---|---|---|
+| `task.class` | SDK class | `Task` | client-side task object | public export; method semantics are compatibility-sensitive | `src/services/task/index.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `task.methods` | SDK methods | `accept`, `decline`, `hold`, `resume`, `end`, `wrapup`, `pauseRecording`, `resumeRecording`, `consult`, `endConsult`, `transfer`, `consultTransfer`, `consultConference`, `exitConference`, `transferConference`, `toggleMute` | task controls | breaking if renamed/removed or completion semantics change | `src/services/task/index.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `task.events` | events | `TASK_EVENTS` enum | SDK task event names | enum renames/removals are breaking | `src/services/task/types.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `task.handoffSummary` | SDK methods/events | `requestHandoffSummary`, `respondToHandoffSummary`, `TASK_HANDOFF_SUMMARY`, `TASK_HANDOFF_SUMMARY_RESPONSE`, `TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT` | request, receive, and respond to generated consult/transfer handoff summaries | additive public surface; payload schema is backend-owned and passed through | `src/services/task/index.ts`; `src/services/task/types.ts`; `../../../../features/cai-7974-agent-handoff-summary/design/contracts/handoff-summary-task-api.md` | `../../../../ai-docs/CONTRACTS.md` |
+| `task.manager` | internal surface | `TaskManager` | creates/updates/removes task instances | internal but behavior-visible through emitted events | `src/services/task/TaskManager.ts` | `../../../../ai-docs/CONTRACTS.md` |
+| `cc.dialer` | facade methods | `startOutdial`, `acceptPreviewContact`, `skipPreviewContact`, `removePreviewContact` | dialer/campaign preview flows | public facade | `src/cc.ts`; `src/services/task/dialer.ts` | `../../../../ai-docs/CONTRACTS.md` |
+
+## Requires
+- `AqmReqs` and WebSocket notifications from `src/services/core/`.
+- Web Calling behavior from `src/services/WebCallingService.ts`.
+- Config profile/wrapup data from config types and `ContactCenter`.
+- MetricsManager for task lifecycle metrics.
+- WCC contact/dialer AQM backend.
+
+## Requirements
+| ID | WHAT | WHY | Source Evidence | Test / Example Evidence | Assumptions / Gaps | Confidence |
+|---|---|---|---|---|---|---|
+| TSK-R-001 | `TaskManager` must create, hydrate, update, emit, and remove task objects from WCC realtime events. | Consumer task state is driven by realtime notifications. | `src/services/task/TaskManager.ts`; `src/services/task/types.ts` | `test/unit/spec/services/task/TaskManager.ts` | exact WCC payload variants are service-owned | PRESENT |
+| TSK-R-002 | `Task` public methods must delegate to contact/dialer/Web Calling services and return caller-visible success/failure. | Consumers rely on method promises for task controls. | `src/services/task/index.ts`; `src/services/task/contact.ts`; `src/services/task/dialer.ts` | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/contact.ts`; `test/unit/spec/services/task/dialer.ts` | none | PRESENT |
+| TSK-R-003 | Task data reconciliation must preserve existing nested interaction/media fields when incoming updates omit them. | Partial WCC updates can otherwise erase data needed by later operations. | `src/services/task/index.ts`; `src/services/task/TaskManager.ts` | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/TaskManager.ts` | none | PRESENT |
+| TSK-R-004 | Hold/resume and transfer logic must use the correct media resource and destination type helpers. | Recent fixes show mismatched media resource or destination type breaks task operations. | `src/services/task/index.ts`; `src/services/core/Utils.ts`; `src/services/task/TaskUtils.ts` | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/core/Utils.ts`; commit `741003b705` | none | PRESENT |
+| TSK-R-005 | Campaign preview accept/skip/remove flows must have dedicated route handling and failure events, including the extended accept timeout. | Preview campaign actions are separate user-visible flows. | `src/cc.ts`; `src/services/task/dialer.ts`; `src/services/task/constants.ts`; `src/services/task/types.ts` | `test/unit/spec/services/task/dialer.ts`; commits `84e9dea766`, `46f03565d8` | none | PRESENT |
+| TSK-R-006 | Task events must preserve `TASK_EVENTS` enum values and CC task event mapping. | Downstream consumers subscribe to event strings. | `src/services/task/types.ts`; `src/services/config/types.ts`; `src/services/task/TaskManager.ts` | `test/unit/spec/services/task/TaskManager.ts` | none | PRESENT |
+| TSK-R-007 | Voice task media behavior must coordinate with WebCallingService call mapping and event listeners. | Browser calling tasks need call answer/decline/mute/media event behavior. | `src/services/task/index.ts`; `src/services/WebCallingService.ts` | `test/unit/spec/services/WebCallingService.ts`; `test/unit/spec/services/task/index.ts` | Calling SDK internals external | PRESENT |
+| TSK-R-008 | Real-time transcript requests must be triggered only for mapped task events and valid interaction identifiers. | Avoids unnecessary or wrong transcript calls. | `src/services/task/TaskManager.ts`; `src/services/ApiAiAssistant.ts` | `test/unit/spec/services/task/TaskManager.ts`; `test/unit/spec/services/ApiAiAssistant.ts` | AI backend contract external | PRESENT |
+| TSK-R-009 | Handoff summary helpers must use `ApiAIAssistant`, require `generatedSummaries.consultTransferSummariesEnabled === true` for requests, and route backend summary/response/enablement websocket events to the owning task. | SDK consumers need one supported task-level path for generated consult/transfer summaries without bypassing task event conventions. | `src/services/task/index.ts`; `src/services/task/TaskManager.ts`; `src/services/task/types.ts`; `src/services/config/types.ts` | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/TaskManager.ts`; `test/unit/spec/services/ApiAiAssistant.ts` | exact backend summary payload fields are external; SDK passes payload records through | PRESENT |
+
+## Design Overview
+`TaskManager` is the event and collection owner; `Task` is the consumer-facing per-interaction object. This split keeps collection-level routing and individual operation methods separate. Route factories in `contact.ts` and `dialer.ts` define AQM details so the Task class stays close to consumer operations.
+
+The module favors preserving current observable behavior over normalizing every backend payload. That is why reconciliation and event mapping logic is explicit and test-backed.
+
+## Data Flow
+```mermaid
+flowchart LR
+  WS[WCC WebSocket event] --> TM[TaskManager]
+  TM --> Task[Task instance]
+  Task --> Consumer[SDK event/method]
+  Consumer --> Task
+  Task --> Contact[contact route]
+  Task --> Dialer[dialer route]
+  Task --> Calling[WebCallingService]
+  Task --> AI[ApiAIAssistant]
+  Contact --> AQM[AqmReqs]
+  Dialer --> AQM
+  AI --> WCCAI[AI Assistant service]
+  AQM --> WCC[WCC AQM]
+```
+
+## Sequence Diagrams
+| Operation group | Diagram | Failure / recovery coverage |
+|---|---|---|
+| incoming task hydration | event-to-task sequence | unknown event and removal cases |
+| task method operation | method-to-AQM sequence | failure notification and timeout |
+
+```mermaid
+sequenceDiagram
+  participant WS as WebSocketManager
+  participant TM as TaskManager
+  participant Task
+  participant App
+  WS->>TM: task event payload
+  alt new task
+    TM->>Task: create Task(data)
+    TM-->>App: emit task:incoming/task:assigned
+  else update existing
+    TM->>Task: reconcile/update data
+    Task-->>App: emit task event
+  else removal
+    TM->>TM: remove from collection
+    TM-->>App: emit terminal event
+  end
+```
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Task
+  participant Route as contact/dialer route
+  participant AQM as AqmReqs
+  participant WCC
+  App->>Task: hold()/transfer()/wrapup()
+  Task->>Route: operation(payload)
+  Route->>AQM: req(config)
+  AQM->>WCC: request
+  alt success notification
+    WCC-->>AQM: operation success
+    AQM-->>Task: resolve
+    Task-->>App: TaskResponse
+  else failure/timeout
+    WCC-->>AQM: failure or no notification
+    AQM-->>Task: reject
+    Task-->>App: error
+  end
+```
+
+## Class / Component Relationships
+```mermaid
+classDiagram
+  EventEmitter <|-- Task
+  EventEmitter <|-- TaskManager
+  TaskManager o-- Task
+  Task --> WebCallingService
+  Task --> routingContact
+  Task --> aqmDialer
+  TaskManager --> ApiAIAssistant
+  TaskManager --> MetricsManager
+```
+
+## Use Cases
+- UC-1 Accept incoming task: WCC event creates Task; consumer calls `accept()`; route waits for success/failure. Evidence: `src/services/task/TaskManager.ts`, `src/services/task/index.ts`, `src/services/task/contact.ts`.
+- UC-2 Control voice contact: consumer holds/resumes/mutes/ends voice task; Task coordinates contact route and WebCallingService. Evidence: `src/services/task/index.ts`, `src/services/WebCallingService.ts`.
+- UC-3 Transfer/consult/conference: consumer invokes consult/transfer/conference methods; helper logic derives destination details. Evidence: `src/services/task/index.ts`, `src/services/core/Utils.ts`.
+- UC-4 Campaign preview: consumer accepts/skips/removes preview reservation through `ContactCenter` facade. Evidence: `src/cc.ts`, `src/services/task/dialer.ts`.
+- UC-5 Handoff summary: consumer calls `requestHandoffSummary()` when generated consult-transfer summaries are enabled, listens for `TASK_HANDOFF_SUMMARY`/`TASK_HANDOFF_SUMMARY_RESPONSE`, and calls `respondToHandoffSummary()` with a typed action. Evidence: `src/services/task/index.ts`, `src/services/task/TaskManager.ts`, `src/services/task/types.ts`.
+
+## State Model
+- `TaskManager` holds active task collection and agent/webRTC context.
+- `Task` holds task data snapshot and operation listeners/timers.
+- `AutoWrapup` controls wrapup timer behavior.
+- Web Calling call id to task id mapping is owned by WebCallingService but consumed by Task.
+
+## Business Rules & Invariants
+- Task event enum strings are public.
+- A task update must not delete preserved task data solely because the backend omitted a nested field.
+- Terminal/removal events must remove tasks from collection.
+- Campaign preview failure events are separate for accept, skip, and remove.
+
+## Concurrency & Reactive Flow
+- WCC events and user task operations can interleave.
+- Task handlers must tolerate duplicate or late notifications and cleanup idempotently.
+- Timers and Web Calling listeners must be registered/unregistered to prevent leaks.
+
+## State Machine
+```mermaid
+stateDiagram-v2
+  [*] --> Incoming
+  Incoming --> Assigned: accept success
+  Incoming --> Rejected: decline/failure
+  Assigned --> Held: hold success
+  Held --> Assigned: resume success
+  Assigned --> Consulting: consult success
+  Consulting --> Assigned: end consult
+  Assigned --> Wrapup: end/contact ended
+  Wrapup --> WrappedUp: wrapup success
+  Assigned --> Ended: disconnect/removal
+  WrappedUp --> [*]
+  Rejected --> [*]
+  Ended --> [*]
+```
+
+## Protocol / Wire Format
+- The module consumes WCC routing messages through TaskManager and route builders.
+- SDK-facing events are `TASK_EVENTS`.
+- WCC bridge events are `CC_TASK_EVENTS`/`CC_EVENTS`.
+- Handoff summary bridge events are `MID_CALL_SUMMARY`, `MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT`, and optional `FEATURE_ENABLEMENT`; SDK task events are `task:handoffSummary`, `task:handoffSummaryResponse`, and `task:handoffSummaryFeatureEnablement`.
+
+## Data Model
+- Task data includes interaction identifiers, media, participants, destination details, wrapup requirements, and campaign preview data.
+- The package caches active tasks in memory only; WCC remains system-of-record.
+
+## Error Handling & Failure Modes
+| Condition | Signal | Caller recovery |
+|---|---|---|
+| contact operation failure | rejected promise and/or failure event | show failure and retry if operation is safe |
+| missing media resource | operation-specific error | inspect task data and avoid destructive retry |
+| Web Calling failure | call event/error or method failure | cleanup call mapping and surface media error |
+| no AQM notification | timeout rejection | retry after connection health check |
+| unknown task event | logged/ignored or generic handling | add mapping only with tests |
+| handoff summary disabled | rejected helper promise and no AI Assistant send | hide or disable summary affordance until config/enablement changes |
+
+## Pitfalls
+- Do not replace task data wholesale on partial events.
+- Do not add raw task event strings without updating `TASK_EVENTS`, tests, contracts, and this spec.
+- Do not assume every task is voice; Web Calling behavior is conditional.
+- Do not shorten campaign preview timeout without confirming UX/backend contract.
+
+## Key Design Trade-off
+- The module keeps rich client-side task state to provide ergonomic SDK events and methods, even though WCC owns authoritative task state. This reduces consumer complexity but makes reconciliation and cleanup correctness critical.
+
+## Test-Case Strategy
+Tests should cover event mapping, create/update/remove behavior, positive and failure route responses, task-data preservation, campaign preview failure events, and Web Calling integration boundaries.
+
+| Behavior / Requirement | Existing test evidence | Gap |
+|---|---|---|
+| TSK-R-001 | `test/unit/spec/services/task/TaskManager.ts` | realtime backend variants need validator sampling |
+| TSK-R-002 | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/contact.ts`; `test/unit/spec/services/task/dialer.ts` | none |
+| TSK-R-003 | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/TaskManager.ts` | none |
+| TSK-R-004 | `test/unit/spec/services/core/Utils.ts`; `test/unit/spec/services/task/index.ts` | none |
+| TSK-R-005 | `test/unit/spec/services/task/dialer.ts` | none |
+| TSK-R-009 | `test/unit/spec/services/task/index.ts`; `test/unit/spec/services/task/TaskManager.ts`; `test/unit/spec/services/ApiAiAssistant.ts` | backend payload schema remains external |
+
+## Traceability
+- Repo architecture: `../../../../ai-docs/ARCHITECTURE.md`
+- Registry: `../../../../ai-docs/SPEC_INDEX.md`
+- Coverage state and contracts baseline: package SDD baseline.

--- a/packages/@webex/contact-center/src/services/task/constants.ts
+++ b/packages/@webex/contact-center/src/services/task/constants.ts
@@ -71,6 +71,8 @@ export const METHODS = {
   CONSULT_CONFERENCE: 'consultConference',
   EXIT_CONFERENCE: 'exitConference',
   TRANSFER_CONFERENCE: 'transferConference',
+  REQUEST_HANDOFF_SUMMARY: 'requestHandoffSummary',
+  RESPOND_TO_HANDOFF_SUMMARY: 'respondToHandoffSummary',
   UPDATE_TASK_DATA: 'updateTaskData',
   RECONCILE_DATA: 'reconcileData',
 
@@ -85,6 +87,7 @@ export const METHODS = {
   GET_TASK_MANAGER: 'getTaskManager',
   SETUP_AUTO_WRAPUP_TIMER: 'setupAutoWrapupTimer',
   CANCEL_AUTO_WRAPUP_TIMER: 'cancelAutoWrapupTimer',
+  HANDLE_HANDOFF_SUMMARY_FEATURE_ENABLEMENT: 'handleHandoffSummaryFeatureEnablement',
 };
 
 export const TRANSCRIPT_EVENT_MAP = {

--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -3,7 +3,7 @@ import {CALL_EVENT_KEYS, LocalMicrophoneStream} from '@webex/calling';
 import {CallId} from '@webex/calling/dist/types/common/types';
 import {generateTaskErrorObject, calculateDestAgentId, calculateDestType} from '../core/Utils';
 import {Failure} from '../core/GlobalTypes';
-import {LoginOption} from '../../types';
+import {AIAssistantEventName, AIAssistantEventType, LoginOption} from '../../types';
 import {TASK_FILE} from '../../constants';
 import {METHODS, KEYS_TO_NOT_DELETE} from './constants';
 import routingContact from './contact';
@@ -21,9 +21,12 @@ import {
   TransferPayLoad,
   DESTINATION_TYPE,
   ConsultTransferPayLoad,
+  HandoffSummaryRequestPayload,
+  HandoffSummaryResponsePayload,
   MEDIA_CHANNEL,
 } from './types';
 import WebCallingService from '../WebCallingService';
+import ApiAIAssistant from '../ApiAiAssistant';
 import MetricsManager from '../../metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../../metrics/constants';
 import AutoWrapup from './AutoWrapup';
@@ -135,6 +138,7 @@ export default class Task extends EventEmitter implements ITask {
   private wrapupData: WrapupData;
   public autoWrapup?: AutoWrapup;
   private agentId: string;
+  private apiAIAssistant?: ApiAIAssistant;
 
   /**
    * Creates a new Task instance which provides the following features:
@@ -148,7 +152,8 @@ export default class Task extends EventEmitter implements ITask {
     webCallingService: WebCallingService,
     data: TaskData,
     wrapupData: WrapupData,
-    agentId: string
+    agentId: string,
+    apiAIAssistant?: ApiAIAssistant
   ) {
     super();
     this.contact = contact;
@@ -160,6 +165,7 @@ export default class Task extends EventEmitter implements ITask {
     this.registerWebCallListeners();
     this.setupAutoWrapupTimer();
     this.agentId = agentId;
+    this.apiAIAssistant = apiAIAssistant;
   }
 
   /**
@@ -1522,6 +1528,117 @@ export default class Task extends EventEmitter implements ITask {
         },
         ['operational', 'behavioral', 'business']
       );
+      throw err;
+    }
+  }
+
+  private getHandoffSummaryInteractionId(interactionId?: string): string {
+    return interactionId || this.data?.interactionId || this.data?.interaction?.interactionId;
+  }
+
+  private isHandoffSummaryEnabled(): boolean {
+    return (
+      this.apiAIAssistant?.aiFeature?.generatedSummaries?.consultTransferSummariesEnabled === true
+    );
+  }
+
+  /**
+   * Requests a generated handoff summary for this task.
+   *
+   * @param payload - optional interaction override and backend-owned event detail fields
+   * @returns Promise resolving with the AI Assistant response body
+   */
+  public async requestHandoffSummary(
+    payload: HandoffSummaryRequestPayload = {}
+  ): Promise<Record<string, unknown>> {
+    try {
+      const interactionId = this.getHandoffSummaryInteractionId(payload.interactionId);
+
+      if (!this.apiAIAssistant) {
+        throw new Error('AI_ASSISTANT_NOT_AVAILABLE');
+      }
+
+      if (!this.isHandoffSummaryEnabled()) {
+        throw new Error('HANDOFF_SUMMARY_NOT_ENABLED');
+      }
+
+      if (!interactionId) {
+        throw new Error('INVALID_INTERACTION_ID');
+      }
+
+      LoggerProxy.info(`Requesting handoff summary`, {
+        module: TASK_FILE,
+        method: METHODS.REQUEST_HANDOFF_SUMMARY,
+        interactionId,
+      });
+
+      return await this.apiAIAssistant.sendEvent(
+        this.agentId,
+        interactionId,
+        AIAssistantEventType.CUSTOM_EVENT,
+        AIAssistantEventName.GET_MID_CALL_SUMMARY,
+        undefined,
+        payload.eventData
+      );
+    } catch (error) {
+      const err = generateTaskErrorObject(error, METHODS.REQUEST_HANDOFF_SUMMARY, TASK_FILE);
+      LoggerProxy.error(`Failed to request handoff summary`, {
+        module: TASK_FILE,
+        method: METHODS.REQUEST_HANDOFF_SUMMARY,
+        interactionId: this.getHandoffSummaryInteractionId(payload.interactionId),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Responds to a generated handoff summary decision for this task.
+   *
+   * @param payload - handoff action and optional backend-owned event detail fields
+   * @returns Promise resolving with the AI Assistant response body
+   */
+  public async respondToHandoffSummary(
+    payload: HandoffSummaryResponsePayload
+  ): Promise<Record<string, unknown>> {
+    try {
+      const interactionId = this.getHandoffSummaryInteractionId(payload.interactionId);
+
+      if (!this.apiAIAssistant) {
+        throw new Error('AI_ASSISTANT_NOT_AVAILABLE');
+      }
+
+      if (!payload?.action) {
+        throw new Error('HANDOFF_SUMMARY_ACTION_REQUIRED');
+      }
+
+      if (!interactionId) {
+        throw new Error('INVALID_INTERACTION_ID');
+      }
+
+      LoggerProxy.info(`Responding to handoff summary`, {
+        module: TASK_FILE,
+        method: METHODS.RESPOND_TO_HANDOFF_SUMMARY,
+        interactionId,
+        data: {action: payload.action},
+      });
+
+      return await this.apiAIAssistant.sendEvent(
+        this.agentId,
+        interactionId,
+        AIAssistantEventType.CUSTOM_EVENT,
+        AIAssistantEventName.MID_CALL_SUMMARY_RESPONSE,
+        payload.action,
+        payload.eventData
+      );
+    } catch (error) {
+      const err = generateTaskErrorObject(error, METHODS.RESPOND_TO_HANDOFF_SUMMARY, TASK_FILE);
+      LoggerProxy.error(`Failed to respond to handoff summary`, {
+        module: TASK_FILE,
+        method: METHODS.RESPOND_TO_HANDOFF_SUMMARY,
+        interactionId: this.getHandoffSummaryInteractionId(payload?.interactionId),
+        error: error instanceof Error ? error.message : String(error),
+      });
       throw err;
     }
   }

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -91,6 +91,25 @@ export const MEDIA_CHANNEL = {
 export type MEDIA_CHANNEL = Enum<typeof MEDIA_CHANNEL>;
 
 /**
+ * Defines the supported response actions for handoff summary decisions.
+ * @public
+ */
+export const HANDOFF_SUMMARY_ACTION = {
+  /** Cancel the handoff summary decision flow */
+  CANCEL: 'CANCEL',
+  /** Continue with consult after reviewing the summary */
+  CONSULT: 'CONSULT',
+  /** Continue with transfer after reviewing the summary */
+  TRANSFER: 'TRANSFER',
+} as const;
+
+/**
+ * Type representing valid handoff summary response actions.
+ * @public
+ */
+export type HandoffSummaryAction = Enum<typeof HANDOFF_SUMMARY_ACTION>;
+
+/**
  * Enumeration of all task-related events that can occur in the contact center system
  * These events represent different states and actions in the task lifecycle
  * @public
@@ -616,6 +635,39 @@ export enum TASK_EVENTS {
    */
 
   TASK_MULTI_LOGIN_HYDRATE = 'task:multiLoginHydrate',
+
+  /**
+   * Triggered when a handoff summary is delivered for a task
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_HANDOFF_SUMMARY, (payload) => {
+   *   console.log('Handoff summary received:', payload);
+   * });
+   * ```
+   */
+  TASK_HANDOFF_SUMMARY = 'task:handoffSummary',
+
+  /**
+   * Triggered when a subsequent-agent handoff summary response is delivered for a task
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_HANDOFF_SUMMARY_RESPONSE, (payload) => {
+   *   console.log('Handoff summary response received:', payload);
+   * });
+   * ```
+   */
+  TASK_HANDOFF_SUMMARY_RESPONSE = 'task:handoffSummaryResponse',
+
+  /**
+   * Triggered when backend sends runtime handoff summary feature enablement state
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT, (payload) => {
+   *   console.log('Handoff summary enablement changed:', payload);
+   * });
+   * ```
+   */
+  TASK_HANDOFF_SUMMARY_FEATURE_ENABLEMENT = 'task:handoffSummaryFeatureEnablement',
 }
 
 /**
@@ -1099,6 +1151,44 @@ export type ConsultPayload = {
 };
 
 /**
+ * Optional payload for requesting a handoff summary.
+ * The backend owns the exact additional event fields, so eventData is intentionally schema-free.
+ * @public
+ */
+export type HandoffSummaryRequestPayload = {
+  /** Optional interaction identifier override; defaults to the task interactionId */
+  interactionId?: string;
+  /** Optional additional AI Assistant event details */
+  eventData?: Record<string, unknown>;
+};
+
+/**
+ * Payload for responding to a handoff summary.
+ * @public
+ */
+export type HandoffSummaryResponsePayload = {
+  /** Handoff summary response action */
+  action: HandoffSummaryAction;
+  /** Optional interaction identifier override; defaults to the task interactionId */
+  interactionId?: string;
+  /** Optional additional AI Assistant event details */
+  eventData?: Record<string, unknown>;
+};
+
+/**
+ * Handoff summary websocket payload passed through from backend messages.
+ * @public
+ */
+export type HandoffSummaryPayload = {
+  /** Optional interaction identifier */
+  interactionId?: string;
+  /** Optional backend payload body */
+  data?: Record<string, unknown>;
+  /** Additional backend-owned fields */
+  [key: string]: unknown;
+};
+
+/**
  * Parameters for ending a consultation task
  * @public
  */
@@ -1442,6 +1532,29 @@ export interface ITask extends EventEmitter {
    * ```
    */
   consultTransfer(consultTransferPayload?: ConsultTransferPayLoad): Promise<TaskResponse>;
+
+  /**
+   * Requests a generated handoff summary for the current task.
+   * The request is sent only when generated consult-transfer summaries are enabled.
+   * @param payload - Optional interaction override and backend-owned event detail fields
+   * @returns Promise resolving with the AI Assistant response body
+   * @example
+   * ```typescript
+   * await task.requestHandoffSummary();
+   * ```
+   */
+  requestHandoffSummary(payload?: HandoffSummaryRequestPayload): Promise<Record<string, unknown>>;
+
+  /**
+   * Responds to a handoff summary decision.
+   * @param payload - Handoff action and optional backend-owned event detail fields
+   * @returns Promise resolving with the AI Assistant response body
+   * @example
+   * ```typescript
+   * await task.respondToHandoffSummary({action: HANDOFF_SUMMARY_ACTION.TRANSFER});
+   * ```
+   */
+  respondToHandoffSummary(payload: HandoffSummaryResponsePayload): Promise<Record<string, unknown>>;
 
   /**
    * Initiates a consult conference (merge consult call with main call).

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -824,6 +824,7 @@ export type BuddyAgentsResponse = Agent.BuddyAgentsSuccess | Error;
 export type UpdateDeviceTypeResponse = Agent.DeviceTypeUpdateSuccess | Error;
 
 export type TranscriptAction = 'START' | 'STOP';
+export type AIAssistantEventAction = TranscriptAction | 'CANCEL' | 'CONSULT' | 'TRANSFER';
 
 export const AIAssistantEventType = {
   CUSTOM_EVENT: 'CUSTOM_EVENT',

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -73,6 +73,40 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual({ok: true});
   });
 
+  it('should send event details without an action when action is not provided', async () => {
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: {ok: true}});
+
+    await apiAIAssistant.sendEvent(
+      'test-agent-id',
+      'interaction-1',
+      'CUSTOM_EVENT',
+      'GET_MID_CALL_SUMMARY',
+      undefined,
+      {source: 'consult-popup'}
+    );
+
+    expect(mockWebex.request).toHaveBeenCalledWith({
+      uri: 'https://api-ai-assistant.produs1.ciscoccservice.com/event',
+      method: HTTP_METHODS.POST,
+      addAuthHeader: true,
+      body: {
+        agentId: 'test-agent-id',
+        orgId: 'test-org-id',
+        eventType: 'CUSTOM_EVENT',
+        eventName: 'GET_MID_CALL_SUMMARY',
+        eventDetails: {
+          data: expect.objectContaining({
+            interactionId: 'interaction-1',
+            source: 'consult-popup',
+          }),
+        },
+      },
+    });
+    expect((mockWebex.request as jest.Mock).mock.calls[0][0].body.eventDetails.data).not.toHaveProperty(
+      'action'
+    );
+  });
+
   it('should fetch historic transcripts with mapped base URL', async () => {
     const responseBody = {interactionId: 'interaction-1', data: []};
     (mockWebex.request as jest.Mock).mockResolvedValue({body: responseBody});

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -11,6 +11,26 @@ import WebCallingService from '../../../../../src/services/WebCallingService';
 import config from '../../../../../src/config';
 import {CC_TASK_EVENTS} from '../../../../../src/services/config/types';
 
+jest.mock('@webex/calling', () => ({
+  CALL_EVENT_KEYS: {
+    DISCONNECT: 'disconnect',
+    REMOTE_MEDIA: 'remote_media',
+  },
+  LINE_EVENTS: {
+    INCOMING_CALL: 'incoming_call',
+    REGISTERED: 'registered',
+    UNREGISTERED: 'unregistered',
+  },
+  LOGGER: {
+    INFO: 'info',
+  },
+  ServiceIndicator: {
+    CONTACT_CENTER: 'contact-center',
+  },
+  LocalMicrophoneStream: jest.fn(),
+  createClient: jest.fn(),
+}));
+
 describe('TaskManager', () => {
   let mockCall;
   let mockApiAIAssistant;
@@ -52,6 +72,9 @@ describe('TaskManager', () => {
       aiFeature: {
         realtimeTranscripts: {
           enable: true,
+        },
+        generatedSummaries: {
+          consultTransferSummariesEnabled: true,
         },
       },
     };
@@ -224,6 +247,72 @@ describe('TaskManager', () => {
       CC_EVENTS.REAL_TIME_TRANSCRIPTION,
       realtimePayload.data
     );
+  });
+
+  it('should emit handoff summary events from task object', () => {
+    const task = taskManager.getTask(taskId);
+    const taskEmitSpy = jest.spyOn(task, 'emit');
+    const summaryPayload = {
+      type: CC_EVENTS.MID_CALL_SUMMARY,
+      data: {
+        conversationId: taskId,
+        summary: 'handoff summary',
+      },
+    };
+
+    webSocketManagerMock.emit('message', JSON.stringify(summaryPayload));
+
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_HANDOFF_SUMMARY,
+      summaryPayload.data
+    );
+    expect(taskEmitSpy).toHaveBeenCalledWith(CC_EVENTS.MID_CALL_SUMMARY, summaryPayload.data);
+  });
+
+  it('should emit subsequent-agent handoff summary response events from task object', () => {
+    const task = taskManager.getTask(taskId);
+    const taskEmitSpy = jest.spyOn(task, 'emit');
+    const responsePayload = {
+      type: CC_EVENTS.MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT,
+      data: {
+        conversationId: taskId,
+        action: 'TRANSFER',
+      },
+    };
+
+    webSocketManagerMock.emit('message', JSON.stringify(responsePayload));
+
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_HANDOFF_SUMMARY_RESPONSE,
+      responsePayload.data
+    );
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      CC_EVENTS.MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT,
+      responsePayload.data
+    );
+  });
+
+  it('should update handoff summary feature enablement from websocket payload', () => {
+    const enablementPayload = {
+      type: CC_EVENTS.FEATURE_ENABLEMENT,
+      data: {
+        conversationId: taskId,
+        generatedSummaries: {
+          consultTransferSummariesEnabled: false,
+        },
+      },
+    };
+
+    webSocketManagerMock.emit('message', JSON.stringify(enablementPayload));
+
+    expect(mockApiAIAssistant.setAIFeatureFlags).toHaveBeenCalledWith({
+      realtimeTranscripts: {
+        enable: true,
+      },
+      generatedSummaries: {
+        consultTransferSummariesEnabled: false,
+      },
+    });
   });
 
   it('should emit REAL_TIME_TRANSCRIPTION from RTD websocket payload on task object', () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
@@ -9,6 +9,7 @@ import config from '../../../../../src/config';
 import WebCallingService from '../../../../../src/services/WebCallingService';
 import {
   TASK_EVENTS,
+  HANDOFF_SUMMARY_ACTION,
   TaskResponse,
   AgentContact,
   ConsultEndPayload,
@@ -23,7 +24,25 @@ import MetricsManager from '../../../../../src/metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../../../../../src/metrics/constants';
 import LoggerProxy from '../../../../../src/logger-proxy';
 
-jest.mock('@webex/calling');
+jest.mock('@webex/calling', () => ({
+  CALL_EVENT_KEYS: {
+    DISCONNECT: 'disconnect',
+    REMOTE_MEDIA: 'remote_media',
+  },
+  LINE_EVENTS: {
+    INCOMING_CALL: 'incoming_call',
+    REGISTERED: 'registered',
+    UNREGISTERED: 'unregistered',
+  },
+  LOGGER: {
+    INFO: 'info',
+  },
+  ServiceIndicator: {
+    CONTACT_CENTER: 'contact-center',
+  },
+  LocalMicrophoneStream: jest.fn(),
+  createClient: jest.fn(),
+}));
 jest.mock('../../../../../src/logger-proxy');
 
 describe('Task', () => {
@@ -41,6 +60,7 @@ describe('Task', () => {
   let loggerErrorSpy;
   let calculateDestAgentIdSpy;
   let calculateDestTypeSpy;
+  let mockApiAIAssistant;
 
   const taskId = '0ae913a4-c857-4705-8d49-76dd3dde75e4';
   const mockTrack = {} as MediaStreamTrack;
@@ -84,6 +104,15 @@ describe('Task', () => {
     mockMetricsManager = {
       trackEvent: jest.fn(),
       timeEvent: jest.fn(),
+    };
+
+    mockApiAIAssistant = {
+      sendEvent: jest.fn().mockResolvedValue({ok: true}),
+      aiFeature: {
+        generatedSummaries: {
+          consultTransferSummariesEnabled: true,
+        },
+      },
     };
 
     jest.spyOn(MetricsManager, 'getInstance').mockReturnValue(mockMetricsManager);
@@ -183,7 +212,7 @@ describe('Task', () => {
       wrapUpProps: { wrapUpReasonList: [] },
       autoWrapEnabled: false,
       autoWrapAfterSeconds: 0
-    }, taskDataMock.agentId);
+    }, taskDataMock.agentId, mockApiAIAssistant);
 
     // Mock navigator.mediaDevices
     global.navigator.mediaDevices = {
@@ -246,6 +275,45 @@ describe('Task', () => {
     remoteMediaCb(mockTrack);
 
     expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_MEDIA, mockTrack);
+  });
+
+  it('requests a handoff summary when generated consult transfer summaries are enabled', async () => {
+    const result = await task.requestHandoffSummary({eventData: {source: 'consult-popup'}});
+
+    expect(mockApiAIAssistant.sendEvent).toHaveBeenCalledWith(
+      taskDataMock.agentId,
+      taskId,
+      'CUSTOM_EVENT',
+      'GET_MID_CALL_SUMMARY',
+      undefined,
+      {source: 'consult-popup'}
+    );
+    expect(result).toEqual({ok: true});
+  });
+
+  it('does not request a handoff summary when generated consult transfer summaries are disabled', async () => {
+    mockApiAIAssistant.aiFeature.generatedSummaries.consultTransferSummariesEnabled = false;
+
+    await expect(task.requestHandoffSummary()).rejects.toThrow();
+
+    expect(mockApiAIAssistant.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it('responds to a handoff summary with a typed action', async () => {
+    const result = await task.respondToHandoffSummary({
+      action: HANDOFF_SUMMARY_ACTION.TRANSFER,
+      eventData: {reason: 'agent-selected'},
+    });
+
+    expect(mockApiAIAssistant.sendEvent).toHaveBeenCalledWith(
+      taskDataMock.agentId,
+      taskId,
+      'CUSTOM_EVENT',
+      'MID_CALL_SUMMARY_RESPONSE',
+      HANDOFF_SUMMARY_ACTION.TRANSFER,
+      {reason: 'agent-selected'}
+    );
+    expect(result).toEqual({ok: true});
   });
 
   describe('updateTaskData cases', () => {


### PR DESCRIPTION
## Summary
- Add Task-level handoff summary request/response helpers and typed handoff summary actions/payloads.
- Route MID_CALL_SUMMARY, MID_CALL_SUMMARY_RESPONSE_SUBSEQUENT_AGENT, and FEATURE_ENABLEMENT websocket events through TaskManager.
- Generalize ApiAIAssistant.sendEvent for optional action and backend-owned eventData.
- Add CAI-7974 feature specs and directly related module/contract docs.

## Validation
- yarn workspace @webex/contact-center exec tsc --noEmit --emitDeclarationOnly false --declaration false
- yarn workspace @webex/contact-center exec eslint src/index.ts src/types.ts src/services/ApiAiAssistant.ts src/services/config/types.ts src/services/task/TaskManager.ts src/services/task/constants.ts src/services/task/index.ts src/services/task/types.ts (0 errors; existing warnings only)
- yarn workspace @webex/contact-center test:unit (20 suites, 569 tests passed; Jest reports existing worker force-exit warning after completion)
- yarn workspace @webex/contact-center build:src

## Scope
Task 1 only: code, focused tests, CAI-7974 feature specs, and directly related module/contract specs. Local onboarding/plugin artifacts are intentionally excluded from this PR.
