### PR TITLE
fix(metrics): move @webex/event-dictionary-ts to a dependency

### DIFF
--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -5,9 +5,6 @@
   "main": "dist/index.js",
   "devMain": "src/index.js",
   "types": "dist/types/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/webex/webex-js-sdk.git",

--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/event-dictionary-ts": "^1.0.2191",
     "@webex/common-timers": "workspace:*",
+    "@webex/event-dictionary-ts": "^1.0.2191",
     "@webex/test-helper-chai": "workspace:*",
     "@webex/test-helper-mock-webex": "workspace:*",
     "@webex/webex-core": "workspace:*",

--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "devMain": "src/index.js",
   "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/webex/webex-js-sdk.git",
@@ -24,7 +27,6 @@
     "@sinonjs/fake-timers": "^6.0.1",
     "@webex/babel-config-legacy": "workspace:*",
     "@webex/eslint-config-legacy": "workspace:*",
-    "@webex/event-dictionary-ts": "^1.0.2191",
     "@webex/jest-config-legacy": "workspace:*",
     "@webex/legacy-tools": "workspace:*",
     "@webex/test-helper-chai": "workspace:*",
@@ -37,6 +39,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
+    "@webex/event-dictionary-ts": "^1.0.2191",
     "@webex/common-timers": "workspace:*",
     "@webex/test-helper-chai": "workspace:*",
     "@webex/test-helper-mock-webex": "workspace:*",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -13,9 +13,6 @@
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "devMain": "src/index.js",
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/webex/webex-js-sdk.git",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/event-dictionary-ts": "^1.0.2181",
+    "@webex/event-dictionary-ts": "^1.0.2191",
     "@webex/internal-media-core": "2.26.1",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -13,6 +13,9 @@
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "devMain": "src/index.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/webex/webex-js-sdk.git",
@@ -41,7 +44,6 @@
     "@types/jsdom": "^21",
     "@webex/babel-config-legacy": "workspace:*",
     "@webex/eslint-config-legacy": "workspace:*",
-    "@webex/event-dictionary-ts": "^1.0.2181",
     "@webex/jest-config-legacy": "workspace:*",
     "@webex/legacy-tools": "workspace:*",
     "@webex/plugin-rooms": "workspace:*",
@@ -62,6 +64,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
+    "@webex/event-dictionary-ts": "^1.0.2181",
     "@webex/internal-media-core": "2.26.1",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,19 +7685,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/event-dictionary-ts@npm:^1.0.2181":
-  version: 1.0.2181
-  resolution: "@webex/event-dictionary-ts@npm:1.0.2181"
-  dependencies:
-    amf-client-js: ^5.2.6
-    json-schema-to-typescript: ^15.0.4
-    minimist: ^1.2.8
-    shelljs: ^0.8.5
-    webapi-parser: ^0.5.0
-  checksum: e0e76c093d37395295558a48378cdfb4cff496197968690ba0b0e62e7b12b2206da7386c02aad4229251c4858836af05fb580e9c34ab3432f8300b5da8875a9b
-  languageName: node
-  linkType: hard
-
 "@webex/event-dictionary-ts@npm:^1.0.2191":
   version: 1.0.2193
   resolution: "@webex/event-dictionary-ts@npm:1.0.2193"
@@ -8901,7 +8888,7 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/event-dictionary-ts": ^1.0.2181
+    "@webex/event-dictionary-ts": ^1.0.2191
     "@webex/internal-media-core": 2.26.2
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The build failures that occur due to @webex/event-dictionary-ts being referenced in code but only included as a dev dep

## by making the following changes

added @webex/event-dictionary-ts as a dependency

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Windsurf
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
