### PR TITLE
feat(metrics/telemetryOptOut): add automatic and manual switches

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -91,8 +91,6 @@ const CallDiagnosticEventsBatcher = Batcher.extend({
 
     if (statusCode === 200) {
       this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(true);
-    } else {
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(false);
     }
   },
 });

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -90,17 +90,9 @@ const CallDiagnosticEventsBatcher = Batcher.extend({
     }
 
     if (statusCode === 200) {
-      if (
-        this.webex.internal.newMetrics?.callDiagnosticMetrics?.getTelemetryOptOut() === undefined
-      ) {
-        // If telemetry opt-out is not set, we can set it to 'automatic' on a 200 response. 'manual' opt out takes precedence over 'automatic' opt out.
-        this.webex.internal.newMetrics?.callDiagnosticMetrics?.setTelemetryOptOut('automatic');
-      }
-    } else if (
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.getTelemetryOptOut() === 'automatic'
-    ) {
-      // If we had set the telemetry opt-out to 'automatic' and the request now responds with something other than 200, we should revert it back to undefined.
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setTelemetryOptOut(undefined);
+      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(true);
+    } else {
+      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(false);
     }
   },
 });

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -108,7 +108,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   private isMercuryConnected = false;
   private eventLimitTracker: Map<string, number> = new Map();
   private eventLimitWarningsLogged: Set<string> = new Set();
-  private telemetryOptOut: NonNullable<ClientEventPayload>['telemetryOptOut'] = undefined;
+  private isTelemetryOptOutManual = false;
+  private isTelemetryOptOutAutomatic = false;
 
   // the default validator before piping an event to the batcher
   // this function can be overridden by the user
@@ -151,15 +152,30 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    * @returns one of 'manual', 'automatic', undefined
    */
   public getTelemetryOptOut() {
-    return this.telemetryOptOut;
+    if (this.isTelemetryOptOutManual) {
+      return 'manual';
+    }
+    if (this.isTelemetryOptOutAutomatic) {
+      return 'automatic';
+    }
+
+    return undefined;
   }
 
   /**
-   * Sets the telemetryOptOut value of the current user
-   * @param value - one of 'manual', 'automatic', undefined
+   * Sets the manual telemetry opt-out status for the current user
+   * @param value - boolean value indicating manual telemetry opt-out status
    */
