### PR TITLE
fix: display hints are sometimes wrong

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -278,6 +278,7 @@ export default class LocusInfo extends EventsScope {
   host: any;
   info: any;
   roles: any;
+  isJoined: boolean;
   mediaShares: any;
   url: any;
   links?: Links;
@@ -304,6 +305,7 @@ export default class LocusInfo extends EventsScope {
     this.compareAndUpdateFlags = {};
     this.meetingId = meetingId;
     this.updateMeeting = updateMeeting;
+    this.isJoined = false;
     this.locusParser = new LocusDeltaParser();
     this.hashTreeParsers = new Map();
     this.hashTreeObjectId2ParticipantId = new Map();
@@ -518,7 +520,7 @@ export default class LocusInfo extends EventsScope {
     this.updateControls(locus.controls, locus.self);
     this.updateLocusUrl(locus.url, ControlsUtils.isMainSessionDTO(locus));
     this.updateFullState(locus.fullState);
-    this.updateMeetingInfo(locus.info);
+    this.updateMeetingInfo(locus.info, locus.self);
     this.updateEmbeddedApps(locus.embeddedApps);
     // self and participants generate sipUrl for 1:1 meeting
     this.updateSelf(locus.self);
@@ -2491,9 +2493,19 @@ export default class LocusInfo extends EventsScope {
    */
   updateMeetingInfo(info: object, self?: object) {
     const roles = self ? SelfUtils.getRoles(self) : this.parsedLocus.self?.roles || [];
-    if ((info && !isEqual(this.info, info)) || (!isEqual(this.roles, roles) && info)) {
-      const isJoined = SelfUtils.isJoined(self || this.parsedLocus.self);
-      const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, info, roles, isJoined);
+    const isJoined = SelfUtils.isJoined(self || this.parsedLocus.self);
+
+    // The parsed userDisplayHints depend on info, roles and isJoined, so we must recompute
+    // whenever any of them changes. A common case is self transitioning to JOINED via a delta
+    // that doesn't carry an info section - in that case we fall back to the previously stored
+    // info so the hints get reparsed with the new joined state (e.g. VIEW_THE_PARTICIPANT_LIST).
+    const infoToParse = info || this.info;
+    const infoChanged = info && !isEqual(this.info, info);
+    const rolesChanged = !isEqual(this.roles, roles);
+    const isJoinedChanged = this.isJoined !== isJoined;
+
+    if (infoToParse && (infoChanged || rolesChanged || isJoinedChanged)) {
+      const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, infoToParse, roles, isJoined);
 
       if (parsedInfo.updates.isLocked) {
         this.emitScoped(
@@ -2516,7 +2528,7 @@ export default class LocusInfo extends EventsScope {
         );
       }
 
-      this.info = info;
+      this.info = infoToParse;
       this.parsedLocus.info = parsedInfo.current;
       // Parses the info and adds necessary values
       this.updateMeeting(parsedInfo.current);
@@ -2533,6 +2545,7 @@ export default class LocusInfo extends EventsScope {
       );
     }
     this.roles = roles;
+    this.isJoined = isJoined;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -278,7 +278,6 @@ export default class LocusInfo extends EventsScope {
   host: any;
   info: any;
   roles: any;
-  isJoined: boolean;
   mediaShares: any;
   url: any;
   links?: Links;
@@ -305,7 +304,6 @@ export default class LocusInfo extends EventsScope {
     this.compareAndUpdateFlags = {};
     this.meetingId = meetingId;
     this.updateMeeting = updateMeeting;
-    this.isJoined = false;
     this.locusParser = new LocusDeltaParser();
     this.hashTreeParsers = new Map();
     this.hashTreeObjectId2ParticipantId = new Map();
@@ -2502,7 +2500,7 @@ export default class LocusInfo extends EventsScope {
     const infoToParse = info || this.info;
     const infoChanged = info && !isEqual(this.info, info);
     const rolesChanged = !isEqual(this.roles, roles);
-    const isJoinedChanged = this.isJoined !== isJoined;
+    const isJoinedChanged = SelfUtils.isJoined(this.parsedLocus.self) !== isJoined;
 
     if (infoToParse && (infoChanged || rolesChanged || isJoinedChanged)) {
       const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, infoToParse, roles, isJoined);
@@ -2545,7 +2543,6 @@ export default class LocusInfo extends EventsScope {
       );
     }
     this.roles = roles;
-    this.isJoined = isJoined;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2846,6 +2846,10 @@ describe('plugin-meetings', () => {
 
         let expectedMeeting;
 
+        // simulate that updateSelf has been called previously (as happens in production)
+        // so that parsedLocus.self reflects the joined state
+        locusInfo.parsedLocus.self = {state: 'JOINED'};
+
         /*
         When the event is triggered, it is required that the meeting has already
         been updated. This is why the meeting is being checked within the stubbed event emitter

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2997,6 +2997,46 @@ describe('plugin-meetings', () => {
         // since self is not passed to updateMeetingInfo, MEETING_INFO_UPDATED should be triggered with isIntializing: true
         checkMeetingInfoUpdatedCalledForRoles(true, {isInitializing: true});
       });
+
+      // joined-section hints (like ROSTER_IN_MEETING) are filtered out while not joined, so they
+      // are a good proxy for verifying that userDisplayHints get recomputed on a join transition
+      [
+        {
+          name: 'the JOINED delta carries the info section',
+          getSecondInfo: (info) => info,
+        },
+        {
+          name: 'the JOINED delta omits the info section (falls back to stored info)',
+          getSecondInfo: () => undefined,
+        },
+      ].forEach(({name, getSecondInfo}) => {
+        it(`recomputes userDisplayHints when self transitions to JOINED with unchanged roles and ${name}`, () => {
+          const info = cloneDeep(meetingInfo); // joined: ['ROSTER_IN_MEETING', 'LOCK_STATUS_UNLOCKED']
+
+          const notJoinedSelf = cloneDeep(self);
+          notJoinedSelf.state = 'IDLE';
+          notJoinedSelf.controls.role.roles = [];
+
+          const joinedSelf = cloneDeep(self);
+          joinedSelf.state = 'JOINED';
+          joinedSelf.controls.role.roles = [];
+
+          sinon.stub(locusInfo, 'emitScoped');
+
+          // first update while not joined: joined-section hints are filtered out
+          locusInfo.updateMeetingInfo(info, notJoinedSelf);
+          assert.notInclude(locusInfo.parsedLocus.info.userDisplayHints, 'ROSTER_IN_MEETING');
+          assert.notInclude(locusInfo.parsedLocus.info.userDisplayHints, 'LOCK_STATUS_UNLOCKED');
+
+          // self transitions to JOINED - info and roles are unchanged
+          locusInfo.updateMeetingInfo(getSecondInfo(info), joinedSelf);
+
+          // the hints must be recomputed with the new joined state
+          assert.include(locusInfo.parsedLocus.info.userDisplayHints, 'ROSTER_IN_MEETING');
+          assert.include(locusInfo.parsedLocus.info.userDisplayHints, 'LOCK_STATUS_UNLOCKED');
+          checkMeetingInfoUpdatedCalled(true, {isInitializing: false});
+        });
+      });
     });
 
     describe('#updateMediaShares', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-832255](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-832255)

## This pull request addresses
display hints are sometimes not recalculated when only the self state changes

## by making the following changes
make sure they're recalculated, requires 2 fixes:
1. in LocusInfo.init()
2. in updateMeetingInfo()

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
