### PR TITLE
fix(calling): resolve hydra URL for voicemail when U2C v2 is enabled

### DIFF
--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -20,6 +20,7 @@ import {
   WebexRequestPayload,
   CALLING_BACKEND,
   RegistrationStatus,
+  HTTP_METHODS,
 } from './types';
 import log from '../Logger';
 import {
@@ -65,7 +66,9 @@ import {
   SCIM_ENDPOINT_RESOURCE,
   SCIM_USER_FILTER,
   WEBEX_API_BTS,
+  XSI_ACTION_ENDPOINT_ORG_URL_PARAM,
 } from './constants';
+import {xsiEndpointUrlResponse} from '../CallSettings/testFixtures';
 import {CALL_EVENT_KEYS} from '../Events/types';
 import SDKConnector from '../SDKConnector';
 
@@ -1783,6 +1786,71 @@ describe('Get XSI Action Endpoint tests', () => {
     file: 'testFile',
     method: 'testMethod',
   };
+
+  const expectedXsiEndpoint = 'https://api-proxy-si.broadcloudpbx.net/com.broadsoft.xsi-actions';
+
+  beforeEach(() => {
+    mockWebex.request.mockClear();
+  });
+
+  it('should return xsiEndpoint for WXC backend using _serviceUrls.hydra', async () => {
+    const hydraEndpoint = 'https://hydra-a.wbx2.com/v1/';
+    const wxcWebex = {
+      request: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        body: xsiEndpointUrlResponse,
+      }),
+      internal: {
+        services: {
+          _serviceUrls: {
+            hydra: hydraEndpoint,
+          },
+          _activeServices: {
+            hydra: 'urn:TEAM:us-east-2_a:hydra',
+          },
+          get: jest.fn(),
+        },
+      },
+    };
+
+    const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
+
+    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+      method: HTTP_METHODS.GET,
+      uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+    });
+    expect(result).toBe(expectedXsiEndpoint);
+    expect(wxcWebex.internal.services.get).not.toHaveBeenCalled();
+  });
+
+  it('should return xsiEndpoint for WXC backend using services.get when _serviceUrls is undefined', async () => {
+    const hydraEndpoint = 'https://hydra-a.wbx2.com/v1/';
+    const activeHydraCluster = 'urn:TEAM:us-east-2_a:hydra';
+    const wxcWebex = {
+      request: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        body: xsiEndpointUrlResponse,
+      }),
+      internal: {
+        services: {
+          _serviceUrls: undefined,
+          _activeServices: {
+            hydra: activeHydraCluster,
+          },
+          get: jest.fn().mockReturnValue(hydraEndpoint),
+        },
+      },
+    };
+
+    const result = await getXsiActionEndpoint(wxcWebex, loggerContext, CALLING_BACKEND.WXC);
+
+    expect(wxcWebex.internal.services.get).toHaveBeenCalledOnceWith(activeHydraCluster);
+    expect(wxcWebex.request).toHaveBeenCalledOnceWith({
+      method: HTTP_METHODS.GET,
+      uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+    });
+    expect(result).toBe(expectedXsiEndpoint);
+  });
 
   it('should return xsiEndpoint for BWRKS backend when URL ends with /v2.0', async () => {
     const mockResponse = {

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1273,8 +1273,12 @@ export async function getXsiActionEndpoint(
   try {
     switch (callingBackend) {
       case CALLING_BACKEND.WXC: {
+        const hydraEndpoint =
+          webex.internal.services._serviceUrls?.hydra ||
+          webex.internal.services.get(webex.internal.services._activeServices.hydra);
+
         const userIdResponse = <WebexRequestPayload>await webex.request({
-          uri: `${webex.internal.services._serviceUrls.hydra}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
+          uri: `${hydraEndpoint}/${XSI_ACTION_ENDPOINT_ORG_URL_PARAM}`,
           method: HTTP_METHODS.GET,
         });
 


### PR DESCRIPTION
Use optional chaining and services.get() fallback in getXsiActionEndpoint for WXC backends, matching the Call Settings fix in PR #4555.

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