-  public setTelemetryOptOut(value: NonNullable<ClientEventPayload>['telemetryOptOut']) {
-    this.telemetryOptOut = value;
+  public setIsTelemetryOptOutManual(value: boolean) {
+    this.isTelemetryOptOutManual = value;
+  }
+
+  /**
+   * Sets the automatic telemetry opt-out status for the current user
+   * @param value - boolean value indicating automatic telemetry opt-out status
+   */
+  public setIsTelemetryOptOutAutomatic(value: boolean) {
+    this.isTelemetryOptOutAutomatic = value;
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics-batcher.ts
@@ -113,17 +113,9 @@ const PreLoginMetricsBatcher = Batcher.extend({
     }
 
     if (statusCode === 200) {
-      if (
-        this.webex.internal.newMetrics?.callDiagnosticMetrics?.getTelemetryOptOut() === undefined
-      ) {
-        // If telemetry opt-out is not set, we can set it to 'automatic' on a 200 response. 'manual' opt out takes precedence over 'automatic' opt out.
-        this.webex.internal.newMetrics?.callDiagnosticMetrics?.setTelemetryOptOut('automatic');
-      }
-    } else if (
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.getTelemetryOptOut() === 'automatic'
-    ) {
-      // If we had set the telemetry opt-out to 'automatic' and the request now responds with something other than 200, we should revert it back to undefined.
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setTelemetryOptOut(undefined);
+      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(true);
+    } else {
+      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(false);
     }
   },
 });

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics-batcher.ts
@@ -114,8 +114,6 @@ const PreLoginMetricsBatcher = Batcher.extend({
 
     if (statusCode === 200) {
       this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(true);
-    } else {
-      this.webex.internal.newMetrics?.callDiagnosticMetrics?.setIsTelemetryOptOutAutomatic(false);
     }
   },
 });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -593,45 +593,60 @@ describe('plugin-metrics', () => {
     });
 
     describe('#handleHttpResponseStatus', () => {
+      let setIsTelemetryOptOutAutomaticStub;
+
+      beforeEach(() => {
+        setIsTelemetryOptOutAutomaticStub = sinon.stub(
+          webex.internal.newMetrics.callDiagnosticMetrics,
+          'setIsTelemetryOptOutAutomatic'
+        );
+      });
+
       [
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: true, expectedSetTelemetryOptOutArg: 'automatic'},
-
-        {shouldMark: true, statusCode: 201, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: true, expectedSetTelemetryOptOutArg: undefined},
-        {shouldMark: true, statusCode: 202, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 203, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-
-        {shouldMark: false, statusCode: 201, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 202, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 203, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-      ].forEach(({shouldMark, statusCode, currentTelemetryOptOut, shouldCallSetTelemetryOptOut, expectedSetTelemetryOptOutArg}) => {
-        it(`should call setTelemetryOptOut ${shouldCallSetTelemetryOptOut ? 'with ' + expectedSetTelemetryOptOutArg : 'not at all'} when shouldMark is ${shouldMark}, statusCode is ${statusCode} and currentTelemetryOptOut is ${currentTelemetryOptOut}`, () => {
-          webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut = sinon.stub();
-          webex.internal.newMetrics.callDiagnosticMetrics.getTelemetryOptOut = sinon
-            .stub()
-            .returns(currentTelemetryOptOut);
-
+        {shouldMark: true, statusCode: 200, expectedArg: true},
+        {shouldMark: true, statusCode: 201, expectedArg: false},
+        {shouldMark: true, statusCode: 400, expectedArg: false},
+        {shouldMark: true, statusCode: 503, expectedArg: false},
+        {shouldMark: true, statusCode: undefined, expectedArg: false},
+      ].forEach(({shouldMark, statusCode, expectedArg}) => {
+        it(`calls setIsTelemetryOptOutAutomatic(${expectedArg}) when shouldMark is ${shouldMark} and statusCode is ${statusCode}`, () => {
           webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
             statusCode,
-            shouldMark ? [{markTelemetryOptOutOnResponse: true}] : [{markTelemetryOptOutOnResponse: false}]
+            [{markTelemetryOptOutOnResponse: true}]
           );
 
-          if (shouldCallSetTelemetryOptOut) {
-            assert.calledOnce(webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut);
-            assert.deepEqual(
-              webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut.getCalls()[0].args[0],
-              expectedSetTelemetryOptOutArg
-            );
-          } else {
-            assert.notCalled(webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut);
-          }
+          assert.calledOnceWithExactly(setIsTelemetryOptOutAutomaticStub, expectedArg);
         });
-      })
+      });
+
+      [200, 201, 400, 503, undefined].forEach((statusCode) => {
+        it(`does not call setIsTelemetryOptOutAutomatic when shouldMark is false (statusCode: ${statusCode})`, () => {
+          webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
+            statusCode,
+            [{markTelemetryOptOutOnResponse: false}]
+          );
+
+          assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+        });
+      });
+
+      it('does not call setIsTelemetryOptOutAutomatic when payload is empty', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
+          200,
+          []
+        );
+
+        assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+      });
+
+      it('does not call setIsTelemetryOptOutAutomatic when payload is not an array', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
+          200,
+          null
+        );
+
+        assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+      });
     });
   });
 });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -602,21 +602,25 @@ describe('plugin-metrics', () => {
         );
       });
 
