### PR TITLE
fix(calling): resolve hydra URL for voicemail when U2C v2 is enabled

### DIFF
--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -1815,7 +1815,7 @@ describe('Get XSI Action Endpoint tests', () => {
 
     const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
 
-    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+    expect(wxcWebex.request).toBeCalledOnceWith({
       method: HTTP_METHODS.GET,
       uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
     });
@@ -1844,8 +1844,8 @@ describe('Get XSI Action Endpoint tests', () => {
 
     const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
 
-    expect(wxcWebex.internal.services.get).toHaveBeenCalledOnceWith(activeHydraCluster);
-    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+    expect(wxcWebex.internal.services.get).toBeCalledOnceWith(activeHydraCluster);
+    expect(wxcWebex.request).toBeCalledOnceWith({
       method: HTTP_METHODS.GET,
       uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
     });

--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -20,6 +20,7 @@ import {
   WebexRequestPayload,
   CALLING_BACKEND,
   RegistrationStatus,
+  HTTP_METHODS,
 } from './types';
 import log from '../Logger';
 import {
@@ -65,7 +66,9 @@ import {
   SCIM_ENDPOINT_RESOURCE,
   SCIM_USER_FILTER,
   WEBEX_API_BTS,
+  XSI_ACTION_ENDPOINT_ORG_URL_PARAM,
 } from './constants';
+import {xsiEndpointUrlResponse} from '../CallSettings/testFixtures';
 import {CALL_EVENT_KEYS} from '../Events/types';
 import SDKConnector from '../SDKConnector';
 
@@ -1783,6 +1786,71 @@ describe('Get XSI Action Endpoint tests', () => {
     file: 'testFile',
     method: 'testMethod',
   };
+
+  const expectedXsiEndpoint = 'https://api-proxy-si.broadcloudpbx.net/com.broadsoft.xsi-actions';
+
+  beforeEach(() => {
+    mockWebex.request.mockClear();
+  });
+
+  it('should return xsiEndpoint for WXC backend using _serviceUrls.hydra', async () => {
+    const hydraEndpoint = 'https://hydra-a.wbx2.com/v1/';
+    const wxcWebex = {
+      request: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        body: xsiEndpointUrlResponse,
+      }),
+      internal: {
+        services: {
+          _serviceUrls: {
+            hydra: hydraEndpoint,
+          },
+          _activeServices: {
+            hydra: 'urn:TEAM:us-east-2_a:hydra',
+          },
+          get: jest.fn(),
+        },
+      },
+    };
+
+    const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
+
+    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+      method: HTTP_METHODS.GET,
+      uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+    });
+    expect(result).toBe(expectedXsiEndpoint);
+    expect(wxcWebex.internal.services.get).not.toHaveBeenCalled();
+  });
+
+  it('should return xsiEndpoint for WXC backend using services.get when _serviceUrls is undefined', async () => {
+    const hydraEndpoint = 'https://hydra-a.wbx2.com/v1/';
+    const activeHydraCluster = 'urn:TEAM:us-east-2_a:hydra';
+    const wxcWebex = {
+      request: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        body: xsiEndpointUrlResponse,
+      }),
+      internal: {
+        services: {
+          _serviceUrls: undefined,
+          _activeServices: {
+            hydra: activeHydraCluster,
+          },
+          get: jest.fn().mockReturnValue(hydraEndpoint),
+        },
+      },
+    };
+
+    const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
+
+    expect(wxcWebex.internal.services.get).toHaveBeenCalledOnceWith(activeHydraCluster);
+    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+      method: HTTP_METHODS.GET,
+      uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+    });
+    expect(result).toBe(expectedXsiEndpoint);
+  });
 
   it('should return xsiEndpoint for BWRKS backend when URL ends with /v2.0', async () => {
     const mockResponse = {

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1273,8 +1273,12 @@ export async function getXsiActionEndpoint(
   try {
     switch (callingBackend) {
       case CALLING_BACKEND.WXC: {
+        const hydraEndpoint =
+          webex.internal.services._serviceUrls?.hydra ||
+          webex.internal.services.get(webex.internal.services._activeServices.hydra);
+
         const userIdResponse = <WebexRequestPayload>await webex.request({
-          uri: `${webex.internal.services._serviceUrls.hydra}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+          uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
           method: HTTP_METHODS.GET,
         });
 


### PR DESCRIPTION

This pull request addresses voicemail being broken on `/calling` when U2C v2 is enabled (spinner, no voicemails, malformed `VoiceMessagingMessages` URL such as `typeerror: Cannot read properties of undefined (reading 'hydra')/v2.0/user/.../VoiceMessagingMessages?format=json`) by making the following changes:

- Updated `getXsiActionEndpoint()` in `Utils.ts` to resolve the Hydra URL using `_serviceUrls?.hydra` with a `services.get()` fallback for WXC backends, matching the U2C v2 pattern already applied in Call Settings (PR #4555).
- Ensures `organizations?callingData=true` is called against a valid Hydra endpoint so the XSI `VoiceMessagingMessages` URL is built correctly (`api-us.bcld.webex.com/...`) instead of a malformed error string.
- Added unit tests in `Utils.test.ts` for WXC when `_serviceUrls.hydra` is present (U2C v1 path) and when `_serviceUrls` is undefined (U2C v2 path via `services.get()`).

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
- [x] Reproduced original bug on `web.webex.com/calling` with U2C v2 enabled (`typeerror` in `VoiceMessagingMessages` Network URL).
- [x] Kitchen Sink: `organizations?callingData=true` returns **200** on Hydra after fix.
- [x] Kitchen Sink: `VoiceMessagingMessages` uses correct `api-us.bcld.webex.com/.../VoiceMessagingMessages?format=json` URL and returns **200 OK**.
- [x] Added unit tests for WXC Hydra lookup in `getXsiActionEndpoint`.
- [ ] CI unit tests pass
- [ ] Verify voicemail loads on `web.webex.com/calling` after SDK release

## The GAI Coding Policy And Copyright Annotation Best Practices
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor

## This PR is related to
- [ ] Feature
- [x] Defect fix
- [ ] Tech Debt
- [ ] Automation

## I certified that
- [x] I have read and followed contributing guidelines
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly