### PR TITLE
fix(calling): deleteRecording uses soft delete (recycle bin)

### DIFF
--- a/packages/calling/src/CallRecording/CallRecording.ts
+++ b/packages/calling/src/CallRecording/CallRecording.ts
@@ -109,9 +109,11 @@ export class CallRecording extends Eventing<CallRecordingEventTypes> implements 
   }
 
   /**
-   * Permanently deletes a single recording. Per the API the recording cannot be recovered.
-   * @param recordingId - The recording id (`id`) to delete.
-   * @param options - Optional `reason`/`comment`, only required for Compliance Officer deletions.
+   * Moves a single recording to the recycle bin (soft delete) via
+   * `POST /convergedRecordings/softDelete`. Requires `spark:recordings_write` on the access token;
+   * the recording can be restored from the recycle bin via the platform restore API.
+   * @param recordingId - The recording id (`id`) to move to the recycle bin.
+   * @param options - Deprecated. Ignored (compliance permanent delete is not exposed).
    */
   public async deleteRecording(
     recordingId: string,

--- a/packages/calling/src/CallRecording/WxcCallRecordingConnector.test.ts
+++ b/packages/calling/src/CallRecording/WxcCallRecordingConnector.test.ts
@@ -331,24 +331,24 @@ describe('WxcCallRecordingConnector tests', () => {
   describe('deleteRecording', () => {
     const loggerContext = {file: CALL_RECORDING_FILE, method: METHODS.DELETE_RECORDING};
 
-    it('successfully deletes a recording without a body when no options are provided', async () => {
-      webex.request.mockResolvedValue(<WebexRequestPayload>(<unknown>{statusCode: 200}));
+    it('successfully soft-deletes a recording via POST /convergedRecordings/softDelete', async () => {
+      webex.request.mockResolvedValue(<WebexRequestPayload>(<unknown>{statusCode: 204}));
 
       const response = await connector.deleteRecording(RECORDING_ONE.id);
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(204);
       expect(response.message).toBe('SUCCESS');
 
       const callArgs = webex.request.mock.calls[webex.request.mock.calls.length - 1][0];
-      expect(callArgs.uri).toContain(`/convergedRecordings/${RECORDING_ONE.id}`);
-      expect(callArgs.uri).not.toContain('/metadata');
-      expect(callArgs.method).toBe(HTTP_METHODS.DELETE);
+      expect(callArgs.uri).toContain('/convergedRecordings/softDelete');
+      expect(callArgs.uri).not.toContain(`/convergedRecordings/${RECORDING_ONE.id}`);
+      expect(callArgs.method).toBe(HTTP_METHODS.POST);
       expect(callArgs.service).toBe('hydraDeveloperApi');
-      expect(callArgs.body).toBeUndefined();
+      expect(callArgs.body).toStrictEqual({recordingIds: [RECORDING_ONE.id]});
     });
 
-    it('sends reason and comment in the body when provided (Compliance Officer deletion)', async () => {
-      webex.request.mockResolvedValue(<WebexRequestPayload>(<unknown>{statusCode: 200}));
+    it('ignores deprecated reason/comment options (compliance DELETE is not exposed)', async () => {
+      webex.request.mockResolvedValue(<WebexRequestPayload>(<unknown>{statusCode: 204}));
 
       await connector.deleteRecording(RECORDING_ONE.id, {
         reason: 'audit',
@@ -356,8 +356,8 @@ describe('WxcCallRecordingConnector tests', () => {
       });
 
       const callArgs = webex.request.mock.calls[webex.request.mock.calls.length - 1][0];
-      expect(callArgs.method).toBe(HTTP_METHODS.DELETE);
-      expect(callArgs.body).toStrictEqual({reason: 'audit', comment: 'Maintain data privacy'});
+      expect(callArgs.method).toBe(HTTP_METHODS.POST);
+      expect(callArgs.body).toStrictEqual({recordingIds: [RECORDING_ONE.id]});
     });
 
     it('handles a 400 error', async () => {

--- a/packages/calling/src/CallRecording/WxcCallRecordingConnector.ts
+++ b/packages/calling/src/CallRecording/WxcCallRecordingConnector.ts
@@ -45,6 +45,7 @@ import {
   OWNER_TYPE,
   RECORDING_NOT_FOUND_MESSAGE,
   SERVICE_TYPE,
+  SOFT_DELETE,
   STATUS,
   STORAGE_REGION,
   TO,
@@ -386,13 +387,20 @@ export class WxcCallRecordingConnector
   }
 
   /**
-   * Permanently deletes a single recording. Per the API the recording cannot be recovered.
-   * @param recordingId - The recording id (`id`) to delete.
-   * @param options - Optional `reason`/`comment`, only required for Compliance Officer deletions.
+   * Moves a recording to the recycle bin (soft delete). Matches native Webex user delete:
+   * `POST /convergedRecordings/softDelete` with `recordingIds: [recordingId]`.
+   * Requires `spark:recordings_write` on the access token.
+   *
+   * Mercury emits `convergedRecordings.updated` + `eventSubType: TRASH`, which this connector
+   * surfaces as `callRecording:deleted`.
+   *
+   * @param recordingId - The recording id (`id`) to move to the recycle bin.
+   * @param _options - Deprecated. Ignored. Compliance permanent delete uses a separate API.
    */
   public async deleteRecording(
     recordingId: string,
-    options?: DeleteRecordingOptions
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for ICallRecording signature parity; soft delete ignores options
+    _options?: DeleteRecordingOptions
   ): Promise<RecordingDeleteResponse> {
     const loggerContext = {
       file: CALL_RECORDING_FILE,
@@ -402,21 +410,13 @@ export class WxcCallRecordingConnector
     log.info(`${METHOD_START_MESSAGE} with recordingId=${recordingId}`, loggerContext);
 
     try {
-      const url = `${this.recordingServiceUrl}/${CONVERGED_RECORDINGS}/${recordingId}`;
-
-      const body: DeleteRecordingOptions = {};
-      if (options?.reason) {
-        body.reason = options.reason;
-      }
-      if (options?.comment) {
-        body.comment = options.comment;
-      }
+      const url = `${this.recordingServiceUrl}/${CONVERGED_RECORDINGS}/${SOFT_DELETE}`;
 
       const response = <WebexRequestPayload>await this.webex.request({
         uri: url,
-        method: HTTP_METHODS.DELETE,
+        method: HTTP_METHODS.POST,
         service: ALLOWED_SERVICES.HYDRA_DEVELOPER_API,
-        ...(Object.keys(body).length > 0 ? {body} : {}),
+        body: {recordingIds: [recordingId]},
       });
 
       log.log(`Response trackingId: ${response?.headers?.trackingid}`, loggerContext);
@@ -427,7 +427,7 @@ export class WxcCallRecordingConnector
         message: SUCCESS_MESSAGE,
       };
 
-      log.log(`Successfully deleted recording ${recordingId}`, loggerContext);
+      log.log(`Successfully moved recording ${recordingId} to recycle bin`, loggerContext);
 
       return responseDetails;
     } catch (err: unknown) {

--- a/packages/calling/src/CallRecording/ai-docs/AGENTS.md
+++ b/packages/calling/src/CallRecording/ai-docs/AGENTS.md
@@ -4,7 +4,7 @@
 
 The `CallRecording` module provides read access to **Post Call Recordings** (recordings, transcripts,
 summaries, and action items) produced for Webex Calling sessions through a single
-`getCallRecording` method, supports permanently deleting a recording, and forwards recording
+`getCallRecording` method, moves a recording to the recycle bin via `deleteRecording`, and forwards recording
 lifecycle events received over Mercury as typed SDK events.
 
 Recordings are fetched from the **Webex public developer API (hydra)** — catalog service
@@ -60,7 +60,7 @@ All reads go through a **single** `getCallRecording` method, which dispatches on
 | Method | Signature | Description |
 | ------ | --------- | ----------- |
 | `getCallRecording` | `<T extends GetCallRecordingRequest>(request: T): Promise<RecordingResponseFor<T>>` | Reads recordings; the `request.type` selects LIST / DETAIL / METADATA / BY_CALL_SESSION |
-| `deleteRecording` | `(recordingId: string, options?: DeleteRecordingOptions): Promise<RecordingDeleteResponse>` | Permanently deletes a recording (cannot be recovered); needs `spark-compliance:recordings_write`. Optional `reason`/`comment` for Compliance Officer deletions |
+| `deleteRecording` | `(recordingId: string, options?: DeleteRecordingOptions): Promise<RecordingDeleteResponse>` | Moves a recording to the recycle bin via `POST /convergedRecordings/softDelete`; needs `spark:recordings_write`. `options` is deprecated and ignored |
 
 ### Helpers (exported from `@webex/calling`)
 
@@ -134,7 +134,7 @@ All reads go through a **single** `getCallRecording` method, which dispatches on
 | `RecordingResponse` | `{statusCode, data: {recording?, error?}, message}` |
 | `RecordingMetadataResponse` | `{statusCode, data: {metadata?, error?}, message}` |
 | `RecordingDeleteResponse` | `{statusCode, data: {error?}, message}` |
-| `DeleteRecordingOptions` | `{reason?, comment?}` (Compliance Officer deletions) |
+| `DeleteRecordingOptions` | `{reason?, comment?}` — **deprecated**, ignored by `deleteRecording` |
 | `RecordingEvent` | Mercury event envelope: `{id?, data: {activity, eventType, eventSubType?}, timestamp?, trackingId?}` |
 
 ### Field Mapping Notes
@@ -235,25 +235,18 @@ const response = await callRecording.getCallRecording({
 console.log(`Found ${response.data.recordings?.length} recordings for the session`);
 ```
 
-### Delete a Recording (permanent)
+### Delete a Recording (soft delete / recycle bin)
 
 ```typescript
-// Deleting your own recording:
 const response = await callRecording.deleteRecording('recording-uuid');
 
-// Compliance Officer deleting another user's recording (reason/comment required):
-await callRecording.deleteRecording('recording-uuid', {
-  reason: 'audit',
-  comment: 'Maintain data privacy',
-});
-
-if (response.statusCode === 200) {
-  // Recording is permanently deleted (cannot be recovered) and no longer appears in a LIST request.
+if (response.statusCode >= 200 && response.statusCode < 300) {
+  // Recording moved to recycle bin; Mercury TRASH -> callRecording:deleted.
 }
 ```
 
-> The recoverable recycle-bin flow (*Move / Purge / Restore Recordings from Recycle Bin*) is a
-> separate set of `POST` endpoints not yet implemented in this client.
+> Compliance permanent delete (`DELETE /convergedRecordings/{id}`) and batch purge/restore APIs are
+> not exposed on this client.
 
 ### Listen for Recording Events
 
@@ -305,7 +298,7 @@ builds the list URL as:
 - The raw list response is `{ "items": [ ... ] }`; the client maps `items` to `data.recordings`.
 - `DETAIL`: `GET {recordingServiceUrl}/convergedRecordings/{recordingId}`.
 - `METADATA`: `GET {recordingServiceUrl}/convergedRecordings/{recordingId}/metadata`.
-- `deleteRecording`: `DELETE {recordingServiceUrl}/convergedRecordings/{recordingId}` (permanent; optional `{reason, comment}` body).
+- `deleteRecording`: `POST {recordingServiceUrl}/convergedRecordings/softDelete` with body `{ recordingIds: [recordingId] }` (soft delete / recycle bin; requires `spark:recordings_write`).
 
 ### `BY_CALL_SESSION` request (API gap)
 

--- a/packages/calling/src/CallRecording/ai-docs/ARCHITECTURE.md
+++ b/packages/calling/src/CallRecording/ai-docs/ARCHITECTURE.md
@@ -164,8 +164,8 @@ sequenceDiagram
     WxApp-->>CR: 200 {owner, session, participants, mediaStreams, extensionData}
     CR-->>App: {statusCode, data: {metadata}, message: 'SUCCESS'}
 
-    App->>CR: deleteRecording(recordingId, {reason?, comment?})
-    CR->>WxApp: DELETE /convergedRecordings/{recordingId} (body {reason, comment} only if provided)
+    App->>CR: deleteRecording(recordingId)
+    CR->>WxApp: POST /convergedRecordings/softDelete { recordingIds: [recordingId] }
     WxApp-->>CR: 200 (recording permanently deleted, cannot be recovered)
     CR-->>App: {statusCode, data: {}, message: 'SUCCESS'}
 ```

--- a/packages/calling/src/CallRecording/ai-docs/ARCHITECTURE.md
+++ b/packages/calling/src/CallRecording/ai-docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ flowchart TB
     CR -->|getCallingBackEnd == WXC: new| WC
     CR -->|delegates getCallRecording/deleteRecording| WC
     WC -->|services.get hydraDeveloperApi| Catalog
-    WC -->|GET/DELETE /convergedRecordings| WxApp
+    WC -->|GET reads / POST /convergedRecordings/softDelete| WxApp
 
     WC -->|registerListener convergedRecordings.*| SDK
     SDK -->|mercury.on| Mercury
@@ -166,7 +166,7 @@ sequenceDiagram
 
     App->>CR: deleteRecording(recordingId)
     CR->>WxApp: POST /convergedRecordings/softDelete { recordingIds: [recordingId] }
-    WxApp-->>CR: 200 (recording permanently deleted, cannot be recovered)
+    WxApp-->>CR: 204 (recording moved to recycle bin)
     CR-->>App: {statusCode, data: {}, message: 'SUCCESS'}
 ```
 

--- a/packages/calling/src/CallRecording/constants.ts
+++ b/packages/calling/src/CallRecording/constants.ts
@@ -2,6 +2,7 @@ export const CALL_RECORDING_FILE = 'CallRecording';
 
 // Recording API (hydra developer API) endpoint segments.
 export const CONVERGED_RECORDINGS = 'convergedRecordings';
+export const SOFT_DELETE = 'softDelete';
 export const METADATA = 'metadata';
 
 // Query parameter keys for the list request.

--- a/packages/calling/src/CallRecording/types.ts
+++ b/packages/calling/src/CallRecording/types.ts
@@ -255,8 +255,8 @@ export type RecordingDeleteResponse = {
 };
 
 /**
- * Optional request body for {@link ICallRecording.deleteRecording}. Both fields are only required
- * when a Compliance Officer deletes another user's recording.
+ * @deprecated Ignored by {@link ICallRecording.deleteRecording}. Retained for backward-compatible
+ * signatures only. Compliance permanent delete is not exposed on the CallRecording client.
  */
 export type DeleteRecordingOptions = {
   /** Reason for deleting the recording (e.g. `audit`). */
@@ -384,27 +384,26 @@ export interface ICallRecording extends Eventing<CallRecordingEventTypes> {
   getCallRecording<T extends GetCallRecordingRequest>(request: T): Promise<RecordingResponseFor<T>>;
 
   /**
-   * Permanently deletes a single recording.
+   * Moves a recording to the recycle bin (soft delete).
    *
-   * Calls `DELETE /convergedRecordings/{recordingId}`. Per the API, the deleted recording
-   * **cannot be recovered**; when a Compliance Officer deletes another user's recording it is
-   * purged from Webex and becomes inaccessible to all parties. Requires the
-   * `spark-compliance:recordings_write` scope on the access token.
+   * Calls `POST /convergedRecordings/softDelete` with `{ recordingIds: [recordingId] }`.
+   * The recording can be restored from the recycle bin via the platform restore API. Requires
+   * `spark:recordings_write` on the access token (recording owner). Control Hub
+   * "Delete recordings and transcripts" enables this for the user; it does **not** grant
+   * compliance-officer permanent delete.
    *
-   * `options.reason` / `options.comment` are only required when a Compliance Officer deletes
-   * another user's recording and are sent as the request body when provided.
+   * Mercury emits `convergedRecordings.updated` + `TRASH`, surfaced as `callRecording:deleted`.
    *
-   * @param recordingId - The recording id (`id`) to delete.
-   * @param options - Optional `reason`/`comment` (Compliance Officer deletions).
+   * @param recordingId - The recording id (`id`) to move to the recycle bin.
+   * @param _options - Deprecated. Ignored.
    *
    * @example
    * ```javascript
    * await callRecording.deleteRecording(recordingId);
-   * await callRecording.deleteRecording(recordingId, {reason: 'audit', comment: 'Maintain data privacy'});
    * ```
    */
   deleteRecording(
     recordingId: string,
-    options?: DeleteRecordingOptions
+    _options?: DeleteRecordingOptions
   ): Promise<RecordingDeleteResponse>;
 }

--- a/packages/calling/src/CallRecording/types.ts
+++ b/packages/calling/src/CallRecording/types.ts
@@ -347,7 +347,8 @@ export type RecordingResponseFor<T extends GetCallRecordingRequest> =
  *
  * Provides read access to Post Call Recordings through a single {@link getCallRecording} method
  * (listing, single fetch, lookup by call session, and metadata — selected by the request `type`),
- * permanent deletion of a recording, and emits recording lifecycle events received over Mercury.
+ * moves a recording to the recycle bin (soft delete), and emits recording lifecycle events received
+ * over Mercury.
  */
 export interface ICallRecording extends Eventing<CallRecordingEventTypes> {
   /**


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

CallRecording.deleteRecording() previously called DELETE /v1/convergedRecordings/{id}, which requires spark-compliance:recordings_write (compliance officer permanent delete). Regular users with Control Hub
"Delete recordings and transcripts" get 403 on that endpoint. Switch to the native Webex user-delete path:
  POST /v1/convergedRecordings/softDelete
  body: { recordingIds: [recordingId] }
  scope: spark:recordings_write
  
Mercury still emits convergedRecordings.updated + TRASH; the connector
continues to surface callRecording:deleted.
- Add SOFT_DELETE constant
- Deprecate DeleteRecordingOptions (ignored for backward compatibility)
- Update connector tests and ai-docs (AGENTS.md, ARCHITECTURE.md)

## by making the following changes

## Summary

Fixes `deleteRecording()` for end-user delete in Post Call Recording.

The connector was calling the **compliance permanent-delete** API (`DELETE /convergedRecordings/{id}`, `spark-compliance:recordings_write`). Users with Control Hub **“Delete recordings and transcripts”** need the **soft-delete** API instead, which matches native Webex behavior.

## Change

| Before | After |
|--------|-------|
| `DELETE /convergedRecordings/{id}` | `POST /convergedRecordings/softDelete` |
| `spark-compliance:recordings_write` | `spark:recordings_write` |
| Permanent purge | Move to recycle bin |

`deleteRecording(recordingId, options?)` signature is unchanged; `DeleteRecordingOptions` is deprecated and ignored.

## Mercury

No event-mapping change. Soft delete still arrives as `convergedRecordings.updated` + `eventSubType: TRASH` → `callRecording:deleted`.

## Test plan

- [x] `WxcCallRecordingConnector.test.ts` — `deleteRecording` uses POST `.../softDelete` with `{ recordingIds: [id] }`
- [x] Existing CallRecording suite (49 tests)
- [ ] Manual: token with `spark:recordings_write`; Network shows POST softDelete, not DELETE by id

## Consumer impact

**webex-calling-msteams-client** — Teams Recording tab delete. Re-auth required after adding `spark:recordings_write` to OAuth scope.

## Docs

- `packages/calling/src/CallRecording/ai-docs/AGENTS.md`
- `packages/calling/src/CallRecording/ai-docs/ARCHITECTURE.md`

<img width="1728" height="1117" alt="Screenshot 2026-07-08 at 3 09 53 PM" src="https://github.com/user-attachments/assets/4fbfda1d-4b12-420c-ae94-5b07a13c6c29" />





### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
