### PR TITLE
fix(internal-plugin-mercury): improve handling of 4000 close code

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -901,9 +901,23 @@ const Mercury = WebexPlugin.extend({
           break;
         case 4000:
           // metric: disconnect
-          this.logger.info(`${this.namespace}: socket ${sessionId} replaced; will not reconnect`);
-          if (isActiveSocket) this._emit(sessionId, 'offline.replaced', event);
-          // If not active, nothing to do
+          if (isActiveSocket) {
+            // 4000 received directly from Mercury on the currently active socket.
+            // Treat as a transient disconnect and reconnect to recover.
+            this.logger.info(
+              `${this.namespace}: active socket ${sessionId} closed with 4000; reconnecting`
+            );
+            this._emit(sessionId, 'offline.transient', event);
+            this._reconnect(socketUrl, sessionId);
+          } else {
+            // 4000 received on an old/replaced connection (e.g. the SDK connected
+            // twice). The old socket is closed; the active connection remains and
+            // no reconnect should be triggered.
+            this.logger.info(
+              `${this.namespace}: old socket ${sessionId} replaced; will not reconnect`
+            );
+            this._emit(sessionId, 'offline.replaced', event);
+          }
           break;
         case 4001:
           // replaced during shutdown

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
@@ -267,7 +267,7 @@ describe('plugin-mercury', () => {
           },
           {
             code: 4000,
-            action: 'replace',
+            action: 'reconnect',
           },
           {
             action: 'close',

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -1394,6 +1394,75 @@ describe('plugin-mercury', () => {
         });
       });
 
+      describe('#_onclose() with code 4000 (replaced connection)', () => {
+        let mockSocket, anotherSocket;
+
+        beforeEach(() => {
+          mockSocket = {
+            url: 'ws://active-socket.com',
+            removeAllListeners: sinon.stub(),
+          };
+          anotherSocket = {
+            url: 'ws://old-socket.com',
+            removeAllListeners: sinon.stub(),
+          };
+          mercury.socket = mockSocket;
+          mercury.sockets.set(mercury.defaultSessionId, mockSocket);
+          mercury.connected = true;
+          sinon.stub(mercury, '_emit');
+          sinon.stub(mercury, '_reconnect');
+          sinon.stub(mercury, 'unset');
+        });
+
+        afterEach(() => {
+          mercury._emit.restore();
+          mercury._reconnect.restore();
+          mercury.unset.restore();
+        });
+
+        it('should reconnect when the active socket is closed with 4000', () => {
+          const closeEvent = {
+            code: 4000,
+            reason: 'replaced',
+          };
+
+          mercury._onclose(mercury.defaultSessionId, closeEvent, mockSocket);
+
+          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.transient', closeEvent);
+          assert.calledOnceWithExactly(
+            mercury._reconnect,
+            mockSocket.url,
+            mercury.defaultSessionId
+          );
+          assert.isFalse(mercury.connected);
+        });
+
+        it('should not reconnect when a non-active (old) socket is closed with 4000', () => {
+          const closeEvent = {
+            code: 4000,
+            reason: 'replaced',
+          };
+
+          mercury._onclose(mercury.defaultSessionId, closeEvent, anotherSocket);
+
+          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.replaced', closeEvent);
+          assert.notCalled(mercury._reconnect);
+          assert.isTrue(mercury.connected); // active connection remains
+          assert.notCalled(mercury.unset);
+        });
+
+        it('should clean up listeners from the old socket closed with 4000', () => {
+          const closeEvent = {
+            code: 4000,
+            reason: 'replaced',
+          };
+
+          mercury._onclose(mercury.defaultSessionId, closeEvent, anotherSocket);
+
+          assert.calledOnce(anotherSocket.removeAllListeners);
+        });
+      });
+
       describe('shutdown switchover with retry logic', () => {
         let connectWithBackoffStub;
         const sessionId = 'mercury-default-session';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-808019](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-808019) >

## This pull request addresses

Fixes the mercury close code 4000 handling for server rebalancing.

## by making the following changes

- **Old connection gets 4000 (SDK connected twice):** When a second connect replaces the socket in `this.sockets`, the map holds the new socket while the old socket still fires its close. So `isActiveSocket` is `false` → the old socket's listeners are cleaned up (by the existing top-level logic), `offline.replaced` is emitted, and no reconnect is triggered. The active connection stays alive.
- **Active socket gets 4000 directly from Mercury:** `sourceSocket === sessionSocket` → `isActiveSocket` is `true` → emits `offline.transient` and calls `_reconnect(socketUrl, sessionId)` to recover the connection.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `mercury-events.js`: changed the parametrized 4000 expectation from `replace` to `reconnect` (that test closes the active socket).
- `mercury.js`: added a new `#_onclose() with code 4000 (replaced connection)` describe block with three cases — active socket reconnects, non-active (old) socket does not reconnect and stays connected, and old socket listeners are cleaned up.

Note: I ran `build:src` since the unit tests execute against `dist/`.

**Vidcast: 4000 close code coming from the server (rebalancing case)**
https://app.vidcast.io/share/f487df24-2e47-4cfd-9bb3-42d07e7fd7c3

**Vidcast: Mercury 4000 close code testing for two times connect**
https://app.vidcast.io/share/68fa87d8-2d4c-4125-b6e8-8cb6b18b8aa3

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Cursor 
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