-      [
-        {shouldMark: true, statusCode: 200, expectedArg: true},
-        {shouldMark: true, statusCode: 201, expectedArg: false},
-        {shouldMark: true, statusCode: 400, expectedArg: false},
-        {shouldMark: true, statusCode: 503, expectedArg: false},
-        {shouldMark: true, statusCode: undefined, expectedArg: false},
-      ].forEach(({shouldMark, statusCode, expectedArg}) => {
-        it(`calls setIsTelemetryOptOutAutomatic(${expectedArg}) when shouldMark is ${shouldMark} and statusCode is ${statusCode}`, () => {
+      [201, 400, 503, undefined].forEach((statusCode) => {
+        it(`does not call setIsTelemetryOptOutAutomatic() when statusCode is ${statusCode} and markTelemetryOptOutOnResponse is true`, () => {
           webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
             statusCode,
             [{markTelemetryOptOutOnResponse: true}]
           );
 
-          assert.calledOnceWithExactly(setIsTelemetryOptOutAutomaticStub, expectedArg);
+          assert.notCalled(setIsTelemetryOptOutAutomaticStub);
         });
+      });
+
+      it('calls setIsTelemetryOptOutAutomatic(true) when statusCode is 200 and markTelemetryOptOutOnResponse is true', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.handleHttpResponseStatus(
+          200,
+          [{markTelemetryOptOutOnResponse: true}]
+        );
+
+        assert.calledOnce(setIsTelemetryOptOutAutomaticStub);
+        assert.calledWithExactly(setIsTelemetryOptOutAutomaticStub, true);
       });
 
       [200, 201, 400, 503, undefined].forEach((statusCode) => {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -4035,15 +4035,93 @@ describe('internal-plugin-metrics', () => {
     });
 
     describe('#getTelemetryOptOut', () => {
-      ['manual', 'automatic', undefined].forEach((telemetryOptOut) => {
-        it(`returns ${telemetryOptOut} if telemetryOptOut is ${telemetryOptOut}`, () => {
-          cd.setTelemetryOptOut(telemetryOptOut);
-          assert.deepEqual(cd.getTelemetryOptOut(), telemetryOptOut);
-        });
+      it('returns "manual" when manual telemetry opt-out is enabled', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+      });
 
-        it('returns undefined if telemetryOptOut is not set', () => {
-          assert.deepEqual(cd.getTelemetryOptOut(), undefined);
-        });
+      it('returns "automatic" when automatic telemetry opt-out is enabled', () => {
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'automatic');
+      });
+
+      it('returns "manual" when manual opt-out takes precedence over automatic', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+      });
+
+      it('returns undefined when neither manual nor automatic opt-out is set', () => {
+        assert.isUndefined(cd.getTelemetryOptOut());
+      });
+
+      it('returns undefined after disabling manual opt-out', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        cd.setIsTelemetryOptOutManual(false);
+        assert.isUndefined(cd.getTelemetryOptOut());
+      });
+    });
+
+    describe('#setIsTelemetryOptOutManual', () => {
+      it('sets manual telemetry opt-out to true', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+      });
+
+      it('sets manual telemetry opt-out to false', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        cd.setIsTelemetryOptOutManual(false);
+        assert.isUndefined(cd.getTelemetryOptOut());
+      });
+
+      it('can toggle manual telemetry opt-out multiple times', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+
+        cd.setIsTelemetryOptOutManual(false);
+        assert.isUndefined(cd.getTelemetryOptOut());
+
+        cd.setIsTelemetryOptOutManual(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+      });
+
+      it('manual opt-out takes precedence when automatic is also set', () => {
+        cd.setIsTelemetryOptOutAutomatic(true);
+        cd.setIsTelemetryOptOutManual(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+      });
+    });
+
+    describe('#setIsTelemetryOptOutAutomatic', () => {
+      it('sets automatic telemetry opt-out to true', () => {
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'automatic');
+      });
+
+      it('sets automatic telemetry opt-out to false', () => {
+        cd.setIsTelemetryOptOutAutomatic(true);
+        cd.setIsTelemetryOptOutAutomatic(false);
+        assert.isUndefined(cd.getTelemetryOptOut());
+      });
+
+      it('can toggle automatic telemetry opt-out multiple times', () => {
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'automatic');
+
+        cd.setIsTelemetryOptOutAutomatic(false);
+        assert.isUndefined(cd.getTelemetryOptOut());
+
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'automatic');
+      });
+
+      it('does not override manual opt-out', () => {
+        cd.setIsTelemetryOptOutManual(true);
+        cd.setIsTelemetryOptOutAutomatic(true);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
+
+        cd.setIsTelemetryOptOutAutomatic(false);
+        assert.equal(cd.getTelemetryOptOut(), 'manual');
       });
     });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
@@ -415,45 +415,60 @@ describe('internal-plugin-metrics', () => {
     })
 
     describe('#handleHttpResponseStatus', () => {
+      let setIsTelemetryOptOutAutomaticStub;
+
+      beforeEach(() => {
+        setIsTelemetryOptOutAutomaticStub = sinon.stub(
+          webex.internal.newMetrics.callDiagnosticMetrics,
+          'setIsTelemetryOptOutAutomatic'
+        );
+      });
+
       [
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 200, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: true, expectedSetTelemetryOptOutArg: 'automatic'},
-
-        {shouldMark: true, statusCode: 201, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: true, expectedSetTelemetryOptOutArg: undefined},
-        {shouldMark: true, statusCode: 202, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: true, statusCode: 203, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 200, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-
-        {shouldMark: false, statusCode: 201, currentTelemetryOptOut: 'automatic', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 202, currentTelemetryOptOut: 'manual', shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-        {shouldMark: false, statusCode: 203, currentTelemetryOptOut: undefined, shouldCallSetTelemetryOptOut: false, expectedSetTelemetryOptOutArg: 'N/A'},
-      ].forEach(({shouldMark, statusCode, currentTelemetryOptOut, shouldCallSetTelemetryOptOut, expectedSetTelemetryOptOutArg}) => {
-        it(`should call setTelemetryOptOut ${shouldCallSetTelemetryOptOut ? 'with ' + expectedSetTelemetryOptOutArg : 'not at all'} when shouldMark is ${shouldMark}, statusCode is ${statusCode} and currentTelemetryOptOut is ${currentTelemetryOptOut}`, () => {
-          webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut = sinon.stub();
-          webex.internal.newMetrics.callDiagnosticMetrics.getTelemetryOptOut = sinon
-            .stub()
-            .returns(currentTelemetryOptOut);
-
+        {shouldMark: true, statusCode: 200, expectedArg: true},
+        {shouldMark: true, statusCode: 201, expectedArg: false},
+        {shouldMark: true, statusCode: 400, expectedArg: false},
+        {shouldMark: true, statusCode: 503, expectedArg: false},
+        {shouldMark: true, statusCode: undefined, expectedArg: false},
+      ].forEach(({shouldMark, statusCode, expectedArg}) => {
+        it(`calls setIsTelemetryOptOutAutomatic(${expectedArg}) when shouldMark is ${shouldMark} and statusCode is ${statusCode}`, () => {
           webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
             statusCode,
-            shouldMark ? [{markTelemetryOptOutOnResponse: true}] : [{markTelemetryOptOutOnResponse: false}]
+            [{markTelemetryOptOutOnResponse: true}]
           );
 
-          if (shouldCallSetTelemetryOptOut) {
-            assert.calledOnce(webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut);
-            assert.deepEqual(
-              webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut.getCalls()[0].args[0],
-              expectedSetTelemetryOptOutArg
-            );
-          } else {
-            assert.notCalled(webex.internal.newMetrics.callDiagnosticMetrics.setTelemetryOptOut);
-          }
+          assert.calledOnceWithExactly(setIsTelemetryOptOutAutomaticStub, expectedArg);
         });
-      })
+      });
+
+      [200, 201, 400, 503, undefined].forEach((statusCode) => {
+        it(`does not call setIsTelemetryOptOutAutomatic when shouldMark is false (statusCode: ${statusCode})`, () => {
+          webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
+            statusCode,
+            [{markTelemetryOptOutOnResponse: false}]
+          );
+
+          assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+        });
+      });
+
+      it('does not call setIsTelemetryOptOutAutomatic when payload is empty', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
+          200,
+          []
+        );
+
+        assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+      });
+
+      it('does not call setIsTelemetryOptOutAutomatic when payload is not an array', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
+          200,
+          null
+        );
+
+        assert.notCalled(setIsTelemetryOptOutAutomaticStub);
+      });
     });
   });
 });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
@@ -424,21 +424,25 @@ describe('internal-plugin-metrics', () => {
         );
       });
 
-      [
-        {shouldMark: true, statusCode: 200, expectedArg: true},
-        {shouldMark: true, statusCode: 201, expectedArg: false},
-        {shouldMark: true, statusCode: 400, expectedArg: false},
-        {shouldMark: true, statusCode: 503, expectedArg: false},
-        {shouldMark: true, statusCode: undefined, expectedArg: false},
-      ].forEach(({shouldMark, statusCode, expectedArg}) => {
-        it(`calls setIsTelemetryOptOutAutomatic(${expectedArg}) when shouldMark is ${shouldMark} and statusCode is ${statusCode}`, () => {
+      [201, 400, 503, undefined].forEach((statusCode) => {
+        it(`does not call setIsTelemetryOptOutAutomatic when shouldMark is true and statusCode is ${statusCode}`, () => {
           webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
             statusCode,
             [{markTelemetryOptOutOnResponse: true}]
           );
 
-          assert.calledOnceWithExactly(setIsTelemetryOptOutAutomaticStub, expectedArg);
+          assert.notCalled(setIsTelemetryOptOutAutomaticStub);
         });
+      });
+
+      it('calls setIsTelemetryOptOutAutomatic(true) when statusCode is 200 and markTelemetryOptOutOnResponse is true', () => {
+        webex.internal.newMetrics.callDiagnosticMetrics.preLoginMetricsBatcher.handleHttpResponseStatus(
+          200,
+          [{markTelemetryOptOutOnResponse: true}]
+        );
+
+        assert.calledOnce(setIsTelemetryOptOutAutomaticStub);
+        assert.calledWithExactly(setIsTelemetryOptOutAutomaticStub, true);
       });
 
       [200, 201, 400, 503, undefined].forEach((statusCode) => {


### PR DESCRIPTION
# COMPLETES #[SPARK-826707](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-826707)

## This pull request addresses

Over-complexity in the overwriting of telemetryOptOut flag.

## by making the following changes

I realised that 2 switches/booleans were needed to keep track of the opt out status of the user, instead of only one string value. That way, if overwriting has to happen and the winning value (manual) switches back to off, then we can still remember the overwritten default value (automatic).

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [X] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [X] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [X] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
