### PR TITLE
Removed sessionId usage

### DIFF
--- a/packages/@webex/internal-plugin-llm/README.md
+++ b/packages/@webex/internal-plugin-llm/README.md
@@ -24,92 +24,72 @@ npm install --save @webex/internal-plugin-llm
 ```js
 import '@webex/internal-plugin-llm';
 import WebexCore from '@webex/webex-core';
-// Optional: import enum from package internals if needed in your app setup
-// import {DataChannelTokenType} from '@webex/internal-plugin-llm/src/llm.types';
 
 const webex = new WebexCore();
+
+// Create a new LLM connection (each meeting owns its own channel)
+const llmChannel = webex.internal.llm.createConnection();
 
 // locusUrl and datachannelUrl are from meeting.locusInfo
 const locusUrl = meeting.locusInfo.url;
 const datachannelUrl = meeting.locusInfo.info.datachannelUrl;
 
-// Optional JWT token for data channel auth
-const datachannelToken = '<jwt-token>';
-
-// Default session (no token)
-await webex.internal.llm.registerAndConnect(locusUrl, datachannelUrl);
-
-// Default session (with JWT token)
-await webex.internal.llm.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
-
-// Multiple named sessions
-await webex.internal.llm.registerAndConnect(locusUrlA, datachannelUrlA, undefined, 'session-a');
-await webex.internal.llm.registerAndConnect(
-  locusUrlB,
-  datachannelUrlB,
-  datachannelToken,
-  'session-b'
-);
-
-// Listen across multiple connections
-const llm = webex.internal.llm;
-const sessionA = 'session-a';
-const sessionB = 'session-b';
-
-// Default session events use the base event name.
-llm.on('online', () => {
-  console.log('[default] connected');
-});
-
-llm.on('event', (envelope) => {
-  console.log('[default] event', envelope.data?.eventType, envelope.sessionId);
-});
-
-// Non-default sessions emit events with :<sessionId> suffix.
-llm.on(`online:${sessionA}`, () => {
-  console.log(`[${sessionA}] connected`);
-});
-
-llm.on(`event:${sessionA}`, (envelope) => {
-  console.log(`[${sessionA}] event`, envelope.data?.eventType, envelope.sessionId);
-});
-
-llm.on(`event:${sessionB}`, (envelope) => {
-  console.log(`[${sessionB}] event`, envelope.data?.eventType, envelope.sessionId);
-});
-
-// Optional: store/retrieve token by token type
-webex.internal.llm.setDatachannelToken(datachannelToken, 'llm-default-session');
-webex.internal.llm.getDatachannelToken('llm-default-session');
-
-// Optional: inject token refresh handler
-webex.internal.llm.setRefreshHandler(async () => {
+// Optional: set up token refresh handler before connecting
+llmChannel.setRefreshHandler(async () => {
   // Return shape must match plugin expectation
   return {
     body: {
       datachannelToken: '<refreshed-jwt-token>',
-      datachannelTokenType: 'llm-default-session',
+      datachannelTokenType: 'llm-default-session', // or 'llm-practice-session'
     },
   };
-}, 'llm-default-session');
+});
 
-// Optional: manually trigger refresh (if needed by your flow)
-await webex.internal.llm.refreshDataChannelToken();
+// Connect (with optional JWT token for data channel auth)
+const datachannelToken = '<jwt-token>';
+await llmChannel.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
 
-// Per-session status and metadata
-webex.internal.llm.isConnected('session-a');
-webex.internal.llm.getBinding('session-a');
-webex.internal.llm.getLocusUrl('session-a');
-webex.internal.llm.getDatachannelUrl('session-a');
+// Subscribe to events directly on the channel
+llmChannel.on('online', () => {
+  console.log('LLM connected');
+});
 
-// All active sessions
+llmChannel.on('event:relay.event', (envelope) => {
+  console.log('LLM event', envelope.data?.eventType);
+});
+
+// Channel status and metadata
+llmChannel.isConnected();
+llmChannel.isConnecting();
+llmChannel.getBinding();
+llmChannel.getLocusUrl();
+llmChannel.getDatachannelUrl();
+llmChannel.getSocket();
+
+// Token management
+llmChannel.setDatachannelToken(datachannelToken);
+llmChannel.getDatachannelToken();
+llmChannel.clearDatachannelToken();
+
+// Manually trigger token refresh (if needed by your flow)
+await llmChannel.refreshDataChannelToken();
+
+// Disconnect when done (owner is responsible for cleanup)
+await llmChannel.disconnect({code: 1000, reason: 'done'});
+
+// --- Plugin-level methods ---
+
+// Check if data channel token feature flag is enabled
+await webex.internal.llm.isDataChannelTokenEnabled();
+
+// Get all active connections (useful for diagnostics)
 webex.internal.llm.getAllConnections();
 
-// Disconnect one session
-await webex.internal.llm.disconnectLLM({code: 1000, reason: 'done'}, 'session-a', 'meeting-id');
+// Find a channel by datachannel URL (used by interceptors)
+webex.internal.llm.getConnectionByDatachannelUrl(datachannelUrl);
 
-// Disconnect all sessions
-await webex.internal.llm.disconnectAllLLM({code: 1000, reason: 'shutdown'});
+// Disconnect all connections (useful for cleanup on logout)
+await webex.internal.llm.disconnectAll({code: 1000, reason: 'shutdown'});
 ```
 
 ## Maintainers

--- a/packages/@webex/internal-plugin-llm/src/index.ts
+++ b/packages/@webex/internal-plugin-llm/src/index.ts
@@ -7,7 +7,7 @@ export type {RegisterAndConnectTiming} from './llm.types';
 WebexCore.registerInternalPlugin('llm', LLMPlugin, {
   config,
   onBeforeLogout() {
-    return this.disconnectAllLLM();
+    return this.disconnectAll();
   },
 });
 
@@ -15,3 +15,4 @@ export {DataChannelTokenType};
 export {LLM_DEFAULT_SESSION, LLM_PRACTICE_SESSION} from './constants';
 export {default} from './llm';
 export {default as LLMPlugin} from './llm-plugin';
+export type {ILLMChannel, ILLMPlugin} from './llm.types';

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -1,255 +1,88 @@
 /* eslint-disable require-jsdoc */
 import {WebexPlugin} from '@webex/webex-core';
 import LLMChannel, {config} from './llm';
-import {DATA_CHANNEL_WITH_JWT_TOKEN, LLM_DEFAULT_SESSION} from './constants';
-import {DataChannelTokenType} from './llm.types';
+import {DATA_CHANNEL_WITH_JWT_TOKEN} from './constants';
 
 /**
  * LLMPlugin — registered as `webex.internal.llm`.
  *
- * Maintains a Map<sessionId, LLMChannel> so multiple simultaneous LLM
- * connections (e.g. default session + practice session) can coexist.
- * All existing callers continue to work unchanged via the session-keyed API.
+ * Factory for creating LLMChannel instances. Each Meeting creates and owns
+ * its own LLMChannel(s), allowing multiple independent connections without
+ * the need for session IDs or ownership tracking.
  *
- * sessionId values are the LLM_DEFAULT_SESSION / LLM_PRACTICE_SESSION constants,
- * which match the DataChannelTokenType enum values so token keys and session keys
- * are the same namespace.
+ * This is a breaking API change from the previous design where the plugin
+ * maintained a Map of sessions and exposed session-keyed methods.
+ *
+ * Old usage (no longer supported):
+ *   webex.internal.llm.isConnected()
+ *   webex.internal.llm.registerAndConnect(url, dcUrl, token, sessionId)
+ *
+ * New usage:
+ *   const llm = webex.internal.llm.createConnection();
+ *   await llm.registerAndConnect(url, dcUrl, token);
+ *   llm.isConnected();
+ *   // When done:
+ *   await llm.disconnect();
  */
 export class LLMPlugin extends (WebexPlugin as any) {
   namespace = 'llm';
 
-  private sessions = new Map<string, LLMChannel>();
+  /**
+   * Registry of active LLM channels for interceptor lookup.
+   * Channels are registered when created and unregistered on disconnect.
+   */
+  private channels = new Set<LLMChannel>();
 
-  private getOrCreateSession(sessionId: string): LLMChannel {
-    let channel = this.sessions.get(sessionId);
+  /**
+   * Creates a new LLMChannel instance. The caller owns the channel and is
+   * responsible for connecting, disconnecting, and cleaning it up.
+   *
+   * @example
+   * const llm = webex.internal.llm.createConnection();
+   * llm.setRefreshHandler(() => meeting.refreshDataChannelToken());
+   * await llm.registerAndConnect(locusUrl, datachannelUrl, token);
+   *
+   * // Subscribe to events directly on the channel
+   * llm.on('event:relay.event', handler);
+   * llm.on('online', onlineHandler);
+   *
+   * // When done
+   * await llm.disconnect();
+   *
+   * @returns {LLMChannel} A new LLM connection instance
+   */
+  public createConnection(): LLMChannel {
+    // @ts-ignore — WebexPlugin children require {parent: this.webex}
+    const channel = new LLMChannel({parent: this.webex});
 
-    if (!channel) {
-      // @ts-ignore — WebexPlugin children require {parent: this.webex}
-      channel = new LLMChannel({parent: this.webex});
-      // Forward all events emitted by the channel up through the plugin so that
-      // callers doing llm.on('event:relay.event', ...) or llm.on('online', ...)
-      // receive events from whichever session channel emits them.
-      // Non-default sessions emit events with :<sessionId> suffix so that
-      // practice-session consumers can subscribe to session-specific names
-      // like `event:relay.event:llm-practice-session`.
-      channel.on('all', (eventName: string, ...args: any[]) => {
-        if (sessionId === LLM_DEFAULT_SESSION) {
-          this.trigger(eventName, ...args);
-        } else {
-          this.trigger(`${eventName}:${sessionId}`, ...args);
-        }
-      });
-      this.sessions.set(sessionId, channel);
-    }
+    this.channels.add(channel);
+
+    // Auto-unregister when disconnected
+    channel.on('offline', () => {
+      this.channels.delete(channel);
+    });
 
     return channel;
   }
 
-  private getSession(sessionId: string): LLMChannel | undefined {
-    return this.sessions.get(sessionId);
+  /**
+   * Returns true if the data channel token feature flag is enabled.
+   * This is a global check, not per-connection.
+   * @returns {Promise<boolean>}
+   */
+  public isDataChannelTokenEnabled(): Promise<boolean> {
+    // @ts-ignore
+    return this.webex.internal.feature.getFeature('developer', DATA_CHANNEL_WITH_JWT_TOKEN);
   }
 
-  // Before webex.internal.llm was LLChannel instance which extended Mercury so it was directly available
-  get hasEverConnected(): boolean {
-    for (const ch of this.sessions.values()) {
-      if (ch.hasEverConnected) return true;
-    }
-
-    return false;
-  }
-
-  public registerAndConnect(
-    locusUrl: string,
-    datachannelUrl: string,
-    datachannelToken?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): Promise<void> {
-    const channel = this.getOrCreateSession(sessionId);
-
-    return channel.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
-  }
-
-  public disconnectLLM(
-    options: {code: number; reason: string},
-    // eslint-disable-next-line default-param-last
-    sessionId: string = LLM_DEFAULT_SESSION,
-    ownerMeetingId?: string
-  ): Promise<boolean | void> {
-    const channel = this.getSession(sessionId);
-
-    if (!channel) return Promise.resolve();
-
-    const {isOwner} = this.resolveSessionOwnership(ownerMeetingId, sessionId);
-
-    if (!isOwner) {
-      this.logger.info(`llm#disconnectLLM --> skipping, not owner of session ${sessionId}`);
-
-      return Promise.resolve(false);
-    }
-
-    return channel.disconnect(options).then(() => {
-      this.sessions.delete(sessionId);
-
-      return true;
-    });
-  }
-
-  public disconnectAllLLM(options?: {code: number; reason: string}): Promise<void> {
-    const promises = Array.from(this.sessions.entries()).map(([sessionId, channel]) =>
-      channel.disconnect(options).then(() => this.sessions.delete(sessionId))
-    );
-
-    return Promise.all(promises).then(() => undefined);
-  }
-
-  public isConnected(sessionId: string = LLM_DEFAULT_SESSION): boolean {
-    const session = this.getSession(sessionId);
-    const connected = session?.isConnected() ?? false;
-
-    return connected;
-  }
-
-  public getBinding(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
-    return this.getSession(sessionId)?.getBinding();
-  }
-
-  public getSocket(sessionId: string = LLM_DEFAULT_SESSION): any {
-    return this.getSession(sessionId)?.socket;
-  }
-
-  // Backwards-compatibility: callers that access llm.socket directly
-  // (e.g. voicea's getPublishTransport) get the default session socket.
-  get socket(): any {
-    return this.getSocket(LLM_DEFAULT_SESSION);
-  }
-
-  public getLocusUrl(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
-    return this.getSession(sessionId)?.getLocusUrl();
-  }
-
-  public getDatachannelUrl(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
-    return this.getSession(sessionId)?.getDatachannelUrl();
-  }
-
-  // tokenKey IS the sessionId (DataChannelTokenType enum values equal LLM_*_SESSION constants)
-
-  public getDatachannelToken(
-    // eslint-disable-next-line default-param-last
-    tokenKey: string = LLM_DEFAULT_SESSION,
-    ownerMeetingId?: string
-  ): string | undefined {
-    const channel = this.getSession(tokenKey);
-
-    if (!channel) return undefined;
-
-    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#getDatachannelToken --> skip read for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return undefined;
-    }
-
-    return channel.getDatachannelToken();
-  }
-
-  public setDatachannelToken(
-    datachannelToken: string,
-    ownerMeetingId?: string,
-    tokenKey: string = LLM_DEFAULT_SESSION
-  ): void {
-    const channel = this.getOrCreateSession(tokenKey);
-    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#setDatachannelToken --> skip write for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    channel.setDatachannelToken(datachannelToken);
-  }
-
-  public clearDatachannelToken(tokenKey: string, ownerMeetingId: string): void {
-    const channel = this.getSession(tokenKey);
-
-    if (!channel) return;
-
-    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#clearDatachannelToken --> skip clear for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    channel.clearDatachannelToken();
-  }
-
-  public setRefreshHandler(
-    handler: () => Promise<{
-      body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
-    }>,
-    ownerMeetingId?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): void {
-    const channel = this.getOrCreateSession(sessionId);
-    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, sessionId);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#setRefreshHandler --> skip write for session ${sessionId}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    channel.setRefreshHandler(handler);
-  }
-
-  public refreshDataChannelToken(sessionId: string = LLM_DEFAULT_SESSION): Promise<any> {
-    const channel = this.getSession(sessionId);
-
-    if (!channel) {
-      this.logger.warn(`llm#refreshDataChannelToken --> no channel for session ${sessionId}`);
-
-      return Promise.resolve(null);
-    }
-
-    return channel.refreshDataChannelToken();
-  }
-
-  public setOwnerMeetingId(
-    ownerMeetingId: string | undefined,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): void {
-    const channel = this.getSession(sessionId);
-
-    if (channel) channel.ownerMeetingId = ownerMeetingId;
-  }
-
-  public getOwnerMeetingId(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
-    return this.getSession(sessionId)?.ownerMeetingId;
-  }
-
-  public resolveSessionOwnership(
-    ownerMeetingId?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): {currentOwner: string | undefined; isOwner: boolean} {
-    const currentOwner = this.getOwnerMeetingId(sessionId);
-    const isOwner = !currentOwner || !ownerMeetingId || currentOwner === ownerMeetingId;
-
-    return {currentOwner, isOwner};
-  }
-
+  /**
+   * Find a connection by its datachannel URL. Used by the interceptor to
+   * route token refresh requests to the correct channel.
+   * @param {string} url - The request URL to match
+   * @returns {LLMChannel | undefined}
+   */
   public getConnectionByDatachannelUrl(url: string): LLMChannel | undefined {
-    for (const channel of this.sessions.values()) {
+    for (const channel of this.channels) {
       const datachannelUrl = channel.getDatachannelUrl();
 
       if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(url, datachannelUrl)) {
@@ -260,37 +93,37 @@ export class LLMPlugin extends (WebexPlugin as any) {
     return undefined;
   }
 
+  /**
+   * Find a locus URL by matching a request URL to an active connection's
+   * datachannel URL. Used by the interceptor.
+   * @param {string} requestUrl - The request URL to match
+   * @returns {string | undefined}
+   */
   public getLocusUrlByDatachannelUrl(requestUrl: string): string | undefined {
-    for (const channel of this.sessions.values()) {
-      const datachannelUrl = channel.getDatachannelUrl();
+    const channel = this.getConnectionByDatachannelUrl(requestUrl);
 
-      if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(requestUrl, datachannelUrl)) {
-        return channel.getLocusUrl();
-      }
-    }
-
-    return undefined;
+    return channel?.getLocusUrl();
   }
 
-  public getSessionIdByDatachannelUrl(requestUrl: string): string | undefined {
-    for (const [sessionId, channel] of this.sessions.entries()) {
-      const datachannelUrl = channel.getDatachannelUrl();
-
-      if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(requestUrl, datachannelUrl)) {
-        return sessionId;
-      }
-    }
-
-    return undefined;
+  /**
+   * Get all active connections. Useful for diagnostics/debugging.
+   * @returns {Set<LLMChannel>}
+   */
+  public getAllConnections(): Set<LLMChannel> {
+    return new Set(this.channels);
   }
 
-  public isDataChannelTokenEnabled(): Promise<boolean> {
-    // @ts-ignore
-    return this.webex.internal.feature.getFeature('developer', DATA_CHANNEL_WITH_JWT_TOKEN);
-  }
+  /**
+   * Disconnect all active connections. Useful for cleanup on logout.
+   * @param {object} [options] - Disconnect options
+   * @param {number} [options.code] - WebSocket close code
+   * @param {string} [options.reason] - WebSocket close reason
+   * @returns {Promise<void>}
+   */
+  public async disconnectAll(options?: {code: number; reason: string}): Promise<void> {
+    const promises = Array.from(this.channels).map((channel) => channel.disconnect(options));
 
-  public getAllConnections(): Map<string, LLMChannel> {
-    return new Map(this.sessions);
+    await Promise.all(promises);
   }
 }
 

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -57,11 +57,6 @@ export class LLMPlugin extends (WebexPlugin as any) {
 
     this.channels.add(channel);
 
-    // Auto-unregister when disconnected
-    channel.on('offline', () => {
-      this.channels.delete(channel);
-    });
-
     return channel;
   }
 
@@ -91,18 +86,6 @@ export class LLMPlugin extends (WebexPlugin as any) {
     }
 
     return undefined;
-  }
-
-  /**
-   * Find a locus URL by matching a request URL to an active connection's
-   * datachannel URL. Used by the interceptor.
-   * @param {string} requestUrl - The request URL to match
-   * @returns {string | undefined}
-   */
-  public getLocusUrlByDatachannelUrl(requestUrl: string): string | undefined {
-    const channel = this.getConnectionByDatachannelUrl(requestUrl);
-
-    return channel?.getLocusUrl();
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -56,6 +56,7 @@ export class LLMPlugin extends (WebexPlugin as any) {
     const channel = new LLMChannel({parent: this.webex});
 
     this.channels.add(channel);
+    channel.onDisconnect = () => this.channels.delete(channel);
 
     return channel;
   }

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -56,7 +56,7 @@ export class LLMPlugin extends (WebexPlugin as any) {
     const channel = new LLMChannel({parent: this.webex});
 
     this.channels.add(channel);
-    channel.onDisconnect = () => this.channels.delete(channel);
+    channel.on('disconnected', () => this.channels.delete(channel));
 
     return channel;
   }

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -63,6 +63,14 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   private connectingPromise?: Promise<RegisterAndConnectTiming | void>;
 
   /**
+   * Check if a connection is currently in progress.
+   * @returns {boolean} True if connecting
+   */
+  public isConnecting(): boolean {
+    return !!this.connectingPromise;
+  }
+
+  /**
    * Register to the websocket
    * @param {string} llmSocketUrl
    * @param {string} datachannelToken

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -62,9 +62,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /** In-flight connection promise for deduplication. */
   private connectingPromise?: Promise<RegisterAndConnectTiming | void>;
 
-  /** Callback invoked after disconnect completes, used by LLMPlugin for cleanup. */
-  public onDisconnect?: () => void;
-
   /**
    * Check if a connection is currently in progress.
    * @returns {boolean} True if connecting
@@ -267,8 +264,7 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
-    this.onDisconnect?.();
-    this.onDisconnect = undefined;
+    this.emit('disconnected');
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -42,8 +42,10 @@ export const config = {
 
 /**
  * LLMChannel — a single WebSocket connection to the LLM data channel.
- * Session-level routing (multiple connections keyed by sessionId) is handled
- * by LLMPlugin, which owns a Map<sessionId, LLMChannel>.
+ *
+ * Created via `webex.internal.llm.createConnection()`. The caller owns the
+ * channel and is responsible for its lifecycle (connect, disconnect, cleanup).
+ * Multiple LLMChannels can exist simultaneously for different meetings.
  */
 export default class LLMChannel extends (Mercury as any) implements ILLMChannel {
   namespace = LLM;
@@ -56,9 +58,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   private refreshHandler?: () => Promise<{
     body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
   }>;
-
-  /** Owning meeting ID — set by LLMPlugin to prevent cross-meeting teardown. */
-  public ownerMeetingId?: string;
 
   /** In-flight connection promise for deduplication. */
   private connectingPromise?: Promise<RegisterAndConnectTiming | void>;
@@ -257,7 +256,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
-    this.ownerMeetingId = undefined;
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -62,6 +62,9 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /** In-flight connection promise for deduplication. */
   private connectingPromise?: Promise<RegisterAndConnectTiming | void>;
 
+  /** Callback invoked after disconnect completes, used by LLMPlugin for cleanup. */
+  public onDisconnect?: () => void;
+
   /**
    * Check if a connection is currently in progress.
    * @returns {boolean} True if connecting
@@ -171,12 +174,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   public isConnected = (): boolean => this.connected;
 
   /**
-   * Get the underlying WebSocket
-   * @returns {any} socket
-   */
-  public getSocket = (): any => this.socket;
-
-  /**
    * Tells if LLM socket is binding
    * @returns {string | undefined} binding
    */
@@ -270,6 +267,8 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
+    this.onDisconnect?.();
+    this.onDisconnect = undefined;
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -163,6 +163,12 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   public isConnected = (): boolean => this.connected;
 
   /**
+   * Get the underlying WebSocket
+   * @returns {any} socket
+   */
+  public getSocket = (): any => this.socket;
+
+  /**
    * Tells if LLM socket is binding
    * @returns {string | undefined} binding
    */

--- a/packages/@webex/internal-plugin-llm/src/llm.types.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.types.ts
@@ -85,9 +85,6 @@ interface ILLMPlugin {
   /** Find a connection by matching a request URL to its datachannel URL. */
   getConnectionByDatachannelUrl: (url: string) => ILLMChannel | undefined;
 
-  /** Find a locus URL by matching a request URL to an active connection. */
-  getLocusUrlByDatachannelUrl: (requestUrl: string) => string | undefined;
-
   /** Get all active connections. */
   getAllConnections: () => Set<ILLMChannel>;
 

--- a/packages/@webex/internal-plugin-llm/src/llm.types.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.types.ts
@@ -13,61 +13,81 @@ type RegisterAndConnectTiming = {
   clientLLMWebSocketConnectTime?: number;
 };
 
+/**
+ * ILLMChannel — interface for a single LLM WebSocket connection.
+ * Created via `webex.internal.llm.createConnection()`.
+ */
 interface ILLMChannel {
+  /** Register with the server and connect the WebSocket. */
   registerAndConnect: (
     locusUrl: string,
     datachannelUrl: string,
-    datachannelToken?: string,
-    sessionId?: string
+    datachannelToken?: string
   ) => Promise<void>;
+
+  /** Returns true if the WebSocket is connected. */
   isConnected: () => boolean;
+
+  /** Get the binding ID for this connection. */
   getBinding: () => string | undefined;
+
+  /** Get the Locus URL associated with this connection. */
   getLocusUrl: () => string | undefined;
+
+  /** Get the datachannel URL for this connection. */
   getDatachannelUrl: () => string | undefined;
-  disconnect: (options?: {code: number; reason: string}) => Promise<void>;
-  disconnectAllLLM: (options?: {code: number; reason: string}) => Promise<void>;
-  setOwnerMeetingId: (ownerMeetingId: string | undefined, sessionId?: string) => void;
-  getOwnerMeetingId: (sessionId?: string) => string | undefined;
-  resolveSessionOwnership: (
-    ownerMeetingId?: string,
-    sessionId?: string
-  ) => {
-    currentOwner: string | undefined;
-    isOwner: boolean;
-  };
-  getDatachannelToken: (
-    tokenKey?: DataChannelTokenKey,
-    ownerMeetingId?: string
-  ) => string | undefined;
-  setDatachannelToken: (
-    datachannelToken: string,
-    tokenKey?: DataChannelTokenKey,
-    ownerMeetingId?: string
-  ) => void;
-  clearDatachannelToken: (tokenKey: DataChannelTokenKey, ownerMeetingId: string) => void;
+
+  /** Get the stored datachannel token. */
+  getDatachannelToken: () => string | undefined;
+
+  /** Store a datachannel token for this connection. */
+  setDatachannelToken: (datachannelToken: string) => void;
+
+  /** Clear the stored datachannel token. */
+  clearDatachannelToken: () => void;
+
+  /** Set the handler used to refresh the datachannel token. */
   setRefreshHandler: (
     handler: () => Promise<{
       body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
-    }>,
-    sessionId?: string,
-    ownerMeetingId?: string
+    }>
   ) => void;
-  refreshDataChannelToken: (sessionId?: string) => Promise<{
+
+  /** Refresh the datachannel token using the injected handler. */
+  refreshDataChannelToken: () => Promise<{
     body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
   } | null>;
+
+  /** Disconnect the WebSocket and clean up state. */
+  disconnect: (options?: {code: number; reason: string}) => Promise<void>;
+
+  /** Check if the datachannel token feature flag is enabled. */
+  isDataChannelTokenEnabled: () => Promise<boolean>;
+}
+
+/**
+ * ILLMPlugin — interface for the LLM plugin factory.
+ * Accessed via `webex.internal.llm`.
+ */
+interface ILLMPlugin {
+  /** Create a new LLM connection instance. */
+  createConnection: () => ILLMChannel;
+
+  /** Check if the datachannel token feature flag is enabled globally. */
+  isDataChannelTokenEnabled: () => Promise<boolean>;
+
+  /** Find a connection by matching a request URL to its datachannel URL. */
+  getConnectionByDatachannelUrl: (url: string) => ILLMChannel | undefined;
+
+  /** Find a locus URL by matching a request URL to an active connection. */
   getLocusUrlByDatachannelUrl: (requestUrl: string) => string | undefined;
-  getSessionIdByDatachannelUrl: (requestUrl: string) => string | undefined;
-  getAllConnections: () => Map<
-    string,
-    {
-      webSocketUrl?: string;
-      binding?: string;
-      locusUrl?: string;
-      datachannelUrl?: string;
-      ownerMeetingId?: string;
-    }
-  >;
+
+  /** Get all active connections. */
+  getAllConnections: () => Set<ILLMChannel>;
+
+  /** Disconnect all active connections. */
+  disconnectAll: (options?: {code: number; reason: string}) => Promise<void>;
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export type {ILLMChannel, DataChannelTokenKey, RegisterAndConnectTiming};
+export type {ILLMChannel, ILLMPlugin, DataChannelTokenKey, RegisterAndConnectTiming};

--- a/packages/@webex/internal-plugin-llm/src/llm.types.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.types.ts
@@ -28,6 +28,9 @@ interface ILLMChannel {
   /** Returns true if the WebSocket is connected. */
   isConnected: () => boolean;
 
+  /** Get the underlying WebSocket. */
+  getSocket: () => any;
+
   /** Get the binding ID for this connection. */
   getBinding: () => string | undefined;
 

--- a/packages/@webex/internal-plugin-llm/src/llm.types.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.types.ts
@@ -28,6 +28,9 @@ interface ILLMChannel {
   /** Returns true if the WebSocket is connected. */
   isConnected: () => boolean;
 
+  /** Returns true if a connection is currently in progress. */
+  isConnecting: () => boolean;
+
   /** Get the underlying WebSocket. */
   getSocket: () => any;
 

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -3,31 +3,12 @@ import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import Mercury from '@webex/internal-plugin-mercury';
 import {LLMPlugin} from '@webex/internal-plugin-llm/src/llm-plugin';
-import {LLM_DEFAULT_SESSION} from '@webex/internal-plugin-llm/src/constants';
+import LLMChannel from '@webex/internal-plugin-llm/src/llm';
 
 describe('plugin-llm', () => {
-  describe('LLMPlugin', () => {
+  describe('LLMPlugin (Factory Pattern)', () => {
     let webex;
     let plugin;
-    let mockChannel;
-
-    const createMockChannel = () => ({
-      registerAndConnect: sinon.stub().resolves(),
-      disconnect: sinon.stub().resolves(),
-      isConnected: sinon.stub().returns(false),
-      getBinding: sinon.stub().returns('binding'),
-      getLocusUrl: sinon.stub().returns('locusUrl'),
-      getDatachannelUrl: sinon.stub().returns('datachannelUrl'),
-      getDatachannelToken: sinon.stub().returns('token'),
-      setDatachannelToken: sinon.stub(),
-      clearDatachannelToken: sinon.stub(),
-      setRefreshHandler: sinon.stub(),
-      refreshDataChannelToken: sinon.stub().resolves({body: {datachannelToken: 'newToken'}}),
-      socket: {send: sinon.stub()},
-      ownerMeetingId: undefined,
-      hasEverConnected: false,
-      on: sinon.stub(),
-    });
 
     beforeEach(() => {
       webex = new MockWebex({
@@ -41,348 +22,111 @@ describe('plugin-llm', () => {
       };
 
       plugin = new LLMPlugin({}, {parent: webex});
-
-      mockChannel = createMockChannel();
     });
 
     afterEach(() => sinon.restore());
 
-    describe('#disconnectLLM', () => {
-      it('calls disconnect and removes session from map', async () => {
-        // Create a session first
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+    describe('#createConnection', () => {
+      it('creates a new LLMChannel instance', () => {
+        const channel = plugin.createConnection();
 
-        const result = await plugin.disconnectLLM(
-          {code: 3000, reason: 'bye'},
-          LLM_DEFAULT_SESSION,
-          'meeting-1'
-        );
-
-        sinon.assert.calledOnceWithExactly(mockChannel.disconnect, {code: 3000, reason: 'bye'});
-        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
-        assert.equal(result, true);
+        assert.instanceOf(channel, LLMChannel);
       });
 
-      it('resolves without error when session does not exist', async () => {
-        const result = await plugin.disconnectLLM(
-          {code: 1000, reason: 'test'},
-          'non-existent-session'
-        );
+      it('adds the channel to the connections registry', () => {
+        const channel = plugin.createConnection();
 
-        assert.equal(result, undefined);
+        const connections = plugin.getAllConnections();
+
+        assert.equal(connections.size, 1);
+        assert.isTrue(connections.has(channel));
       });
 
-      it('skips disconnect if not the owner', async () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+      it('creates independent channels for multiple calls', () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
 
-        const result = await plugin.disconnectLLM(
-          {code: 1000, reason: 'test'},
-          LLM_DEFAULT_SESSION,
-          'meeting-2'
-        );
-
-        sinon.assert.notCalled(mockChannel.disconnect);
-        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), true);
-        assert.equal(result, false);
+        assert.notStrictEqual(channel1, channel2);
+        assert.equal(plugin.getAllConnections().size, 2);
       });
 
-      it('disconnects if owner matches', async () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+      it('auto-unregisters channel when offline event fires', () => {
+        const channel = plugin.createConnection();
 
-        const result = await plugin.disconnectLLM(
-          {code: 1000, reason: 'test'},
-          LLM_DEFAULT_SESSION,
-          'meeting-1'
-        );
+        assert.equal(plugin.getAllConnections().size, 1);
 
-        sinon.assert.calledOnce(mockChannel.disconnect);
-        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
-        assert.equal(result, true);
-      });
+        // Simulate offline event
+        channel.trigger('offline');
 
-      it('disconnects if no owner is set', async () => {
-        mockChannel.ownerMeetingId = undefined;
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        const result = await plugin.disconnectLLM(
-          {code: 1000, reason: 'test'},
-          LLM_DEFAULT_SESSION,
-          'meeting-1'
-        );
-
-        sinon.assert.calledOnce(mockChannel.disconnect);
-        assert.equal(result, true);
-      });
-
-      it('supports legacy call with options only', async () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        await plugin.disconnectLLM({code: 1000, reason: 'test'});
-
-        sinon.assert.calledOnce(mockChannel.disconnect);
-        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
-      });
-
-      it('supports legacy call with options and sessionId', async () => {
-        plugin.sessions.set('custom-session', mockChannel);
-
-        await plugin.disconnectLLM({code: 1000, reason: 'test'}, 'custom-session');
-
-        sinon.assert.calledOnceWithExactly(mockChannel.disconnect, {code: 1000, reason: 'test'});
-        assert.equal(plugin.sessions.has('custom-session'), false);
+        assert.equal(plugin.getAllConnections().size, 0);
       });
     });
 
-    describe('#disconnectAllLLM', () => {
-      it('disconnects and removes all sessions', async () => {
-        const channel1 = createMockChannel();
-        const channel2 = createMockChannel();
+    describe('#getAllConnections', () => {
+      it('returns an empty set when no connections exist', () => {
+        const connections = plugin.getAllConnections();
 
-        plugin.sessions.set('session-1', channel1);
-        plugin.sessions.set('session-2', channel2);
+        assert.equal(connections.size, 0);
+      });
 
-        await plugin.disconnectAllLLM({code: 1000, reason: 'cleanup'});
+      it('returns a copy of the connections set', () => {
+        const channel = plugin.createConnection();
+        const connections = plugin.getAllConnections();
+
+        // Verify it's a copy, not the same reference
+        connections.delete(channel);
+        assert.equal(plugin.getAllConnections().size, 1);
+      });
+    });
+
+    describe('#disconnectAll', () => {
+      it('disconnects all active connections', async () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+
+        sinon.stub(channel1, 'disconnect').resolves();
+        sinon.stub(channel2, 'disconnect').resolves();
+
+        await plugin.disconnectAll({code: 1000, reason: 'cleanup'});
 
         sinon.assert.calledOnceWithExactly(channel1.disconnect, {code: 1000, reason: 'cleanup'});
         sinon.assert.calledOnceWithExactly(channel2.disconnect, {code: 1000, reason: 'cleanup'});
-        assert.equal(plugin.sessions.size, 0);
       });
 
-      it('works with no active sessions', async () => {
-        await plugin.disconnectAllLLM({code: 1000, reason: 'cleanup'});
+      it('works with no active connections', async () => {
+        await plugin.disconnectAll({code: 1000, reason: 'cleanup'});
 
-        assert.equal(plugin.sessions.size, 0);
-      });
-    });
-
-    describe('#resolveSessionOwnership', () => {
-      it('returns isOwner true when no current owner', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-        mockChannel.ownerMeetingId = undefined;
-
-        const result = plugin.resolveSessionOwnership('meeting-1', LLM_DEFAULT_SESSION);
-
-        assert.deepEqual(result, {currentOwner: undefined, isOwner: true});
-      });
-
-      it('returns isOwner true when no ownerMeetingId provided', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-        mockChannel.ownerMeetingId = 'meeting-1';
-
-        const result = plugin.resolveSessionOwnership(undefined, LLM_DEFAULT_SESSION);
-
-        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: true});
-      });
-
-      it('returns isOwner true when owner matches', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-        mockChannel.ownerMeetingId = 'meeting-1';
-
-        const result = plugin.resolveSessionOwnership('meeting-1', LLM_DEFAULT_SESSION);
-
-        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: true});
-      });
-
-      it('returns isOwner false when owner does not match', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-        mockChannel.ownerMeetingId = 'meeting-1';
-
-        const result = plugin.resolveSessionOwnership('meeting-2', LLM_DEFAULT_SESSION);
-
-        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: false});
-      });
-    });
-
-    describe('#registerAndConnect', () => {
-      it('creates session and calls registerAndConnect on channel', async () => {
-        // Stub the internal getOrCreateSession to return our mock
-        sinon.stub(plugin, 'getOrCreateSession').returns(mockChannel);
-
-        await plugin.registerAndConnect('locusUrl', 'datachannelUrl', 'token', 'session-1');
-
-        sinon.assert.calledOnceWithExactly(
-          mockChannel.registerAndConnect,
-          'locusUrl',
-          'datachannelUrl',
-          'token'
-        );
-      });
-
-      it('uses default session when sessionId not provided', async () => {
-        sinon.stub(plugin, 'getOrCreateSession').returns(mockChannel);
-
-        await plugin.registerAndConnect('locusUrl', 'datachannelUrl', 'token');
-
-        sinon.assert.calledOnceWithExactly(plugin.getOrCreateSession, LLM_DEFAULT_SESSION);
-      });
-    });
-
-    describe('#isConnected', () => {
-      it('returns false when session does not exist', () => {
-        assert.equal(plugin.isConnected('non-existent'), false);
-      });
-
-      it('returns channel isConnected value', () => {
-        mockChannel.isConnected.returns(true);
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.isConnected(LLM_DEFAULT_SESSION), true);
-      });
-    });
-
-    describe('#getBinding', () => {
-      it('returns undefined when session does not exist', () => {
-        assert.equal(plugin.getBinding('non-existent'), undefined);
-      });
-
-      it('returns channel binding', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.getBinding(LLM_DEFAULT_SESSION), 'binding');
-      });
-    });
-
-    describe('#getSocket', () => {
-      it('returns undefined when session does not exist', () => {
-        assert.equal(plugin.getSocket('non-existent'), undefined);
-      });
-
-      it('returns channel socket', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.getSocket(LLM_DEFAULT_SESSION), mockChannel.socket);
-      });
-    });
-
-    describe('#socket (getter)', () => {
-      it('returns default session socket for backwards compatibility', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.socket, mockChannel.socket);
-      });
-    });
-
-    describe('#setDatachannelToken', () => {
-      it('sets token when owner matches', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.setDatachannelToken('newToken', 'meeting-1', LLM_DEFAULT_SESSION);
-
-        sinon.assert.calledOnceWithExactly(mockChannel.setDatachannelToken, 'newToken');
-      });
-
-      it('skips setting token when not owner', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.setDatachannelToken('newToken', 'meeting-2', LLM_DEFAULT_SESSION);
-
-        sinon.assert.notCalled(mockChannel.setDatachannelToken);
-      });
-    });
-
-    describe('#getDatachannelToken', () => {
-      it('returns token when owner matches', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        const token = plugin.getDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-1');
-
-        assert.equal(token, 'token');
-      });
-
-      it('returns undefined when not owner', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        const token = plugin.getDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-2');
-
-        assert.equal(token, undefined);
-      });
-
-      it('returns undefined when session does not exist', () => {
-        const token = plugin.getDatachannelToken('non-existent');
-
-        assert.equal(token, undefined);
-      });
-    });
-
-    describe('#clearDatachannelToken', () => {
-      it('clears token when owner matches', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.clearDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-1');
-
-        sinon.assert.calledOnce(mockChannel.clearDatachannelToken);
-      });
-
-      it('skips clearing when not owner', () => {
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.clearDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-2');
-
-        sinon.assert.notCalled(mockChannel.clearDatachannelToken);
-      });
-    });
-
-    describe('#setOwnerMeetingId / #getOwnerMeetingId', () => {
-      it('sets and gets owner meeting id', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.setOwnerMeetingId('meeting-1', LLM_DEFAULT_SESSION);
-
-        assert.equal(mockChannel.ownerMeetingId, 'meeting-1');
-        assert.equal(plugin.getOwnerMeetingId(LLM_DEFAULT_SESSION), 'meeting-1');
-      });
-
-      it('returns undefined when session does not exist', () => {
-        assert.equal(plugin.getOwnerMeetingId('non-existent'), undefined);
-      });
-    });
-
-    describe('#hasEverConnected', () => {
-      it('returns false when no sessions exist', () => {
-        assert.equal(plugin.hasEverConnected, false);
-      });
-
-      it('returns true when any session has connected', () => {
-        mockChannel.hasEverConnected = true;
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.hasEverConnected, true);
-      });
-
-      it('returns false when no session has connected', () => {
-        mockChannel.hasEverConnected = false;
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        assert.equal(plugin.hasEverConnected, false);
+        assert.equal(plugin.getAllConnections().size, 0);
       });
     });
 
     describe('#getConnectionByDatachannelUrl', () => {
       it('returns channel matching datachannel URL', () => {
-        mockChannel.getDatachannelUrl.returns(
-          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
-        );
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        const channel = plugin.createConnection();
+
+        sinon
+          .stub(channel, 'getDatachannelUrl')
+          .returns('https://board.wbx2.com/datachannel/api/v1/locus/123/registrations');
 
         const result = plugin.getConnectionByDatachannelUrl(
           'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
         );
 
-        assert.equal(result, mockChannel);
+        assert.equal(result, channel);
       });
 
       it('returns undefined when no match', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        const channel = plugin.createConnection();
+
+        sinon.stub(channel, 'getDatachannelUrl').returns('https://board.wbx2.com/datachannel/123');
 
         const result = plugin.getConnectionByDatachannelUrl('https://unknown.example.com');
+
+        assert.equal(result, undefined);
+      });
+
+      it('returns undefined when no connections exist', () => {
+        const result = plugin.getConnectionByDatachannelUrl('https://example.com');
 
         assert.equal(result, undefined);
       });
@@ -390,11 +134,12 @@ describe('plugin-llm', () => {
 
     describe('#getLocusUrlByDatachannelUrl', () => {
       it('returns locus URL for matching datachannel URL', () => {
-        mockChannel.getDatachannelUrl.returns(
-          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
-        );
-        mockChannel.getLocusUrl.returns('https://locus.example.com/123');
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        const channel = plugin.createConnection();
+
+        sinon
+          .stub(channel, 'getDatachannelUrl')
+          .returns('https://board.wbx2.com/datachannel/api/v1/locus/123/registrations');
+        sinon.stub(channel, 'getLocusUrl').returns('https://locus.example.com/123');
 
         const result = plugin.getLocusUrlByDatachannelUrl(
           'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
@@ -402,117 +147,61 @@ describe('plugin-llm', () => {
 
         assert.equal(result, 'https://locus.example.com/123');
       });
-    });
 
-    describe('#getSessionIdByDatachannelUrl', () => {
-      it('returns sessionId for matching datachannel URL', () => {
-        mockChannel.getDatachannelUrl.returns(
-          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
-        );
-        plugin.sessions.set('my-session', mockChannel);
+      it('returns undefined when no match', () => {
+        const result = plugin.getLocusUrlByDatachannelUrl('https://unknown.example.com');
 
-        const result = plugin.getSessionIdByDatachannelUrl(
-          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
-        );
-
-        assert.equal(result, 'my-session');
+        assert.equal(result, undefined);
       });
     });
 
-    describe('#getAllConnections', () => {
-      it('returns copy of sessions map', () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+    describe('#isDataChannelTokenEnabled', () => {
+      it('returns true when feature flag is enabled', async () => {
+        webex.internal.feature.getFeature.resolves(true);
 
-        const result = plugin.getAllConnections();
+        const result = await plugin.isDataChannelTokenEnabled();
 
-        assert.equal(result.size, 1);
-        assert.equal(result.get(LLM_DEFAULT_SESSION), mockChannel);
-        assert.notStrictEqual(result, plugin.sessions);
-      });
-    });
-
-    describe('#refreshDataChannelToken', () => {
-      it('calls channel refreshDataChannelToken', async () => {
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        const result = await plugin.refreshDataChannelToken(LLM_DEFAULT_SESSION);
-
-        sinon.assert.calledOnce(mockChannel.refreshDataChannelToken);
-        assert.deepEqual(result, {body: {datachannelToken: 'newToken'}});
-      });
-
-      it('returns null when session does not exist', async () => {
-        const result = await plugin.refreshDataChannelToken('non-existent');
-
-        assert.equal(result, null);
-      });
-    });
-
-    describe('#setRefreshHandler', () => {
-      it('sets handler when owner matches', () => {
-        const handler = sinon.stub();
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.setRefreshHandler(handler, 'meeting-1', LLM_DEFAULT_SESSION);
-
-        sinon.assert.calledOnceWithExactly(mockChannel.setRefreshHandler, handler);
-      });
-
-      it('skips setting handler when not owner', () => {
-        const handler = sinon.stub();
-        mockChannel.ownerMeetingId = 'meeting-1';
-        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
-
-        plugin.setRefreshHandler(handler, 'meeting-2', LLM_DEFAULT_SESSION);
-
-        sinon.assert.notCalled(mockChannel.setRefreshHandler);
-      });
-    });
-
-    describe('event forwarding', () => {
-      let triggerSpy;
-
-      beforeEach(() => {
-        triggerSpy = sinon.spy(plugin, 'trigger');
-      });
-
-      it('forwards default session events without suffix', () => {
-        // Create a session via getOrCreateSession (creates real LLMChannel with event handler)
-        const channel = plugin.getOrCreateSession(LLM_DEFAULT_SESSION);
-
-        // Trigger an event on the channel - the 'all' handler should forward it
-        channel.trigger('event:relay.event', {data: 'test'});
-
-        sinon.assert.calledOnceWithExactly(triggerSpy, 'event:relay.event', {data: 'test'});
-      });
-
-      it('forwards non-default session events with sessionId suffix', () => {
-        const practiceSession = 'llm-practice-session';
-
-        // Create a session via getOrCreateSession (creates real LLMChannel with event handler)
-        const channel = plugin.getOrCreateSession(practiceSession);
-
-        // Trigger an event on the channel - the 'all' handler should forward it with suffix
-        channel.trigger('event:relay.event', {data: 'test'});
-
-        sinon.assert.calledOnceWithExactly(triggerSpy, `event:relay.event:${practiceSession}`, {
-          data: 'test',
-        });
-      });
-
-      it('forwards locus events with sessionId suffix for practice session', () => {
-        const practiceSession = 'llm-practice-session';
-
-        const channel = plugin.getOrCreateSession(practiceSession);
-
-        channel.trigger('event:locus.state_message', {locusData: 'test'});
-
+        assert.equal(result, true);
         sinon.assert.calledOnceWithExactly(
-          triggerSpy,
-          `event:locus.state_message:${practiceSession}`,
-          {locusData: 'test'}
+          webex.internal.feature.getFeature,
+          'developer',
+          'data-channel-with-jwt-token'
         );
+      });
+
+      it('returns false when feature flag is disabled', async () => {
+        webex.internal.feature.getFeature.resolves(false);
+
+        const result = await plugin.isDataChannelTokenEnabled();
+
+        assert.equal(result, false);
+      });
+    });
+
+    describe('connection lifecycle', () => {
+      it('channel remains in registry until offline', () => {
+        const channel = plugin.createConnection();
+
+        // Simulate connection then disconnection
+        channel.trigger('online');
+        assert.equal(plugin.getAllConnections().size, 1);
+
+        channel.trigger('offline');
+        assert.equal(plugin.getAllConnections().size, 0);
+      });
+
+      it('multiple channels can be managed independently', () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+
+        assert.equal(plugin.getAllConnections().size, 2);
+
+        // Disconnect only channel1
+        channel1.trigger('offline');
+
+        assert.equal(plugin.getAllConnections().size, 1);
+        assert.isTrue(plugin.getAllConnections().has(channel2));
+        assert.isFalse(plugin.getAllConnections().has(channel1));
       });
     });
   });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -244,26 +244,22 @@ describe('plugin-llm', () => {
         sinon.assert.calledOnceWithExactly(channelB.registerAndConnect, sameLocus, sameDc);
       });
 
-      it('individual channel disconnect does not clear other channels from registry', async () => {
+      it('individual channel disconnect removes only that channel from registry', async () => {
         const channel1 = plugin.createConnection();
         const channel2 = plugin.createConnection();
         const channel3 = plugin.createConnection();
 
-        // Stub disconnect on channel2
-        sinon.stub(channel2, 'disconnect').resolves();
-
         assert.equal(plugin.getAllConnections().size, 3);
 
-        // Disconnect only channel2
+        // Disconnect channel2 - real disconnect triggers onDisconnect callback
         await channel2.disconnect({code: 3050, reason: 'meeting ended'});
 
-        // All channels still exist in registry (disconnect doesn't auto-remove)
-        // The Meeting class is responsible for cleanup after disconnect
+        // Only channel2 should be removed from registry
         const connections = plugin.getAllConnections();
 
-        assert.equal(connections.size, 3);
+        assert.equal(connections.size, 2);
         assert.isTrue(connections.has(channel1));
-        assert.isTrue(connections.has(channel2));
+        assert.isFalse(connections.has(channel2));
         assert.isTrue(connections.has(channel3));
       });
 

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -153,5 +153,243 @@ describe('plugin-llm', () => {
         assert.equal(result, false);
       });
     });
+
+    describe('channel isolation multi-meeting scenarios', () => {
+      it('disconnecting one channel does not affect another channel', async () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+
+        // Stub disconnect on channel1 only - simulating the real behavior where
+        // disconnect clears the connected state
+        sinon.stub(channel1, 'disconnect').callsFake(async function () {
+          this.connected = false;
+        });
+
+        // Simulate both channels being connected
+        channel1.connected = true;
+        channel2.connected = true;
+
+        // Disconnect channel1 with permanent code (simulating meeting end)
+        await channel1.disconnect({code: 3050, reason: 'done (permanent)'});
+
+        // Channel2 should still be connected - its state is independent
+        assert.equal(channel2.isConnected(), true);
+
+        // Channel1 should be disconnected
+        assert.equal(channel1.isConnected(), false);
+
+        // Verify that disconnect was called on channel1
+        sinon.assert.calledOnceWithExactly(channel1.disconnect, {
+          code: 3050,
+          reason: 'done (permanent)',
+        });
+      });
+
+      it('channels for same locus URL are still independent instances', async () => {
+        const sameLocus = 'https://locus.example.com/loci/shared-meeting';
+        const sameDc = 'https://datachannel.example.com/dc/shared';
+
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+
+        // Both channels have the same locus URL (the scenario in the bug)
+        sinon.stub(channel1, 'getLocusUrl').returns(sameLocus);
+        sinon.stub(channel1, 'getDatachannelUrl').returns(sameDc);
+        sinon.stub(channel2, 'getLocusUrl').returns(sameLocus);
+        sinon.stub(channel2, 'getDatachannelUrl').returns(sameDc);
+
+        // They are separate instances despite same URLs
+        assert.notStrictEqual(channel1, channel2);
+
+        // Both are tracked independently
+        const connections = plugin.getAllConnections();
+
+        assert.equal(connections.size, 2);
+        assert.isTrue(connections.has(channel1));
+        assert.isTrue(connections.has(channel2));
+      });
+
+      it('simulates overlapping meeting lifecycle without cross-channel impact', async () => {
+        // Scenario: Meeting A is ending while Meeting B is starting for the same locus
+        const sameLocus = 'https://locus.example.com/loci/abc123';
+        const sameDc = 'https://datachannel.example.com/dc/abc123';
+
+        // Meeting A has an active channel
+        const channelA = plugin.createConnection();
+
+        sinon.stub(channelA, 'getLocusUrl').returns(sameLocus);
+        sinon.stub(channelA, 'getDatachannelUrl').returns(sameDc);
+        sinon.stub(channelA, 'disconnect').resolves();
+        channelA.connected = true;
+
+        // Meeting B creates its own channel for the same locus
+        const channelB = plugin.createConnection();
+
+        sinon.stub(channelB, 'registerAndConnect').resolves();
+        sinon.stub(channelB, 'isConnected').returns(false);
+
+        // Meeting A ends and disconnects with permanent code
+        await channelA.disconnect({code: 3050, reason: 'done (permanent)'});
+
+        // Meeting B connects - this should work because it has its own channel
+        await channelB.registerAndConnect(sameLocus, sameDc);
+
+        // Assert: channelA's disconnect was called
+        sinon.assert.calledOnceWithExactly(channelA.disconnect, {
+          code: 3050,
+          reason: 'done (permanent)',
+        });
+
+        // Assert: channelB's registerAndConnect was called (not blocked by A's disconnect)
+        sinon.assert.calledOnceWithExactly(channelB.registerAndConnect, sameLocus, sameDc);
+      });
+
+      it('individual channel disconnect does not clear other channels from registry', async () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+        const channel3 = plugin.createConnection();
+
+        // Stub disconnect on channel2
+        sinon.stub(channel2, 'disconnect').resolves();
+
+        assert.equal(plugin.getAllConnections().size, 3);
+
+        // Disconnect only channel2
+        await channel2.disconnect({code: 3050, reason: 'meeting ended'});
+
+        // All channels still exist in registry (disconnect doesn't auto-remove)
+        // The Meeting class is responsible for cleanup after disconnect
+        const connections = plugin.getAllConnections();
+
+        assert.equal(connections.size, 3);
+        assert.isTrue(connections.has(channel1));
+        assert.isTrue(connections.has(channel2));
+        assert.isTrue(connections.has(channel3));
+      });
+
+      it('getConnectionByDatachannelUrl returns correct channel when multiple exist for similar URLs', () => {
+        const channel1 = plugin.createConnection();
+        const channel2 = plugin.createConnection();
+
+        // Different locus IDs in the URL
+        sinon
+          .stub(channel1, 'getDatachannelUrl')
+          .returns('https://board.wbx2.com/datachannel/api/v1/locus/meeting-111/registrations');
+        sinon
+          .stub(channel2, 'getDatachannelUrl')
+          .returns('https://board.wbx2.com/datachannel/api/v1/locus/meeting-222/registrations');
+
+        // Request for meeting-111 should return channel1
+        const result1 = plugin.getConnectionByDatachannelUrl(
+          'https://board.wbx2.com/datachannel/api/v1/locus/meeting-111/registrations/events'
+        );
+
+        assert.equal(result1, channel1);
+
+        // Request for meeting-222 should return channel2
+        const result2 = plugin.getConnectionByDatachannelUrl(
+          'https://board.wbx2.com/datachannel/api/v1/locus/meeting-222/registrations/events'
+        );
+
+        assert.equal(result2, channel2);
+      });
+
+      it('multi-webinar PS token refresh routes to correct meeting (webinar A vs B coexistence)', async () => {
+        // Scenario: User hosts webinar A and joins webinar B as promoted panelist.
+        // Both webinars have practice session (PS) channels with different locus URLs.
+        // When A's PS token expires, the refresh must use A's locus URL, not B's.
+        //
+        // This test verifies URL-based routing, not actual JWT expiry. The real flow is:
+        //   1. Request to datachannel URL fails with 401/403 (expired token)
+        //   2. Interceptor extracts the request URL from the error
+        //   3. Interceptor calls getConnectionByDatachannelUrl(requestUrl) to find the channel
+        //   4. Interceptor calls channel.refreshDataChannelToken() to get new token
+        //   5. Interceptor retries the original request
+        //
+        // We test steps 3-4: given a request URL, does the correct channel's refresh get called?
+
+        const webinarALocusUrl = 'https://locus.wbx2.com/loci/webinar-aaa-111';
+        const webinarBLocusUrl = 'https://locus.wbx2.com/loci/webinar-bbb-222';
+        const webinarAPSDatachannelUrl =
+          'https://board.wbx2.com/datachannel/api/v1/locus/webinar-aaa-111/practiceSession/registrations';
+        const webinarBPSDatachannelUrl =
+          'https://board.wbx2.com/datachannel/api/v1/locus/webinar-bbb-222/practiceSession/registrations';
+
+        const psChannelA = plugin.createConnection();
+        const psChannelB = plugin.createConnection();
+
+        // Mock meeting refresh handlers that track which meeting's handler was invoked
+        const refreshCallLog = [];
+        const mockMeetingARefresh = () => {
+          refreshCallLog.push({meeting: 'A', locusUrl: webinarALocusUrl});
+
+          return Promise.resolve({body: {datachannelToken: 'new-token-for-A'}});
+        };
+        const mockMeetingBRefresh = () => {
+          refreshCallLog.push({meeting: 'B', locusUrl: webinarBLocusUrl});
+
+          return Promise.resolve({body: {datachannelToken: 'new-token-for-B'}});
+        };
+
+        sinon.stub(psChannelA, 'getDatachannelUrl').returns(webinarAPSDatachannelUrl);
+        sinon.stub(psChannelB, 'getDatachannelUrl').returns(webinarBPSDatachannelUrl);
+        psChannelA.setRefreshHandler(mockMeetingARefresh);
+        psChannelB.setRefreshHandler(mockMeetingBRefresh);
+
+        // --- Simulate interceptor handling a 401 on webinar A's request ---
+        const failingRequestUrlA = webinarAPSDatachannelUrl + '/events';
+        const channelForARequest = plugin.getConnectionByDatachannelUrl(failingRequestUrlA);
+
+        assert.equal(channelForARequest, psChannelA);
+
+        await channelForARequest.refreshDataChannelToken();
+
+        assert.equal(refreshCallLog.length, 1);
+        assert.equal(refreshCallLog[0].meeting, 'A');
+        assert.equal(refreshCallLog[0].locusUrl, webinarALocusUrl);
+
+        // --- Simulate interceptor handling a 401 on webinar B's request ---
+        refreshCallLog.length = 0;
+
+        const failingRequestUrlB = webinarBPSDatachannelUrl + '/events';
+        const channelForBRequest = plugin.getConnectionByDatachannelUrl(failingRequestUrlB);
+
+        assert.equal(channelForBRequest, psChannelB);
+
+        await channelForBRequest.refreshDataChannelToken();
+
+        assert.equal(refreshCallLog.length, 1);
+        assert.equal(refreshCallLog[0].meeting, 'B');
+        assert.equal(refreshCallLog[0].locusUrl, webinarBLocusUrl);
+      });
+
+      it('PS channel refresh handlers remain independent after subsequent channel creation', async () => {
+        // Verify that creating channel B does not affect channel A's refresh handler
+
+        const psChannelA = plugin.createConnection();
+        const mockRefreshA = sinon.stub().resolves({body: {datachannelToken: 'token-A'}});
+
+        psChannelA.setRefreshHandler(mockRefreshA);
+
+        // Create channel B after A (simulating User 1 getting promoted in webinar B)
+        const psChannelB = plugin.createConnection();
+        const mockRefreshB = sinon.stub().resolves({body: {datachannelToken: 'token-B'}});
+
+        psChannelB.setRefreshHandler(mockRefreshB);
+
+        // Verify A's handler was not affected by B's setup
+        const resultA = await psChannelA.refreshDataChannelToken();
+
+        assert.equal(resultA.body.datachannelToken, 'token-A');
+        sinon.assert.calledOnce(mockRefreshA);
+        sinon.assert.notCalled(mockRefreshB);
+
+        // Verify B has its own handler
+        const resultB = await psChannelB.refreshDataChannelToken();
+
+        assert.equal(resultB.body.datachannelToken, 'token-B');
+        sinon.assert.calledOnce(mockRefreshB);
+      });
+    });
   });
 });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -132,29 +132,6 @@ describe('plugin-llm', () => {
       });
     });
 
-    describe('#getLocusUrlByDatachannelUrl', () => {
-      it('returns locus URL for matching datachannel URL', () => {
-        const channel = plugin.createConnection();
-
-        sinon
-          .stub(channel, 'getDatachannelUrl')
-          .returns('https://board.wbx2.com/datachannel/api/v1/locus/123/registrations');
-        sinon.stub(channel, 'getLocusUrl').returns('https://locus.example.com/123');
-
-        const result = plugin.getLocusUrlByDatachannelUrl(
-          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
-        );
-
-        assert.equal(result, 'https://locus.example.com/123');
-      });
-
-      it('returns undefined when no match', () => {
-        const result = plugin.getLocusUrlByDatachannelUrl('https://unknown.example.com');
-
-        assert.equal(result, undefined);
-      });
-    });
-
     describe('#isDataChannelTokenEnabled', () => {
       it('returns true when feature flag is enabled', async () => {
         webex.internal.feature.getFeature.resolves(true);

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -49,17 +49,6 @@ describe('plugin-llm', () => {
         assert.notStrictEqual(channel1, channel2);
         assert.equal(plugin.getAllConnections().size, 2);
       });
-
-      it('auto-unregisters channel when offline event fires', () => {
-        const channel = plugin.createConnection();
-
-        assert.equal(plugin.getAllConnections().size, 1);
-
-        // Simulate offline event
-        channel.trigger('offline');
-
-        assert.equal(plugin.getAllConnections().size, 0);
-      });
     });
 
     describe('#getAllConnections', () => {
@@ -130,6 +119,16 @@ describe('plugin-llm', () => {
 
         assert.equal(result, undefined);
       });
+
+      it('skips channels with no datachannel URL set', () => {
+        const channel = plugin.createConnection();
+
+        sinon.stub(channel, 'getDatachannelUrl').returns(undefined);
+
+        const result = plugin.getConnectionByDatachannelUrl('https://example.com');
+
+        assert.equal(result, undefined);
+      });
     });
 
     describe('#isDataChannelTokenEnabled', () => {
@@ -152,33 +151,6 @@ describe('plugin-llm', () => {
         const result = await plugin.isDataChannelTokenEnabled();
 
         assert.equal(result, false);
-      });
-    });
-
-    describe('connection lifecycle', () => {
-      it('channel remains in registry until offline', () => {
-        const channel = plugin.createConnection();
-
-        // Simulate connection then disconnection
-        channel.trigger('online');
-        assert.equal(plugin.getAllConnections().size, 1);
-
-        channel.trigger('offline');
-        assert.equal(plugin.getAllConnections().size, 0);
-      });
-
-      it('multiple channels can be managed independently', () => {
-        const channel1 = plugin.createConnection();
-        const channel2 = plugin.createConnection();
-
-        assert.equal(plugin.getAllConnections().size, 2);
-
-        // Disconnect only channel1
-        channel1.trigger('offline');
-
-        assert.equal(plugin.getAllConnections().size, 1);
-        assert.isTrue(plugin.getAllConnections().has(channel2));
-        assert.isFalse(plugin.getAllConnections().has(channel1));
       });
     });
   });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -315,14 +315,12 @@ describe('plugin-llm', () => {
       it('calls super.disconnect and clears all connection state', async () => {
         await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
         llmChannel.setDatachannelToken('token123');
-        llmChannel.ownerMeetingId = 'meeting-1';
 
         assert.equal(llmChannel.isConnected(), true);
         assert.equal(llmChannel.getLocusUrl(), locusUrl);
         assert.equal(llmChannel.getDatachannelUrl(), datachannelUrl);
         assert.equal(llmChannel.getBinding(), 'binding');
         assert.equal(llmChannel.getDatachannelToken(), 'token123');
-        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
 
         await llmChannel.disconnect({code: 1000, reason: 'test'});
 
@@ -330,7 +328,6 @@ describe('plugin-llm', () => {
         assert.equal(llmChannel.getDatachannelUrl(), undefined);
         assert.equal(llmChannel.getBinding(), undefined);
         assert.equal(llmChannel.getDatachannelToken(), undefined);
-        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
 
       it('works without options', async () => {
@@ -440,37 +437,6 @@ describe('plugin-llm', () => {
 
         llmChannel.clearDatachannelToken();
         assert.equal(llmChannel.getDatachannelToken(), undefined);
-      });
-    });
-
-    describe('#ownerMeetingId', () => {
-      it('stores and returns the owner meeting id', () => {
-        llmChannel.ownerMeetingId = 'meeting-1';
-
-        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
-      });
-
-      it('returns undefined when no owner has been set', () => {
-        assert.equal(llmChannel.ownerMeetingId, undefined);
-      });
-
-      it('allows clearing ownership by setting undefined', () => {
-        llmChannel.ownerMeetingId = 'meeting-1';
-        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
-
-        llmChannel.ownerMeetingId = undefined;
-
-        assert.equal(llmChannel.ownerMeetingId, undefined);
-      });
-
-      it('is cleared by disconnect', async () => {
-        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
-        llmChannel.ownerMeetingId = 'meeting-1';
-        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
-
-        await llmChannel.disconnect({code: 1000, reason: 'test'});
-
-        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
     });
 

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -383,6 +383,27 @@ describe('plugin-llm', () => {
           assert.equal(error.message, 'disconnect failed');
         }
       });
+
+      it('calls onDisconnect callback and clears it', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        const onDisconnectSpy = sinon.spy();
+
+        llmChannel.onDisconnect = onDisconnectSpy;
+
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        sinon.assert.calledOnce(onDisconnectSpy);
+        assert.isUndefined(llmChannel.onDisconnect);
+      });
+
+      it('does not throw if onDisconnect is not set', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        llmChannel.onDisconnect = undefined;
+
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        assert.isUndefined(llmChannel.onDisconnect);
+      });
     });
 
     describe('#setRefreshHandler', () => {

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -330,18 +330,6 @@ describe('plugin-llm', () => {
       });
     });
 
-    describe('#getSocket', () => {
-      it('returns the underlying socket', async () => {
-        llmChannel.socket = {readyState: 1};
-
-        assert.deepEqual(llmChannel.getSocket(), {readyState: 1});
-      });
-
-      it('returns undefined when not connected', () => {
-        assert.equal(llmChannel.getSocket(), undefined);
-      });
-    });
-
     describe('#disconnect', () => {
       it('calls super.disconnect and clears all connection state', async () => {
         await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
@@ -384,25 +372,15 @@ describe('plugin-llm', () => {
         }
       });
 
-      it('calls onDisconnect callback and clears it', async () => {
+      it('emits disconnected event', async () => {
         await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
-        const onDisconnectSpy = sinon.spy();
+        const disconnectedSpy = sinon.spy();
 
-        llmChannel.onDisconnect = onDisconnectSpy;
+        llmChannel.on('disconnected', disconnectedSpy);
 
         await llmChannel.disconnect({code: 1000, reason: 'test'});
 
-        sinon.assert.calledOnce(onDisconnectSpy);
-        assert.isUndefined(llmChannel.onDisconnect);
-      });
-
-      it('does not throw if onDisconnect is not set', async () => {
-        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
-        llmChannel.onDisconnect = undefined;
-
-        await llmChannel.disconnect({code: 1000, reason: 'test'});
-
-        assert.isUndefined(llmChannel.onDisconnect);
+        sinon.assert.calledOnce(disconnectedSpy);
       });
     });
 

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -311,6 +311,37 @@ describe('plugin-llm', () => {
       });
     });
 
+    describe('#isConnecting', () => {
+      it('returns true while connection is in progress', () => {
+        // Start connection but don't await
+        llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        assert.equal(llmChannel.isConnecting(), true);
+      });
+
+      it('returns false after connection completes', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        assert.equal(llmChannel.isConnecting(), false);
+      });
+
+      it('returns false before any connection attempt', () => {
+        assert.equal(llmChannel.isConnecting(), false);
+      });
+    });
+
+    describe('#getSocket', () => {
+      it('returns the underlying socket', async () => {
+        llmChannel.socket = {readyState: 1};
+
+        assert.deepEqual(llmChannel.getSocket(), {readyState: 1});
+      });
+
+      it('returns undefined when not connected', () => {
+        assert.equal(llmChannel.getSocket(), undefined);
+      });
+    });
+
     describe('#disconnect', () => {
       it('calls super.disconnect and clears all connection state', async () => {
         await llmChannel.registerAndConnect(locusUrl, datachannelUrl);

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -185,6 +185,14 @@ const Mercury = WebexPlugin.extend({
     return this.lastError;
   },
 
+  /**
+   * Get the underlying WebSocket.
+   * @returns {any} The socket instance, or undefined if not connected.
+   */
+  getSocket() {
+    return this.socket;
+  },
+
   connect(webSocketUrl) {
     if (this.connected) {
       this.logger.info(`${this.namespace}: already connected, will not connect again`);

--- a/packages/@webex/internal-plugin-voicea/src/constants.ts
+++ b/packages/@webex/internal-plugin-voicea/src/constants.ts
@@ -1,5 +1,3 @@
-export {LLM_PRACTICE_SESSION} from '@webex/internal-plugin-llm';
-
 export const EVENT_TRIGGERS = {
   VOICEA_ANNOUNCEMENT: 'voicea:announcement',
   CAPTION_LANGUAGE_UPDATE: 'voicea:captionLanguageUpdate',

--- a/packages/@webex/internal-plugin-voicea/src/index.ts
+++ b/packages/@webex/internal-plugin-voicea/src/index.ts
@@ -1,10 +1,12 @@
 import * as WebexCore from '@webex/webex-core';
 
-import VoiceaChannel from './voicea';
+import Voicea from './voicea-plugin';
+import {VoiceaChannel} from './voicea';
 import type {MeetingTranscriptPayload} from './voicea.types';
 
-WebexCore.registerInternalPlugin('voicea', VoiceaChannel, {});
+WebexCore.registerInternalPlugin('voicea', Voicea, {});
 
-export {default} from './voicea';
+export {Voicea as VoiceaPlugin, VoiceaChannel};
+export default Voicea;
 export {type MeetingTranscriptPayload};
 export {EVENT_TRIGGERS, TURN_ON_CAPTION_STATUS} from './constants';

--- a/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
@@ -13,13 +13,18 @@ export class VoiceaPlugin extends WebexPlugin {
   namespace = VOICEA;
 
   /**
-   * Creates a VoiceaChannel bound to the given LLMChannel
+   * Creates a VoiceaChannel bound to the given LLMChannel.
+   *
+   * Note: VoiceaChannel does not take ownership of the LLMChannel.
+   * The caller retains ownership and is responsible for the LLMChannel's
+   * lifecycle (connection, disconnection, cleanup).
+   *
    * @param {LLMChannel} llmChannel - The LLM channel to use for voicea
    * @returns {VoiceaChannel} A new VoiceaChannel instance
    */
   public createChannel(llmChannel: LLMChannel): VoiceaChannel {
     // @ts-ignore - webex is available on WebexPlugin
-    const channel = new VoiceaChannel(llmChannel, this.webex);
+    const channel = new VoiceaChannel(llmChannel, this.webex.request.bind(this.webex));
 
     return channel;
   }

--- a/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
@@ -1,0 +1,26 @@
+import {WebexPlugin} from '@webex/webex-core';
+import type LLMChannel from '@webex/internal-plugin-llm';
+
+import {VoiceaChannel} from './voicea';
+import {VOICEA} from './constants';
+
+/**
+ * VoiceaPlugin - factory for creating VoiceaChannel instances
+ * @export
+ * @class VoiceaPlugin
+ */
+export class VoiceaPlugin extends WebexPlugin {
+  namespace = VOICEA;
+
+  /**
+   * Creates a VoiceaChannel bound to the given LLMChannel
+   * @param {LLMChannel} llmChannel - The LLM channel to use for voicea
+   * @returns {VoiceaChannel} A new VoiceaChannel instance
+   */
+  public createChannel(llmChannel: LLMChannel): VoiceaChannel {
+    // @ts-ignore - webex is available on WebexPlugin
+    return new VoiceaChannel(llmChannel, this.webex);
+  }
+}
+
+export default VoiceaPlugin;

--- a/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
@@ -19,7 +19,9 @@ export class VoiceaPlugin extends WebexPlugin {
    */
   public createChannel(llmChannel: LLMChannel): VoiceaChannel {
     // @ts-ignore - webex is available on WebexPlugin
-    return new VoiceaChannel(llmChannel, this.webex);
+    const channel = new VoiceaChannel(llmChannel, this.webex);
+
+    return channel;
   }
 }
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -262,7 +262,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
     const socket = this.llmChannel.getSocket();
     const binding = this.llmChannel.getBinding();
 
-    socket.send({
+    const payload = {
       id: `${this.seqNum}`,
       type: 'publishRequest',
       recipients: [
@@ -280,7 +280,8 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
         relayType: AIBRIDGE_RELAY_TYPES.VOICEA.CLIENT_ANNOUNCEMENT,
       },
       trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
-    });
+    };
+    socket.send(payload);
     this.seqNum += 1;
   };
 
@@ -409,6 +410,8 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
   private requestTurnOnCaptions = (languageCode?: string): undefined | Promise<void> => {
     this.captionStatus = TURN_ON_CAPTION_STATUS.SENDING;
 
+    const locusUrl = this.llmChannel.getLocusUrl();
+
     const body = {
       transcribe: {caption: true},
       languageCode,
@@ -417,7 +420,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
     return this.webex
       .request({
         method: 'PUT',
-        url: `${this.llmChannel.getLocusUrl()}/controls/`,
+        url: `${locusUrl}/controls/`,
         body,
       })
       .then(() => {
@@ -428,7 +431,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
         this.announce();
         this.updateSubchannelSubscriptionsAndSyncCaptionState({subscribe: ['transcription']}, true);
       })
-      .catch(() => {
+      .catch((error) => {
         this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
         throw new Error('turn on captions fail');
       });

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -1,7 +1,10 @@
+// @ts-ignore - events module types
 import {EventEmitter} from 'events';
 import uuid from 'uuid';
+// @ts-ignore - webex-core types
 import {config} from '@webex/webex-core';
 
+// @ts-ignore - internal-plugin-llm types
 import type LLMChannel from '@webex/internal-plugin-llm';
 import {
   EVENT_TRIGGERS,
@@ -27,7 +30,7 @@ import {millisToMinutesAndSeconds} from './utils';
  * @export
  * @class VoiceaChannel
  */
-export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
+export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChannel {
   private webex: any;
   private llmChannel: LLMChannel;
 
@@ -162,7 +165,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
         this.emit(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: true,
           transcriptId: voiceaPayload.transcript_id,
-          transcripts: voiceaPayload.transcripts.map((transcript) => {
+          transcripts: voiceaPayload.transcripts?.map((transcript) => {
             transcript.timestamp = millisToMinutesAndSeconds(transcript.end_millis);
 
             return transcript;
@@ -172,12 +175,12 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
 
       case TRANSCRIPTION_TYPE.HIGHLIGHT_CREATED:
         this.emit(EVENT_TRIGGERS.HIGHLIGHT_CREATED, {
-          csis: voiceaPayload.highlight.csis,
-          highlightId: voiceaPayload.highlight.highlight_id,
-          text: voiceaPayload.highlight.transcript,
-          highlightLabel: voiceaPayload.highlight.highlight_label,
-          highlightSource: voiceaPayload.highlight.highlight_source,
-          timestamp: millisToMinutesAndSeconds(voiceaPayload.highlight.end_millis),
+          csis: voiceaPayload.highlight?.csis,
+          highlightId: voiceaPayload.highlight?.highlight_id,
+          text: voiceaPayload.highlight?.transcript,
+          highlightLabel: voiceaPayload.highlight?.highlight_label,
+          highlightSource: voiceaPayload.highlight?.highlight_source,
+          timestamp: millisToMinutesAndSeconds(voiceaPayload.highlight?.end_millis ?? 0),
         });
         break;
 
@@ -403,7 +406,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @param {string} [languageCode] - Optional Parameter for spoken language code
    * @returns {Promise}
    */
-  private requestTurnOnCaptions = (languageCode?): undefined | Promise<void> => {
+  private requestTurnOnCaptions = (languageCode?: string): undefined | Promise<void> => {
     this.captionStatus = TURN_ON_CAPTION_STATUS.SENDING;
 
     const body = {
@@ -470,7 +473,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @param {string} [spokenLanguage] - Optional Spoken language code
    * @returns {Promise}
    */
-  public turnOnCaptions = async (spokenLanguage?): Promise<void | undefined> => {
+  public turnOnCaptions = async (spokenLanguage?: string): Promise<void | undefined> => {
     if (this.captionStatus === TURN_ON_CAPTION_STATUS.SENDING) return undefined;
 
     if (!this.isLLMConnected()) {

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -1,5 +1,4 @@
-// @ts-ignore - events module types
-import {EventEmitter} from 'events';
+import EventEmitter from 'events';
 import uuid from 'uuid';
 // @ts-ignore - webex-core types
 import {config} from '@webex/webex-core';
@@ -30,8 +29,8 @@ import {millisToMinutesAndSeconds} from './utils';
  * @export
  * @class VoiceaChannel
  */
-export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChannel {
-  private webex: any;
+export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
+  private request: (options: {method: string; url: string; body?: object}) => Promise<any>;
   private llmChannel: LLMChannel;
 
   private seqNum: number;
@@ -51,12 +50,15 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
   /**
    * Creates a VoiceaChannel bound to the given LLMChannel
    * @param {LLMChannel} llmChannel - The LLM channel to use
-   * @param {Object} webex - The webex instance for making requests
+   * @param {Function} request - The request function for making API calls (typically webex.request bound to webex)
    */
-  constructor(llmChannel: LLMChannel, webex: any) {
+  constructor(
+    llmChannel: LLMChannel,
+    request: (options: {method: string; url: string; body?: object}) => Promise<any>
+  ) {
     super();
     this.llmChannel = llmChannel;
-    this.webex = webex;
+    this.request = request;
 
     this.seqNum = 1;
     this.areCaptionsEnabled = false;
@@ -129,7 +131,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
   /**
    * Switch to a different LLM channel while preserving caption state.
    * Used when transitioning between main meeting and practice session.
-   * - Preserves isCaptionBoxOn and spokenLanguage state
+   * - Preserves keepTranscriptionSubscribed and spokenLanguage state
    * - Unsubscribes from old channel, subscribes to new channel
    * - Re-announces and re-enables captions if they were on
    * @param {LLMChannel} newLLMChannel - The new LLM channel to switch to
@@ -137,7 +139,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
    */
   public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
     // Save current state
-    const captionsWereOn = this.isCaptionBoxOn;
+    const captionsWereOn = this.keepTranscriptionSubscribed;
     const spokenLanguage = this.currentSpokenLanguage;
 
     // Unsubscribe from old channel
@@ -334,20 +336,18 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
     languageCode: string,
     languageAssignment?: 'DEFAULT' | 'AUTO' | 'MANUAL'
   ): Promise<void> =>
-    this.webex
-      .request({
-        method: 'PUT',
-        url: `${this.llmChannel.getLocusUrl()}/controls/`,
-        body: {
-          transcribe: {
-            spokenLanguage: languageCode,
-            ...(languageAssignment && {languageAssignment}),
-          },
+    this.request({
+      method: 'PUT',
+      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      body: {
+        transcribe: {
+          spokenLanguage: languageCode,
+          ...(languageAssignment && {languageAssignment}),
         },
-      })
-      .then(() => {
-        this.emit(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
-      });
+      },
+    }).then(() => {
+      this.emit(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
+    });
 
   /**
    * Request Language translation
@@ -456,12 +456,11 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
       languageCode,
     };
 
-    return this.webex
-      .request({
-        method: 'PUT',
-        url: `${locusUrl}/controls/`,
-        body,
-      })
+    return this.request({
+      method: 'PUT',
+      url: `${locusUrl}/controls/`,
+      body,
+    })
       .then(() => {
         this.emit(EVENT_TRIGGERS.CAPTIONS_TURNED_ON);
 
@@ -480,14 +479,14 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
    * is announce processing
    * @returns {boolean}
    */
-  public isAnnounceProcessing = (): boolean =>
+  private isAnnounceProcessing = (): boolean =>
     [ANNOUNCE_STATUS.JOINING, ANNOUNCE_STATUS.JOINED].includes(this.announceStatus);
 
   /**
    * is announce processed
    * @returns {boolean}
    */
-  public isAnnounceProcessed = (): boolean => this.announceStatus === ANNOUNCE_STATUS.JOINED;
+  private isAnnounceProcessed = (): boolean => this.announceStatus === ANNOUNCE_STATUS.JOINED;
 
   /**
    * announce to voicea data channel
@@ -507,7 +506,7 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
    * is turn on caption processing
    * @returns {boolean}
    */
-  public isCaptionProcessing = (): boolean =>
+  private isCaptionProcessing = (): boolean =>
     [TURN_ON_CAPTION_STATUS.SENDING, TURN_ON_CAPTION_STATUS.ENABLED].includes(this.captionStatus);
 
   /**
@@ -535,24 +534,22 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
     activate: boolean,
     spokenLanguage?: string
   ): undefined | Promise<void> => {
-    return this.webex
-      .request({
-        method: 'PUT',
-        url: `${this.llmChannel.getLocusUrl()}/controls/`,
-        body: {
-          transcribe: {
-            transcribing: activate,
-          },
-          spokenLanguage,
+    return this.request({
+      method: 'PUT',
+      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      body: {
+        transcribe: {
+          transcribing: activate,
         },
-      })
-      .then((): undefined | Promise<void> => {
-        if (activate && !this.areCaptionsEnabled) {
-          return this.turnOnCaptions(spokenLanguage);
-        }
+        spokenLanguage,
+      },
+    }).then((): undefined | Promise<void> => {
+      if (activate && !this.areCaptionsEnabled) {
+        return this.turnOnCaptions(spokenLanguage);
+      }
 
-        return undefined;
-      });
+      return undefined;
+    });
   };
 
   /**
@@ -565,16 +562,15 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
 
     this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.SENDING;
 
-    return this.webex
-      .request({
-        method: 'PUT',
-        url: `${this.llmChannel.getLocusUrl()}/controls/`,
-        body: {
-          manualCaption: {
-            enable,
-          },
+    return this.request({
+      method: 'PUT',
+      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      body: {
+        manualCaption: {
+          enable,
         },
-      })
+      },
+    })
       .then((): undefined | Promise<void> => {
         this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -1,19 +1,17 @@
+import {EventEmitter} from 'events';
 import uuid from 'uuid';
-import {WebexPlugin, config} from '@webex/webex-core';
+import {config} from '@webex/webex-core';
 
+import type LLMChannel from '@webex/internal-plugin-llm';
 import {
   EVENT_TRIGGERS,
   AIBRIDGE_RELAY_TYPES,
   TRANSCRIPTION_TYPE,
-  VOICEA,
-  LLM_PRACTICE_SESSION,
   ANNOUNCE_STATUS,
   TURN_ON_CAPTION_STATUS,
   TOGGLE_MANUAL_CAPTION_STATUS,
   DEFAULT_SPOKEN_LANGUAGE,
-  LANGUAGE_ASSIGNMENT,
 } from './constants';
-// eslint-disable-next-line no-unused-vars
 import {
   AnnouncementPayload,
   CaptionLanguageResponse,
@@ -23,41 +21,61 @@ import {
 import {millisToMinutesAndSeconds} from './utils';
 
 /**
- * @description VoiceaChannel to hold single instance of LLM
+ * @description VoiceaChannel — handles voicea/transcription functionality for a single LLM connection.
+ * Created via `webex.internal.voicea.createChannel(llmChannel)`. The caller owns the
+ * channel and is responsible for its lifecycle.
  * @export
  * @class VoiceaChannel
  */
-export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
-  namespace = VOICEA;
+export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
+  private webex: any;
+  private llmChannel: LLMChannel;
 
   private seqNum: number;
-
   private areCaptionsEnabled: boolean;
-
   private hasSubscribedToEvents = false;
-
   private captionServiceId?: string;
-
   private announceStatus: string;
-
   private captionStatus: string;
 
   private keepTranscriptionSubscribed: boolean;
 
   private toggleManualCaptionStatus: string;
-
   private currentSpokenLanguage?: string;
-
   private spokenLanguages: string[] = [];
-
   private currentCaptionLanguage?: string;
 
   /**
-   * @param {Object} e
-   * @returns {undefined}
+   * Creates a VoiceaChannel bound to the given LLMChannel
+   * @param {LLMChannel} llmChannel - The LLM channel to use
+   * @param {Object} webex - The webex instance for making requests
    */
+  constructor(llmChannel: LLMChannel, webex: any) {
+    super();
+    this.llmChannel = llmChannel;
+    this.webex = webex;
 
-  private eventProcessor = (e) => {
+    this.seqNum = 1;
+    this.areCaptionsEnabled = false;
+    this.captionServiceId = undefined;
+    this.announceStatus = ANNOUNCE_STATUS.IDLE;
+    this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
+    this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
+    this.currentSpokenLanguage = DEFAULT_SPOKEN_LANGUAGE;
+    this.currentCaptionLanguage = undefined;
+    this.keepTranscriptionSubscribed = false;
+
+    // Subscribe to relay events from the LLM channel
+    this.llmChannel.on('event:relay.event', this.eventProcessor);
+    this.hasSubscribedToEvents = true;
+  }
+
+  /**
+   * Process events from LLM channel
+   * @param {Object} e - Event data
+   * @returns {void}
+   */
+  private eventProcessor = (e: any): void => {
     this.seqNum = e.sequenceNumber + 1;
     switch (e.data.relayType) {
       case AIBRIDGE_RELAY_TYPES.VOICEA.ANNOUNCEMENT:
@@ -85,53 +103,23 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
   };
 
   /**
-   * Listen to websocket messages
-   * @returns {undefined}
-   */
-  private listenToEvents() {
-    if (!this.hasSubscribedToEvents) {
-      // @ts-ignore
-      this.webex.internal.llm.on('event:relay.event', this.eventProcessor);
-      // @ts-ignore
-      this.webex.internal.llm.on(`event:relay.event:${LLM_PRACTICE_SESSION}`, this.eventProcessor);
-      this.hasSubscribedToEvents = true;
-    }
-  }
-
-  /**
-   * Listen to websocket messages
+   * Deregister events and clean up
    * @returns {void}
    */
-  public deregisterEvents() {
+  public deregisterEvents(): void {
     this.areCaptionsEnabled = false;
     this.keepTranscriptionSubscribed = false;
     this.captionServiceId = undefined;
-    // @ts-ignore
-    this.webex.internal.llm.off('event:relay.event', this.eventProcessor);
-    // @ts-ignore
-    this.webex.internal.llm.off(`event:relay.event:${LLM_PRACTICE_SESSION}`, this.eventProcessor);
-    this.hasSubscribedToEvents = false;
+
+    if (this.hasSubscribedToEvents) {
+      this.llmChannel.off('event:relay.event', this.eventProcessor);
+      this.hasSubscribedToEvents = false;
+    }
+
     this.announceStatus = ANNOUNCE_STATUS.IDLE;
     this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
     this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
     this.currentSpokenLanguage = undefined;
-    this.currentCaptionLanguage = undefined;
-  }
-
-  /**
-   * Initializes Voicea plugin
-   * @param {any} args
-   */
-  constructor(...args) {
-    super(...args);
-    this.seqNum = 1;
-    this.areCaptionsEnabled = false;
-    this.keepTranscriptionSubscribed = false;
-    this.captionServiceId = undefined;
-    this.announceStatus = ANNOUNCE_STATUS.IDLE;
-    this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
-    this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
-    this.currentSpokenLanguage = DEFAULT_SPOKEN_LANGUAGE;
     this.currentCaptionLanguage = undefined;
   }
 
@@ -145,8 +133,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       transcriptPayload.type === TRANSCRIPTION_TYPE.MANUAL_CAPTION_FINAL_RESULT ||
       transcriptPayload.type === TRANSCRIPTION_TYPE.MANUAL_CAPTION_INTERIM_RESULT
     ) {
-      // @ts-ignore
-      this.trigger(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, {
+      this.emit(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, {
         isFinal: transcriptPayload.type === TRANSCRIPTION_TYPE.MANUAL_CAPTION_FINAL_RESULT,
         transcriptId: transcriptPayload.id,
         transcripts: transcriptPayload.transcripts,
@@ -164,8 +151,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
   private processTranscription = (voiceaPayload: TranscriptionResponse): void => {
     switch (voiceaPayload.type) {
       case TRANSCRIPTION_TYPE.TRANSCRIPT_INTERIM_RESULTS:
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
+        this.emit(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: false,
           transcriptId: voiceaPayload.transcript_id,
           transcripts: voiceaPayload.transcripts,
@@ -173,8 +159,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.TRANSCRIPT_FINAL_RESULT:
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
+        this.emit(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: true,
           transcriptId: voiceaPayload.transcript_id,
           transcripts: voiceaPayload.transcripts.map((transcript) => {
@@ -186,8 +171,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.HIGHLIGHT_CREATED:
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.HIGHLIGHT_CREATED, {
+        this.emit(EVENT_TRIGGERS.HIGHLIGHT_CREATED, {
           csis: voiceaPayload.highlight.csis,
           highlightId: voiceaPayload.highlight.highlight_id,
           text: voiceaPayload.highlight.transcript,
@@ -198,8 +182,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.EVA_THANKS:
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
+        this.emit(EVENT_TRIGGERS.EVA_COMMAND, {
           isListening: false,
           text: voiceaPayload.command_response,
         });
@@ -207,22 +190,18 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
 
       case TRANSCRIPTION_TYPE.EVA_WAKE:
       case TRANSCRIPTION_TYPE.EVA_CANCEL:
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
+        this.emit(EVENT_TRIGGERS.EVA_COMMAND, {
           isListening: voiceaPayload.type === TRANSCRIPTION_TYPE.EVA_WAKE,
         });
         break;
 
       case TRANSCRIPTION_TYPE.LANGUAGE_DETECTED: {
         const isInSpokenLanguages = this.spokenLanguages.includes(voiceaPayload.language);
-
         if (isInSpokenLanguages) {
-          // @ts-ignore
-          this.trigger(EVENT_TRIGGERS.LANGUAGE_DETECTED, {
+          this.emit(EVENT_TRIGGERS.LANGUAGE_DETECTED, {
             languageCode: voiceaPayload.language,
           });
         }
-
         break;
       }
       default:
@@ -237,11 +216,9 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    */
   private processCaptionLanguageResponse = (voiceaPayload: CaptionLanguageResponse): void => {
     if (voiceaPayload.statusCode === 200) {
-      // @ts-ignore
-      this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {statusCode: 200});
+      this.emit(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {statusCode: 200});
     } else {
-      // @ts-ignore
-      this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {
+      this.emit(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {
         statusCode: voiceaPayload.errorCode,
         errorMessage: voiceaPayload.message,
       });
@@ -262,50 +239,26 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
     };
 
     this.spokenLanguages = voiceaPayload?.ASR?.spoken_languages ?? [];
-    // @ts-ignore
-    this.trigger(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, voiceaLanguageOptions);
+    this.emit(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, voiceaLanguageOptions);
   };
 
   /**
-   * Indicates whether the default or practice-session LLM connection is active.
+   * Indicates whether the LLM channel is connected.
    * @returns {boolean}
    */
-  private isLLMConnected = (): boolean =>
-    // @ts-ignore
-    this.webex.internal.llm.isConnected() ||
-    // @ts-ignore
-    this.webex.internal.llm.isConnected(LLM_PRACTICE_SESSION);
+  public isLLMConnected = (): boolean => this.llmChannel.isConnected();
 
   public getKeepTranscriptionSubscribed = (): boolean => this.keepTranscriptionSubscribed;
-
-  /**
-   * Resolves the active LLM publish transport, preferring the practice-session
-   * connection only when that session is fully connected.
-   * @returns {Object}
-   */
-  private getPublishTransport = () => {
-    // @ts-ignore
-    const {llm} = this.webex.internal;
-    const isPracticeSessionConnected = llm.isConnected(LLM_PRACTICE_SESSION);
-
-    return {
-      socket: (isPracticeSessionConnected && llm.getSocket(LLM_PRACTICE_SESSION)) || llm.socket,
-      binding:
-        (isPracticeSessionConnected && llm.getBinding(LLM_PRACTICE_SESSION)) || llm.getBinding(),
-      datachannelUrl:
-        (isPracticeSessionConnected && llm.getDatachannelUrl(LLM_PRACTICE_SESSION)) ||
-        llm.getDatachannelUrl(),
-    };
-  };
 
   /**
    * Sends Announcement to add voicea to the meeting
    * @returns {void}
    */
-  private sendAnnouncement = (): void => {
+  public sendAnnouncement = (): void => {
     this.announceStatus = ANNOUNCE_STATUS.JOINING;
-    this.listenToEvents();
-    const {socket, binding} = this.getPublishTransport();
+    const socket = this.llmChannel.getSocket();
+    const binding = this.llmChannel.getBinding();
+
     socket.send({
       id: `${this.seqNum}`,
       type: 'publishRequest',
@@ -338,21 +291,20 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
     languageCode: string,
     languageAssignment?: 'DEFAULT' | 'AUTO' | 'MANUAL'
   ): Promise<void> =>
-    // @ts-ignore
-    this.request({
-      method: 'PUT',
-      // @ts-ignore
-      url: `${this.webex.internal.llm.getLocusUrl()}/controls/`,
-      body: {
-        transcribe: {
-          spokenLanguage: languageCode,
-          ...(languageAssignment && {languageAssignment}),
+    this.webex
+      .request({
+        method: 'PUT',
+        url: `${this.llmChannel.getLocusUrl()}/controls/`,
+        body: {
+          transcribe: {
+            spokenLanguage: languageCode,
+            ...(languageAssignment && {languageAssignment}),
+          },
         },
-      },
-    }).then(() => {
-      // @ts-ignore
-      this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
-    });
+      })
+      .then(() => {
+        this.emit(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
+      });
 
   /**
    * Request Language translation
@@ -364,7 +316,9 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       return;
     }
 
-    const {socket, binding} = this.getPublishTransport();
+    const socket = this.llmChannel.getSocket();
+    const binding = this.llmChannel.getBinding();
+
     socket.send({
       id: `${this.seqNum}`,
       type: 'publishRequest',
@@ -387,7 +341,6 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
     });
     this.currentCaptionLanguage = languageCode;
-
     this.seqNum += 1;
   };
 
@@ -409,7 +362,8 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       return;
     }
 
-    const {socket, binding} = this.getPublishTransport();
+    const socket = this.llmChannel.getSocket();
+    const binding = this.llmChannel.getBinding();
 
     socket?.send({
       id: `${this.seqNum}`,
@@ -446,29 +400,25 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
 
   /**
    * request turn on Captions
-   * @param {string} [languageCode] - Optional Parameter for spoken language code. Defaults to English
+   * @param {string} [languageCode] - Optional Parameter for spoken language code
    * @returns {Promise}
    */
   private requestTurnOnCaptions = (languageCode?): undefined | Promise<void> => {
     this.captionStatus = TURN_ON_CAPTION_STATUS.SENDING;
 
-    // only set the spoken language if it is provided
     const body = {
       transcribe: {caption: true},
       languageCode,
     };
 
-    // @ts-ignore
-    // eslint-disable-next-line newline-before-return
-    return this.request({
-      method: 'PUT',
-      // @ts-ignore
-      url: `${this.webex.internal.llm.getLocusUrl()}/controls/`,
-      body,
-    })
+    return this.webex
+      .request({
+        method: 'PUT',
+        url: `${this.llmChannel.getLocusUrl()}/controls/`,
+        body,
+      })
       .then(() => {
-        // @ts-ignore
-        this.trigger(EVENT_TRIGGERS.CAPTIONS_TURNED_ON);
+        this.emit(EVENT_TRIGGERS.CAPTIONS_TURNED_ON);
 
         this.areCaptionsEnabled = true;
         this.captionStatus = TURN_ON_CAPTION_STATUS.ENABLED;
@@ -485,20 +435,20 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    * is announce processing
    * @returns {boolean}
    */
-  private isAnnounceProcessing = () =>
+  public isAnnounceProcessing = (): boolean =>
     [ANNOUNCE_STATUS.JOINING, ANNOUNCE_STATUS.JOINED].includes(this.announceStatus);
 
   /**
    * is announce processed
    * @returns {boolean}
    */
-  private isAnnounceProcessed = () => this.announceStatus === ANNOUNCE_STATUS.JOINED;
+  public isAnnounceProcessed = (): boolean => this.announceStatus === ANNOUNCE_STATUS.JOINED;
 
   /**
-   * announce to voicea data chanel
+   * announce to voicea data channel
    * @returns {void}
    */
-  public announce = () => {
+  public announce = (): void => {
     if (this.isAnnounceProcessed()) {
       return;
     }
@@ -512,7 +462,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    * is turn on caption processing
    * @returns {boolean}
    */
-  private isCaptionProcessing = () =>
+  public isCaptionProcessing = (): boolean =>
     [TURN_ON_CAPTION_STATUS.SENDING, TURN_ON_CAPTION_STATUS.ENABLED].includes(this.captionStatus);
 
   /**
@@ -520,7 +470,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    * @param {string} [spokenLanguage] - Optional Spoken language code
    * @returns {Promise}
    */
-  public turnOnCaptions = async (spokenLanguage?): undefined | Promise<void> => {
+  public turnOnCaptions = async (spokenLanguage?): Promise<void | undefined> => {
     if (this.captionStatus === TURN_ON_CAPTION_STATUS.SENDING) return undefined;
 
     if (!this.isLLMConnected()) {
@@ -540,24 +490,24 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
     activate: boolean,
     spokenLanguage?: string
   ): undefined | Promise<void> => {
-    // @ts-ignore
-    return this.request({
-      method: 'PUT',
-      // @ts-ignore
-      url: `${this.webex.internal.llm.getLocusUrl()}/controls/`,
-      body: {
-        transcribe: {
-          transcribing: activate,
+    return this.webex
+      .request({
+        method: 'PUT',
+        url: `${this.llmChannel.getLocusUrl()}/controls/`,
+        body: {
+          transcribe: {
+            transcribing: activate,
+          },
+          spokenLanguage,
         },
-        spokenLanguage,
-      },
-    }).then((): undefined | Promise<void> => {
-      if (activate && !this.areCaptionsEnabled) {
-        return this.turnOnCaptions(spokenLanguage);
-      }
+      })
+      .then((): undefined | Promise<void> => {
+        if (activate && !this.areCaptionsEnabled) {
+          return this.turnOnCaptions(spokenLanguage);
+        }
 
-      return undefined;
-    });
+        return undefined;
+      });
   };
 
   /**
@@ -570,17 +520,16 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
 
     this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.SENDING;
 
-    // @ts-ignore
-    return this.request({
-      method: 'PUT',
-      // @ts-ignore
-      url: `${this.webex.internal.llm.getLocusUrl()}/controls/`,
-      body: {
-        manualCaption: {
-          enable,
+    return this.webex
+      .request({
+        method: 'PUT',
+        url: `${this.llmChannel.getLocusUrl()}/controls/`,
+        body: {
+          manualCaption: {
+            enable,
+          },
         },
-      },
-    })
+      })
       .then((): undefined | Promise<void> => {
         this.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
 
@@ -598,9 +547,8 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    * @param {string} meetingId
    * @returns {void}
    */
-  public onSpokenLanguageUpdate = (languageCode: string, meetingId): void => {
-    // @ts-ignore
-    this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode, meetingId});
+  public onSpokenLanguageUpdate = (languageCode: string, meetingId: string): void => {
+    this.emit(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode, meetingId});
     this.currentSpokenLanguage = languageCode;
   };
 
@@ -615,7 +563,6 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
     }
     if (this.captionServiceId !== serviceId) {
       this.captionServiceId = serviceId;
-      // if service id value has changed and the translation language has been set, client needs to resend the translator language message to the LLM.
       if (this.currentCaptionLanguage) {
         this.requestLanguage(this.currentCaptionLanguage);
       }
@@ -626,18 +573,16 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    * get caption status
    * @returns {string}
    */
-  public getCaptionStatus = () => this.captionStatus;
+  public getCaptionStatus = (): string => this.captionStatus;
 
   /**
    * get announce status
    * @returns {string}
    */
-  public getAnnounceStatus = () => this.announceStatus;
+  public getAnnounceStatus = (): string => this.announceStatus;
+
   /**
    * update LLM sub‑channel subscriptions.
-   *
-   * sends a single `subchannelSubscriptionRequest` to LLM,
-   * allowing subscribe and unsubscribe subchannel.
    *
    * @param {string[]} options.subscribe   Sub‑channels to subscribe to.
    * @param {string[]} options.unsubscribe Sub‑channels to unsubscribe from.
@@ -650,19 +595,18 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
     subscribe?: string[];
     unsubscribe?: string[];
   } = {}): Promise<void> => {
-    // @ts-ignore
-    const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
-    // @ts-ignore
-    if (!this.isLLMConnected() || !isDataChannelTokenEnabled) return;
+    if (!this.isLLMConnected()) return;
 
-    const {socket, datachannelUrl} = this.getPublishTransport();
+    const isDataChannelTokenEnabled = await this.llmChannel.isDataChannelTokenEnabled();
+    if (!isDataChannelTokenEnabled) return;
 
-    // @ts-ignore
+    const socket = this.llmChannel.getSocket();
+    const datachannelUrl = this.llmChannel.getDatachannelUrl();
+
     socket.send({
       id: `${this.seqNum}`,
       type: 'subchannelSubscriptionRequest',
       data: {
-        // @ts-ignore
         datachannelUri: datachannelUrl,
         subscribe,
         unsubscribe,

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -127,6 +127,45 @@ export class VoiceaChannel extends (EventEmitter as any) implements IVoiceaChann
   }
 
   /**
+   * Switch to a different LLM channel while preserving caption state.
+   * Used when transitioning between main meeting and practice session.
+   * - Preserves isCaptionBoxOn and spokenLanguage state
+   * - Unsubscribes from old channel, subscribes to new channel
+   * - Re-announces and re-enables captions if they were on
+   * @param {LLMChannel} newLLMChannel - The new LLM channel to switch to
+   * @returns {Promise<void>}
+   */
+  public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
+    // Save current state
+    const captionsWereOn = this.isCaptionBoxOn;
+    const spokenLanguage = this.currentSpokenLanguage;
+
+    // Unsubscribe from old channel
+    if (this.hasSubscribedToEvents && this.llmChannel) {
+      this.llmChannel.off('event:relay.event', this.eventProcessor);
+      this.hasSubscribedToEvents = false;
+    }
+
+    // Switch to new channel
+    this.llmChannel = newLLMChannel;
+
+    // Subscribe to new channel
+    this.llmChannel.on('event:relay.event', this.eventProcessor);
+    this.hasSubscribedToEvents = true;
+
+    // Reset announcement state for new connection
+    this.announceStatus = ANNOUNCE_STATUS.IDLE;
+    this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
+    this.captionServiceId = undefined;
+    this.areCaptionsEnabled = false;
+
+    // Re-announce and re-enable captions if they were on
+    if (captionsWereOn) {
+      await this.turnOnCaptions(spokenLanguage);
+    }
+  }
+
+  /**
    * Process manual Transcript and send alert
    * @param {TranscriptionResponse} transcriptPayload
    * @returns {void}

--- a/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
@@ -96,6 +96,7 @@ interface IVoiceaChannel {
     csis: number[],
     isFinal: boolean
   ) => void;
+  getKeepTranscriptionSubscribed: () => boolean;
 }
 
 type MeetingTranscripts = {

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea-plugin.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea-plugin.js
@@ -1,0 +1,71 @@
+import MockWebex from '@webex/test-helper-mock-webex';
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import Mercury from '@webex/internal-plugin-mercury';
+import LLMChannel from '@webex/internal-plugin-llm';
+
+import {VoiceaPlugin} from '@webex/internal-plugin-voicea/src/voicea-plugin';
+import {VoiceaChannel} from '@webex/internal-plugin-voicea/src/voicea';
+
+/**
+ * Creates a mock LLM channel for testing
+ * @returns {Object} Mock channel
+ */
+function createMockLLMChannel() {
+  return {
+    isConnected: sinon.stub().returns(true),
+    getSocket: sinon.stub().returns({}),
+    getBinding: sinon.stub().returns('binding'),
+    getDatachannelUrl: sinon.stub().returns('datachannelUrl'),
+    getLocusUrl: sinon.stub().returns('locusUrl'),
+    isDataChannelTokenEnabled: sinon.stub().resolves(true),
+    on: sinon.stub(),
+    off: sinon.stub(),
+  };
+}
+
+describe('plugin-voicea', () => {
+  describe('VoiceaPlugin', () => {
+    let webex;
+    let plugin;
+
+    beforeEach(() => {
+      webex = new MockWebex({
+        children: {
+          mercury: Mercury,
+          llm: LLMChannel,
+        },
+      });
+
+      plugin = new VoiceaPlugin({}, {parent: webex});
+    });
+
+    afterEach(() => sinon.restore());
+
+    describe('#createChannel', () => {
+      it('creates a new VoiceaChannel instance', () => {
+        const mockLLMChannel = createMockLLMChannel();
+
+        const channel = plugin.createChannel(mockLLMChannel);
+
+        assert.instanceOf(channel, VoiceaChannel);
+      });
+
+      it('creates independent channels for multiple calls', () => {
+        const mockLLMChannel1 = createMockLLMChannel();
+        const mockLLMChannel2 = createMockLLMChannel();
+
+        const channel1 = plugin.createChannel(mockLLMChannel1);
+        const channel2 = plugin.createChannel(mockLLMChannel2);
+
+        assert.notStrictEqual(channel1, channel2);
+      });
+    });
+
+    describe('namespace', () => {
+      it('has the correct namespace', () => {
+        assert.equal(plugin.namespace, 'voicea');
+      });
+    });
+  });
+});

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -7,17 +7,50 @@ import Mercury from '@webex/internal-plugin-mercury';
 import LLMChannel from '@webex/internal-plugin-llm';
 
 import VoiceaService from '../../../src/index';
-import {
-  EVENT_TRIGGERS,
-  LLM_PRACTICE_SESSION,
-  TOGGLE_MANUAL_CAPTION_STATUS,
-} from '../../../src/constants';
+import {EVENT_TRIGGERS, TOGGLE_MANUAL_CAPTION_STATUS} from '../../../src/constants';
+
+/**
+ * Creates a mock LLM channel for testing
+ * @param {Object} [options] - Options for the mock channel
+ * @param {boolean} [options.isConnected=true] - Whether the channel is connected
+ * @param {string} [options.locusUrl] - The locus URL
+ * @returns {Object} Mock channel
+ */
+function createMockChannel(options = {}) {
+  const mockWebSocket = new MockWebSocket();
+  const {isConnected = true, locusUrl = 'locusUrl'} = options;
+
+  return {
+    isConnected: sinon.stub().returns(isConnected),
+    getSocket: sinon.stub().returns(mockWebSocket),
+    getBinding: sinon.stub().returns(undefined),
+    getDatachannelUrl: sinon.stub().returns('datachannelUrl'),
+    getLocusUrl: sinon.stub().returns(locusUrl),
+    isDataChannelTokenEnabled: sinon.stub().resolves(true),
+    on: sinon.stub(),
+    off: sinon.stub(),
+    socket: mockWebSocket,
+  };
+}
+
+/**
+ * Emits a relay event to voiceaService by calling the registered handler
+ * @param {Object} voiceaService - The voicea service instance
+ * @param {Object} mockChannel - The mock channel that has the handler registered
+ * @param {Object} eventData - The event data to emit
+ */
+function emitRelayEvent(voiceaService, mockChannel, eventData) {
+  const handler = mockChannel.on.getCalls().find(call => call.args[0] === 'event:relay.event')?.args[1];
+  if (handler) {
+    handler({sequenceNumber: 1, ...eventData});
+  }
+}
 
 describe('plugin-voicea', () => {
   const locusUrl = 'locusUrl';
 
   describe('voicea', () => {
-    let webex, voiceaService;
+    let webex, voiceaService, mockChannel;
 
     beforeEach(() => {
       webex = new MockWebex({
@@ -30,10 +63,10 @@ describe('plugin-voicea', () => {
 
       voiceaService = webex.internal.voicea;
       voiceaService.connect = sinon.stub().resolves(true);
-      voiceaService.webex.internal.llm.isConnected = sinon.stub().returns(true);
-      voiceaService.webex.internal.llm.getBinding = sinon.stub().returns(undefined);
-      voiceaService.webex.internal.llm.getSocket = sinon.stub().returns(undefined);
-      voiceaService.webex.internal.llm.getLocusUrl = sinon.stub().returns(locusUrl);
+
+      // Create and register a mock channel
+      mockChannel = createMockChannel({locusUrl});
+      voiceaService.registerChannel(mockChannel, 'default');
 
       voiceaService.request = sinon.stub().resolves({
         headers: {},
@@ -47,6 +80,10 @@ describe('plugin-voicea', () => {
       });
     });
 
+    afterEach(() => {
+      voiceaService.deregisterEvents();
+    });
+
     describe("#constructor", () => {
       it('should init status', () => {
         assert.equal(voiceaService.announceStatus, 'idle');
@@ -56,10 +93,7 @@ describe('plugin-voicea', () => {
 
     describe('#sendAnnouncement', () => {
       beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-        voiceaService.announceStatus = "idle";
+        voiceaService.announceStatus = 'idle';
       });
 
       it("sends announcement if voicea hasn't joined", () => {
@@ -69,7 +103,7 @@ describe('plugin-voicea', () => {
         assert.equal(voiceaService.announceStatus, 'joining');
         assert.calledOnce(spy);
 
-        assert.calledOnceWithExactly(voiceaService.webex.internal.llm.socket.send, {
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -85,28 +119,27 @@ describe('plugin-voicea', () => {
         });
       });
 
-      it('listens to events once', () => {
-        const spy = sinon.spy(webex.internal.llm, 'on');
+      it('listens to events once via registerChannel', () => {
+        // Channel events are registered when registerChannel is called
+        // The handler should be set up already from beforeEach
+        assert.calledWith(mockChannel.on, 'event:relay.event', sinon.match.func);
 
+        // Calling sendAnnouncement should not register more handlers
+        const callCount = mockChannel.on.callCount;
+        voiceaService.sendAnnouncement();
         voiceaService.sendAnnouncement();
 
-        voiceaService.sendAnnouncement();
-
-        assert.calledTwice(spy);
-        assert.calledWith(spy, 'event:relay.event', sinon.match.func);
-        assert.calledWith(spy, `event:relay.event:${LLM_PRACTICE_SESSION}`, sinon.match.func);
+        // No additional registrations
+        assert.equal(mockChannel.on.callCount, callCount);
       });
 
       it('includes captionServiceId in headers when set', () => {
-        const mockWebSocket = new MockWebSocket();
-
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
         voiceaService.announceStatus = 'idle';
         voiceaService.captionServiceId = 'svc-123';
 
         voiceaService.sendAnnouncement();
 
-        assert.calledOnceWithExactly(voiceaService.webex.internal.llm.socket.send, {
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -125,8 +158,6 @@ describe('plugin-voicea', () => {
 
     describe('#sendManualClosedCaption', () => {
       beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
         voiceaService.seqNum = 1;
       });
 
@@ -138,33 +169,30 @@ describe('plugin-voicea', () => {
 
         voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
 
-        assert.calledOnceWithExactly(
-          voiceaService.webex.internal.llm.socket.send,
-          {
-            id: '1',
-            type: 'publishRequest',
-            recipients: [{route: undefined}],
-            headers: {},
-            data: {
-              eventType: 'relay.event',
-              relayType: 'client.manual_transcription',
-              transcriptPayload: {
-                type: 'manual_caption_interim_result',
-                id: sinon.match.string,
-                transcripts: [
-                  {
-                    text: 'Test interim caption',
-                    start_millis: 1234567890,
-                    end_millis: 1234567890,
-                    csis: [123456],
-                  },
-                ],
-                transcript_id: sinon.match.string,
-              },
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
+          id: '1',
+          type: 'publishRequest',
+          recipients: [{route: undefined}],
+          headers: {},
+          data: {
+            eventType: 'relay.event',
+            relayType: 'client.manual_transcription',
+            transcriptPayload: {
+              type: 'manual_caption_interim_result',
+              id: sinon.match.string,
+              transcripts: [
+                {
+                  text: 'Test interim caption',
+                  start_millis: 1234567890,
+                  end_millis: 1234567890,
+                  csis: [123456],
+                },
+              ],
+              transcript_id: sinon.match.string,
             },
-            trackingId: sinon.match.string,
-          }
-        );
+          },
+          trackingId: sinon.match.string,
+        });
         // seqNum should increment
         assert.equal(voiceaService.seqNum, 2);
       });
@@ -177,39 +205,39 @@ describe('plugin-voicea', () => {
 
         voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
 
-        assert.calledOnceWithExactly(
-          voiceaService.webex.internal.llm.socket.send,
-          {
-            id: '1',
-            type: 'publishRequest',
-            recipients: [{route: undefined}],
-            headers: {},
-            data: {
-              eventType: 'relay.event',
-              relayType: 'client.manual_transcription',
-              transcriptPayload: {
-                type: 'manual_caption_final_result',
-                id: sinon.match.string,
-                transcripts: [
-                  {
-                    text: 'Test final caption',
-                    start_millis: 9876543210,
-                    end_millis: 9876543210,
-                    csis: [654321],
-                  },
-                ],
-                transcript_id: sinon.match.string,
-              },
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
+          id: '1',
+          type: 'publishRequest',
+          recipients: [{route: undefined}],
+          headers: {},
+          data: {
+            eventType: 'relay.event',
+            relayType: 'client.manual_transcription',
+            transcriptPayload: {
+              type: 'manual_caption_final_result',
+              id: sinon.match.string,
+              transcripts: [
+                {
+                  text: 'Test final caption',
+                  start_millis: 9876543210,
+                  end_millis: 9876543210,
+                  csis: [654321],
+                },
+              ],
+              transcript_id: sinon.match.string,
             },
-            trackingId: sinon.match.string,
-          }
-        );
+          },
+          trackingId: sinon.match.string,
+        });
         // seqNum should increment
         assert.equal(voiceaService.seqNum, 2);
       });
 
       it('does not send if not connected', () => {
-        voiceaService.webex.internal.llm.isConnected.returns(false);
+        // Replace the channel with a disconnected one
+        const disconnectedChannel = createMockChannel({isConnected: false});
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedChannel, 'default');
 
         const text = 'Should not send';
         const timeStamp = 111;
@@ -218,24 +246,30 @@ describe('plugin-voicea', () => {
 
         voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
 
-        assert.notCalled(voiceaService.webex.internal.llm.socket.send);
+        assert.notCalled(disconnectedChannel.socket.send);
       });
     });
     describe('#deregisterEvents', () => {
       beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
         voiceaService.keepTranscriptionSubscribed = true;
       });
 
       it('deregisters voicea service and resets caption state', async () => {
-        voiceaService.listenToEvents();
+        // Simulate receiving an event through the registered handler
+        const handler = mockChannel.on
+          .getCalls()
+          .find((call) => call.args[0] === 'event:relay.event')?.args[1];
+
         await voiceaService.toggleTranscribing(true);
 
-        voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.annc', voiceaPayload: {}},
-        });
+        // Call the handler directly to simulate receiving an event
+        if (handler) {
+          handler({
+            sequenceNumber: 1,
+            headers: {from: 'ws'},
+            data: {relayType: 'voicea.annc', voiceaPayload: {}},
+          });
+        }
 
         assert.equal(voiceaService.areCaptionsEnabled, true);
         assert.equal(voiceaService.captionServiceId, 'ws');
@@ -293,16 +327,10 @@ describe('plugin-voicea', () => {
     });
 
     describe('#requestLanguage', () => {
-      beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-      });
-
       it('requests caption language', () => {
         voiceaService.requestLanguage('en');
 
-        assert.calledOnceWithExactly(voiceaService.webex.internal.llm.socket.send, {
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -324,7 +352,7 @@ describe('plugin-voicea', () => {
 
         voiceaService.requestLanguage('fr');
 
-        assert.calledOnceWithExactly(voiceaService.webex.internal.llm.socket.send, {
+        assert.calledOnceWithExactly(mockChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -469,24 +497,27 @@ describe('plugin-voicea', () => {
     });
 
     describe('#isLLMConnected', () => {
-      it('returns true when the default llm connection is connected', () => {
-        voiceaService.webex.internal.llm.isConnected.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION ? false : true
-        );
+      it('returns true when the default channel is connected', () => {
+        // mockChannel is already registered and connected
+        assert.equal(voiceaService.isLLMConnected(), true);
+      });
+
+      it('returns true when only the practice session channel is connected', () => {
+        // Replace default with disconnected, add connected practice session
+        const disconnectedDefault = createMockChannel({isConnected: false});
+        const connectedPractice = createMockChannel({isConnected: true});
+
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedDefault, 'default');
+        voiceaService.registerChannel(connectedPractice, 'practice-session');
 
         assert.equal(voiceaService.isLLMConnected(), true);
       });
 
-      it('returns true when only the practice session llm connection is connected', () => {
-        voiceaService.webex.internal.llm.isConnected.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION
-        );
-
-        assert.equal(voiceaService.isLLMConnected(), true);
-      });
-
-      it('returns false when neither llm connection is connected', () => {
-        voiceaService.webex.internal.llm.isConnected.returns(false);
+      it('returns false when neither channel is connected', () => {
+        const disconnectedChannel = createMockChannel({isConnected: false});
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedChannel, 'default');
 
         assert.equal(voiceaService.isLLMConnected(), false);
       });
@@ -532,15 +563,21 @@ describe('plugin-voicea', () => {
       });
 
       it('announce to llm data channel before llm connected', ()=> {
-        voiceaService.webex.internal.llm.isConnected.returns(false);
+        const disconnectedChannel = createMockChannel({isConnected: false});
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedChannel, 'default');
+
         assert.throws(() =>  voiceaService.announce(), "voicea can not announce before llm connected");
         assert.notCalled(sendAnnouncement);
       });
 
       it('announce to llm data channel when only practice session is connected', ()=> {
-        voiceaService.webex.internal.llm.isConnected.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION
-        );
+        const disconnectedDefault = createMockChannel({isConnected: false});
+        const connectedPractice = createMockChannel({isConnected: true});
+
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedDefault, 'default');
+        voiceaService.registerChannel(connectedPractice, 'practice-session');
 
         voiceaService.announce();
 
@@ -592,7 +629,9 @@ describe('plugin-voicea', () => {
 
       it('throws before turning on captions when llm is not connected', async () => {
         voiceaService.captionStatus = 'idle';
-        voiceaService.webex.internal.llm.isConnected.returns(false);
+        const disconnectedChannel = createMockChannel({isConnected: false});
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedChannel, 'default');
 
         await assert.isRejected(
           voiceaService.turnOnCaptions(),
@@ -602,9 +641,12 @@ describe('plugin-voicea', () => {
       });
 
       it('turns on captions when only the practice session llm connection is connected', () => {
-        voiceaService.webex.internal.llm.isConnected.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION
-        );
+        const disconnectedDefault = createMockChannel({isConnected: false});
+        const connectedPractice = createMockChannel({isConnected: true});
+
+        voiceaService.unregisterChannel('default');
+        voiceaService.registerChannel(disconnectedDefault, 'default');
+        voiceaService.registerChannel(connectedPractice, 'practice-session');
 
         voiceaService.turnOnCaptions();
 

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -992,5 +992,82 @@ describe('plugin-voicea', () => {
         assert.notCalled(spy);
       });
     });
+
+    describe('#switchLLMChannel', () => {
+      it('switches to a new LLM channel and preserves caption state', async () => {
+        // First enable captions
+        voiceaChannel.isCaptionBoxOn = true;
+        voiceaChannel.currentSpokenLanguage = 'es';
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+
+        await voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Should have unsubscribed from old channel
+        assert.calledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
+
+        // Should have subscribed to new channel
+        assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+
+        // Should have reset announcement state to joining (since captions were on and it re-announced)
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'joining');
+
+        // turnOnCaptions sends both an announcement and a subchannel subscription
+        assert.calledTwice(newMockLLMChannel.socket.send);
+
+        // First call should be the announcement
+        assert.calledWithExactly(newMockLLMChannel.socket.send.getCall(0), {
+          id: '1',
+          type: 'publishRequest',
+          recipients: {route: 'binding'},
+          headers: {},
+          data: {
+            clientPayload: {
+              version: 'v2',
+            },
+            eventType: 'relay.event',
+            relayType: 'client.annc',
+          },
+          trackingId: sinon.match.string,
+        });
+      });
+
+      it('does not turn on captions if they were not on before switching', async () => {
+        // Captions are off
+        voiceaChannel.isCaptionBoxOn = false;
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+
+        await voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Should have unsubscribed from old channel
+        assert.calledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
+
+        // Should have subscribed to new channel
+        assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+
+        // Should NOT have sent any messages (no announcement for captions)
+        assert.notCalled(newMockLLMChannel.socket.send);
+
+        // State should be idle since captions weren't re-enabled
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'idle');
+      });
+
+      it('handles case when not previously subscribed to events', async () => {
+        // Create a new channel that hasn't subscribed to events
+        const freshVoiceaChannel = new VoiceaChannel(mockLLMChannel, webex);
+        freshVoiceaChannel.hasSubscribedToEvents = false;
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+
+        await freshVoiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Should NOT have tried to unsubscribe from old channel (wasn't subscribed)
+        assert.neverCalledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
+
+        // Should have subscribed to new channel
+        assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+      });
+    });
   });
 });

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -4,9 +4,8 @@ import MockWebSocket from '@webex/test-helper-mock-web-socket';
 import {assert, expect} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import Mercury from '@webex/internal-plugin-mercury';
-import LLMChannel from '@webex/internal-plugin-llm';
 
-import VoiceaService from '../../../src/index';
+import {VoiceaChannel} from '../../../src/voicea';
 import {EVENT_TRIGGERS, TOGGLE_MANUAL_CAPTION_STATUS} from '../../../src/constants';
 
 /**
@@ -16,14 +15,14 @@ import {EVENT_TRIGGERS, TOGGLE_MANUAL_CAPTION_STATUS} from '../../../src/constan
  * @param {string} [options.locusUrl] - The locus URL
  * @returns {Object} Mock channel
  */
-function createMockChannel(options = {}) {
+function createMockLLMChannel(options = {}) {
   const mockWebSocket = new MockWebSocket();
   const {isConnected = true, locusUrl = 'locusUrl'} = options;
 
   return {
     isConnected: sinon.stub().returns(isConnected),
     getSocket: sinon.stub().returns(mockWebSocket),
-    getBinding: sinon.stub().returns(undefined),
+    getBinding: sinon.stub().returns('binding'),
     getDatachannelUrl: sinon.stub().returns('datachannelUrl'),
     getLocusUrl: sinon.stub().returns(locusUrl),
     isDataChannelTokenEnabled: sinon.stub().resolves(true),
@@ -33,80 +32,53 @@ function createMockChannel(options = {}) {
   };
 }
 
-/**
- * Emits a relay event to voiceaService by calling the registered handler
- * @param {Object} voiceaService - The voicea service instance
- * @param {Object} mockChannel - The mock channel that has the handler registered
- * @param {Object} eventData - The event data to emit
- */
-function emitRelayEvent(voiceaService, mockChannel, eventData) {
-  const handler = mockChannel.on.getCalls().find(call => call.args[0] === 'event:relay.event')?.args[1];
-  if (handler) {
-    handler({sequenceNumber: 1, ...eventData});
-  }
-}
-
 describe('plugin-voicea', () => {
   const locusUrl = 'locusUrl';
 
-  describe('voicea', () => {
-    let webex, voiceaService, mockChannel;
+  describe('VoiceaChannel', () => {
+    let webex, voiceaChannel, mockLLMChannel;
 
     beforeEach(() => {
       webex = new MockWebex({
         children: {
           mercury: Mercury,
-          llm: LLMChannel,
-          voicea: VoiceaService,
         },
       });
 
-      voiceaService = webex.internal.voicea;
-      voiceaService.connect = sinon.stub().resolves(true);
+      mockLLMChannel = createMockLLMChannel({locusUrl});
+      voiceaChannel = new VoiceaChannel(mockLLMChannel, webex);
 
-      // Create and register a mock channel
-      mockChannel = createMockChannel({locusUrl});
-      voiceaService.registerChannel(mockChannel, 'default');
-
-      voiceaService.request = sinon.stub().resolves({
+      webex.request = sinon.stub().resolves({
         headers: {},
         body: '',
-      });
-      voiceaService.register = sinon.stub().resolves({
-        body: {
-          binding: 'binding',
-          webSocketUrl: 'url',
-        },
       });
     });
 
     afterEach(() => {
-      voiceaService.deregisterEvents();
+      voiceaChannel.deregisterEvents();
+      sinon.restore();
     });
 
-    describe("#constructor", () => {
+    describe('#constructor', () => {
       it('should init status', () => {
-        assert.equal(voiceaService.announceStatus, 'idle');
-        assert.equal(voiceaService.captionStatus, 'idle');
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'idle');
+        assert.equal(voiceaChannel.getCaptionStatus(), 'idle');
+      });
+
+      it('should subscribe to relay events', () => {
+        assert.calledWith(mockLLMChannel.on, 'event:relay.event', sinon.match.func);
       });
     });
 
     describe('#sendAnnouncement', () => {
-      beforeEach(async () => {
-        voiceaService.announceStatus = 'idle';
-      });
-
       it("sends announcement if voicea hasn't joined", () => {
-        const spy = sinon.spy(voiceaService, 'listenToEvents');
+        voiceaChannel.sendAnnouncement();
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'joining');
 
-        voiceaService.sendAnnouncement();
-        assert.equal(voiceaService.announceStatus, 'joining');
-        assert.calledOnce(spy);
-
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
-          recipients: [{route: undefined}],
+          recipients: [{route: 'binding'}],
           headers: {},
           data: {
             clientPayload: {
@@ -119,30 +91,15 @@ describe('plugin-voicea', () => {
         });
       });
 
-      it('listens to events once via registerChannel', () => {
-        // Channel events are registered when registerChannel is called
-        // The handler should be set up already from beforeEach
-        assert.calledWith(mockChannel.on, 'event:relay.event', sinon.match.func);
-
-        // Calling sendAnnouncement should not register more handlers
-        const callCount = mockChannel.on.callCount;
-        voiceaService.sendAnnouncement();
-        voiceaService.sendAnnouncement();
-
-        // No additional registrations
-        assert.equal(mockChannel.on.callCount, callCount);
-      });
-
       it('includes captionServiceId in headers when set', () => {
-        voiceaService.announceStatus = 'idle';
-        voiceaService.captionServiceId = 'svc-123';
+        voiceaChannel.captionServiceId = 'svc-123';
 
-        voiceaService.sendAnnouncement();
+        voiceaChannel.sendAnnouncement();
 
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
-          recipients: [{route: undefined}],
+          recipients: [{route: 'binding'}],
           headers: {to: 'svc-123'},
           data: {
             clientPayload: {
@@ -157,22 +114,18 @@ describe('plugin-voicea', () => {
     });
 
     describe('#sendManualClosedCaption', () => {
-      beforeEach(async () => {
-        voiceaService.seqNum = 1;
-      });
-
       it('sends interim manual closed caption when connected', () => {
         const text = 'Test interim caption';
         const timeStamp = 1234567890;
         const csis = [123456];
         const isFinal = false;
 
-        voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
+        voiceaChannel.sendManualClosedCaption(text, timeStamp, csis, isFinal);
 
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
-          recipients: [{route: undefined}],
+          recipients: [{route: 'binding'}],
           headers: {},
           data: {
             eventType: 'relay.event',
@@ -193,8 +146,6 @@ describe('plugin-voicea', () => {
           },
           trackingId: sinon.match.string,
         });
-        // seqNum should increment
-        assert.equal(voiceaService.seqNum, 2);
       });
 
       it('sends final manual closed caption when connected', () => {
@@ -203,12 +154,12 @@ describe('plugin-voicea', () => {
         const csis = [654321];
         const isFinal = true;
 
-        voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
+        voiceaChannel.sendManualClosedCaption(text, timeStamp, csis, isFinal);
 
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
-          recipients: [{route: undefined}],
+          recipients: [{route: 'binding'}],
           headers: {},
           data: {
             eventType: 'relay.event',
@@ -229,108 +180,45 @@ describe('plugin-voicea', () => {
           },
           trackingId: sinon.match.string,
         });
-        // seqNum should increment
-        assert.equal(voiceaService.seqNum, 2);
       });
 
       it('does not send if not connected', () => {
-        // Replace the channel with a disconnected one
-        const disconnectedChannel = createMockChannel({isConnected: false});
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedChannel, 'default');
+        const disconnectedChannel = createMockLLMChannel({isConnected: false});
+        const channel = new VoiceaChannel(disconnectedChannel, webex);
 
-        const text = 'Should not send';
-        const timeStamp = 111;
-        const csis = [1];
-        const isFinal = true;
-
-        voiceaService.sendManualClosedCaption(text, timeStamp, csis, isFinal);
+        channel.sendManualClosedCaption('Should not send', 111, [1], true);
 
         assert.notCalled(disconnectedChannel.socket.send);
       });
     });
+
     describe('#deregisterEvents', () => {
+
       beforeEach(async () => {
-        voiceaService.keepTranscriptionSubscribed = true;
+        voiceaChannel.keepTranscriptionSubscribed = true;
       });
 
-      it('deregisters voicea service and resets caption state', async () => {
-        // Simulate receiving an event through the registered handler
-        const handler = mockChannel.on
-          .getCalls()
-          .find((call) => call.args[0] === 'event:relay.event')?.args[1];
+      it('deregisters voicea channel and resets state', () => {
+        voiceaChannel.areCaptionsEnabled = true;
+        voiceaChannel.captionServiceId = 'ws';
+        voiceaChannel.keepTranscriptionSubscribed = true;
 
-        await voiceaService.toggleTranscribing(true);
+        voiceaChannel.deregisterEvents();
 
-        // Call the handler directly to simulate receiving an event
-        if (handler) {
-          handler({
-            sequenceNumber: 1,
-            headers: {from: 'ws'},
-            data: {relayType: 'voicea.annc', voiceaPayload: {}},
-          });
-        }
-
-        assert.equal(voiceaService.areCaptionsEnabled, true);
-        assert.equal(voiceaService.captionServiceId, 'ws');
-        assert.equal(voiceaService.keepTranscriptionSubscribed, true);
-
-        voiceaService.deregisterEvents();
-        assert.equal(voiceaService.areCaptionsEnabled, false);
-        assert.equal(voiceaService.captionServiceId, undefined);
-        assert.equal(voiceaService.announceStatus, 'idle');
-        assert.equal(voiceaService.captionStatus, 'idle');
-        assert.equal(voiceaService.keepTranscriptionSubscribed, false);
-      });
-    });
-    describe('#processAnnouncementMessage', () => {
-      it('works on non-empty payload', async () => {
-        const voiceaPayload = {
-          translation: {
-            allowed_languages: ['af', 'am'],
-            max_languages: 5,
-          },
-          ASR: {
-            spoken_languages: ['en'],
-          },
-
-          version: 'v2',
-        };
-
-        const spy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
-        voiceaService.listenToEvents();
-        voiceaService.processAnnouncementMessage(voiceaPayload);
-        assert.calledOnceWithExactly(spy, {
-          captionLanguages: ['af', 'am'],
-          spokenLanguages: ['en'],
-          maxLanguages: 5,
-          currentSpokenLanguage: 'en',
-        });
-      });
-
-      it('works on empty payload', async () => {
-        const spy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
-        voiceaService.listenToEvents();
-        voiceaService.currentSpokenLanguage = 'fr';
-        await voiceaService.processAnnouncementMessage({});
-        assert.calledOnceWithExactly(spy, {
-          captionLanguages: [],
-          spokenLanguages: [],
-          maxLanguages: 0,
-          currentSpokenLanguage: 'fr',
-        });
+        assert.equal(voiceaChannel.areCaptionsEnabled, false);
+        assert.equal(voiceaChannel.captionServiceId, undefined);
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'idle');
+        assert.equal(voiceaChannel.getCaptionStatus(), 'idle');
+        assert.equal(voiceaChannel.getIsCaptionBoxOn(), false);
+        assert.calledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
       });
     });
 
     describe('#requestLanguage', () => {
       it('requests caption language', () => {
-        voiceaService.requestLanguage('en');
+        voiceaChannel.requestLanguage('en');
 
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -348,11 +236,11 @@ describe('plugin-voicea', () => {
       });
 
       it('uses captionServiceId as "to" header when set', () => {
-        voiceaService.captionServiceId = 'svc-456';
+        voiceaChannel.captionServiceId = 'svc-456';
 
-        voiceaService.requestLanguage('fr');
+        voiceaChannel.requestLanguage('fr');
 
-        assert.calledOnceWithExactly(mockChannel.socket.send, {
+        assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
           id: '1',
           type: 'publishRequest',
           recipients: [{route: undefined}],
@@ -368,6 +256,15 @@ describe('plugin-voicea', () => {
           trackingId: sinon.match.string,
         });
       });
+
+      it('does not send when not connected', () => {
+        const disconnectedChannel = createMockLLMChannel({isConnected: false});
+        const channel = new VoiceaChannel(disconnectedChannel, webex);
+
+        channel.requestLanguage('en');
+
+        assert.notCalled(disconnectedChannel.socket.send);
+      });
     });
 
     describe('#setSpokenLanguage', () => {
@@ -375,38 +272,33 @@ describe('plugin-voicea', () => {
         const languageCode = 'en';
         const triggerSpy = sinon.spy();
 
-        voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
-        voiceaService.listenToEvents();
-        await voiceaService.setSpokenLanguage(languageCode);
+        voiceaChannel.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
+        await voiceaChannel.setSpokenLanguage(languageCode);
 
         assert.calledOnceWithExactly(triggerSpy, {languageCode});
 
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
             body: {
               transcribe: {
                 spokenLanguage: languageCode,
-              }
+              },
             },
           })
         );
       });
+
       it('sets spoken language with language assignment', async () => {
         const languageCode = 'zh';
         const languageAssignment = 'DEFAULT';
-        const triggerSpy = sinon.spy();
 
-        voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
-        voiceaService.listenToEvents();
-        await voiceaService.setSpokenLanguage(languageCode, languageAssignment);
-
-        assert.calledOnceWithExactly(triggerSpy, {languageCode});
+        await voiceaChannel.setSpokenLanguage(languageCode, languageAssignment);
 
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -414,1211 +306,690 @@ describe('plugin-voicea', () => {
               transcribe: {
                 spokenLanguage: languageCode,
                 languageAssignment,
-              }
+              },
             },
           })
         );
       });
-
-    });
-
-    describe('#requestTurnOnCaptions', () => {
-      beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-        voiceaService.captionStatus = 'idle';
-      });
-
-      afterEach( () => {
-        voiceaService.captionStatus = 'idle';
-      })
-
-      it('turns on captions', async () => {
-        const announcementSpy = sinon.spy(voiceaService, 'announce');
-        const updateSubchannelSubscriptionsAndSyncCaptionStateSpy = sinon.spy(voiceaService, 'updateSubchannelSubscriptionsAndSyncCaptionState');
-
-        const triggerSpy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.CAPTIONS_TURNED_ON, triggerSpy);
-        voiceaService.listenToEvents();
-
-        await voiceaService.requestTurnOnCaptions();
-        assert.equal(voiceaService.captionStatus, 'enabled');
-        sinon.assert.calledWith(
-          voiceaService.request,
-          sinon.match({
-            method: 'PUT',
-            url: `${locusUrl}/controls/`,
-            body: {transcribe: {caption: true}},
-          })
-        );
-
-        assert.calledOnceWithExactly(triggerSpy);
-
-        assert.calledOnce(announcementSpy);
-        assert.calledOnceWithExactly(
-          updateSubchannelSubscriptionsAndSyncCaptionStateSpy,
-          { subscribe: ['transcription'] },
-          true
-        );
-      });
-
-      it("should handle request fail", async () => {
-        voiceaService.captionStatus = 'sending';
-        voiceaService.request = sinon.stub().rejects();
-
-        try {
-          await voiceaService.requestTurnOnCaptions();
-        } catch (error) {
-          expect(error.message).to.include('turn on captions fail');
-          return;
-        }
-        assert.equal(voiceaService.captionStatus, 'idle');
-      });
-    });
-
-    describe("#isAnnounceProcessing", () => {
-      afterEach(() => {
-        voiceaService.announceStatus = 'idle';
-      });
-
-      ['joining', 'joined'].forEach((status) => {
-        it(`should return true when status is ${status}`, () => {
-          voiceaService.announceStatus = status;
-          assert.equal(voiceaService.isAnnounceProcessing(), true);
-        });
-      });
-
-      it('should return false when status is not processing status', () => {
-        voiceaService.announceStatus = 'idle';
-          assert.equal(voiceaService.isAnnounceProcessing(), false);
-      });
     });
 
     describe('#isLLMConnected', () => {
-      it('returns true when the default channel is connected', () => {
-        // mockChannel is already registered and connected
-        assert.equal(voiceaService.isLLMConnected(), true);
+      it('returns true when the LLM channel is connected', () => {
+        assert.equal(voiceaChannel.isLLMConnected(), true);
       });
 
-      it('returns true when only the practice session channel is connected', () => {
-        // Replace default with disconnected, add connected practice session
-        const disconnectedDefault = createMockChannel({isConnected: false});
-        const connectedPractice = createMockChannel({isConnected: true});
-
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedDefault, 'default');
-        voiceaService.registerChannel(connectedPractice, 'practice-session');
-
-        assert.equal(voiceaService.isLLMConnected(), true);
-      });
-
-      it('returns false when neither channel is connected', () => {
-        const disconnectedChannel = createMockChannel({isConnected: false});
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedChannel, 'default');
-
-        assert.equal(voiceaService.isLLMConnected(), false);
+      it('returns false when the LLM channel is not connected', () => {
+        mockLLMChannel.isConnected.returns(false);
+        assert.equal(voiceaChannel.isLLMConnected(), false);
       });
     });
 
     describe('#getKeepTranscriptionSubscribed', () => {
-      beforeEach(() => {
-        voiceaService.keepTranscriptionSubscribed = false;
+      it('returns false when keepTranscriptionSubscribed is false', () => {
+        voiceaChannel.keepTranscriptionSubscribed = false;
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), false);
       });
 
-      it('returns false when captions are disabled', () => {
-        voiceaService.keepTranscriptionSubscribed = false;
-
-        const result = voiceaService.getKeepTranscriptionSubscribed();
-
-        assert.equal(result, false);
-      });
-
-      it('returns true when captions are enabled', () => {
-        voiceaService.keepTranscriptionSubscribed = true;
-
-        const result = voiceaService.getKeepTranscriptionSubscribed();
-
-        assert.equal(result, true);
+      it('returns true when keepTranscriptionSubscribed is true', () => {
+        voiceaChannel.keepTranscriptionSubscribed = true;
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), true);
       });
     });
 
-    describe("#announce", () => {
-      let isAnnounceProcessed, sendAnnouncement;
-      beforeEach(() => {
-        sendAnnouncement = sinon.stub(voiceaService, 'sendAnnouncement');
-        isAnnounceProcessed = sinon.stub(voiceaService, 'isAnnounceProcessed').returns(false)
+    describe('#getIsCaptionBoxOn', () => {
+      it('returns false when isCaptionBoxOn is false', () => {
+        voiceaChannel.isCaptionBoxOn = false;
+        assert.equal(voiceaChannel.getIsCaptionBoxOn(), false);
       });
 
-      afterEach(() => {
-        isAnnounceProcessed.restore();
-        sendAnnouncement.restore();
+      it('returns true when isCaptionBoxOn is true', () => {
+        voiceaChannel.isCaptionBoxOn = true;
+        assert.equal(voiceaChannel.getIsCaptionBoxOn(), true);
       });
-
-      it('announce to llm data channel', ()=> {
-        voiceaService.announce();
-        assert.calledOnce(sendAnnouncement);
-      });
-
-      it('announce to llm data channel before llm connected', ()=> {
-        const disconnectedChannel = createMockChannel({isConnected: false});
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedChannel, 'default');
-
-        assert.throws(() =>  voiceaService.announce(), "voicea can not announce before llm connected");
-        assert.notCalled(sendAnnouncement);
-      });
-
-      it('announce to llm data channel when only practice session is connected', ()=> {
-        const disconnectedDefault = createMockChannel({isConnected: false});
-        const connectedPractice = createMockChannel({isConnected: true});
-
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedDefault, 'default');
-        voiceaService.registerChannel(connectedPractice, 'practice-session');
-
-        voiceaService.announce();
-
-        assert.calledOnce(sendAnnouncement);
-      });
-
-      it('should not announce duplicate', () => {
-        isAnnounceProcessed.returns(true);
-        voiceaService.announce();
-        assert.notCalled(sendAnnouncement);
-      })
     });
 
-    describe("#isCaptionProcessing", () => {
-      afterEach(() => {
-        voiceaService.captionStatus = 'idle';
-      });
-
-      ['sending', 'enabled'].forEach((status) => {
+    describe('#isAnnounceProcessing', () => {
+      ['joining', 'joined'].forEach((status) => {
         it(`should return true when status is ${status}`, () => {
-          voiceaService.captionStatus = status;
-          assert.equal(voiceaService.isCaptionProcessing(), true);
+          voiceaChannel.announceStatus = status;
+          assert.equal(voiceaChannel.isAnnounceProcessing(), true);
         });
       });
 
-      it('should return false when status is not processing status', () => {
-        voiceaService.captionStatus = 'idle';
-          assert.equal(voiceaService.isCaptionProcessing(), false);
+      it('should return false when status is idle', () => {
+        voiceaChannel.announceStatus = 'idle';
+        assert.equal(voiceaChannel.isAnnounceProcessing(), false);
+      });
+    });
+
+    describe('#announce', () => {
+      it('announce to llm data channel', () => {
+        const sendAnnouncementSpy = sinon.spy(voiceaChannel, 'sendAnnouncement');
+        voiceaChannel.announce();
+        assert.calledOnce(sendAnnouncementSpy);
+      });
+
+      it('throws when llm is not connected', () => {
+        mockLLMChannel.isConnected.returns(false);
+        assert.throws(
+          () => voiceaChannel.announce(),
+          'voicea can not announce before llm connected'
+        );
+      });
+
+      it('should not announce duplicate when already processed', () => {
+        voiceaChannel.announceStatus = 'joined';
+        const sendAnnouncementSpy = sinon.spy(voiceaChannel, 'sendAnnouncement');
+        voiceaChannel.announce();
+        assert.notCalled(sendAnnouncementSpy);
+      });
+    });
+
+    describe('#isCaptionProcessing', () => {
+      ['sending', 'enabled'].forEach((status) => {
+        it(`should return true when status is ${status}`, () => {
+          voiceaChannel.captionStatus = status;
+          assert.equal(voiceaChannel.isCaptionProcessing(), true);
+        });
+      });
+
+      it('should return false when status is idle', () => {
+        voiceaChannel.captionStatus = 'idle';
+        assert.equal(voiceaChannel.isCaptionProcessing(), false);
       });
     });
 
     describe('#turnOnCaptions', () => {
-      let requestTurnOnCaptions;
-      beforeEach(() => {
-        requestTurnOnCaptions = sinon.stub(voiceaService, 'requestTurnOnCaptions');
-        voiceaService.captionStatus = 'idle';
+      it('turns on captions', async () => {
+        const announceSpy = sinon.spy(voiceaChannel, 'announce');
+        const triggerSpy = sinon.spy();
+
+        voiceaChannel.on(EVENT_TRIGGERS.CAPTIONS_TURNED_ON, triggerSpy);
+
+        await voiceaChannel.turnOnCaptions();
+
+        assert.equal(voiceaChannel.getCaptionStatus(), 'enabled');
+        assert.calledOnce(announceSpy);
+        assert.calledOnce(triggerSpy);
       });
 
-      afterEach(() => {
-        requestTurnOnCaptions.restore();
-        voiceaService.captionStatus = 'idle';
-      });
-
-      it('call request turn on captions', () => {
-        voiceaService.captionStatus = 'idle';
-        voiceaService.turnOnCaptions();
-        assert.calledOnce(requestTurnOnCaptions);
-      });
-
-      it('throws before turning on captions when llm is not connected', async () => {
-        voiceaService.captionStatus = 'idle';
-        const disconnectedChannel = createMockChannel({isConnected: false});
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedChannel, 'default');
+      it('throws when llm is not connected', async () => {
+        mockLLMChannel.isConnected.returns(false);
 
         await assert.isRejected(
-          voiceaService.turnOnCaptions(),
+          voiceaChannel.turnOnCaptions(),
           'can not turn on captions before llm connected'
         );
-        assert.notCalled(requestTurnOnCaptions);
       });
 
-      it('turns on captions when only the practice session llm connection is connected', () => {
-        const disconnectedDefault = createMockChannel({isConnected: false});
-        const connectedPractice = createMockChannel({isConnected: true});
-
-        voiceaService.unregisterChannel('default');
-        voiceaService.registerChannel(disconnectedDefault, 'default');
-        voiceaService.registerChannel(connectedPractice, 'practice-session');
-
-        voiceaService.turnOnCaptions();
-
-        assert.calledOnce(requestTurnOnCaptions);
+      it('returns undefined when already sending', async () => {
+        voiceaChannel.captionStatus = 'sending';
+        const result = await voiceaChannel.turnOnCaptions();
+        assert.equal(result, undefined);
       });
 
-      it('should not turn on duplicate when processing', () => {
-        voiceaService.captionStatus = 'sending';
-        voiceaService.turnOnCaptions();
-        assert.notCalled(voiceaService.requestTurnOnCaptions);
+      it('throws error on request failure', async () => {
+        webex.request.rejects(new Error('Request failed'));
+
+        await assert.isRejected(voiceaChannel.turnOnCaptions(), 'turn on captions fail');
+      });
+
+      it('resets caption status to idle on error', async () => {
+        webex.request.rejects(new Error('Request failed'));
+
+        try {
+          await voiceaChannel.turnOnCaptions();
+        } catch {
+          // expected
+        }
+
+        assert.equal(voiceaChannel.getCaptionStatus(), 'idle');
       });
     });
 
     describe('#toggleTranscribing', () => {
-      beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
+      it('turns on transcribing', async () => {
+        await voiceaChannel.toggleTranscribing(true);
 
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-      });
-
-      it('turns on transcribing with CC enabled', async () => {
-        // Turn on captions
-        await voiceaService.turnOnCaptions();
-        const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
-
-        // eslint-disable-next-line no-underscore-dangle
-        voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.annc', voiceaPayload: {}},
-        });
-
-        voiceaService.listenToEvents();
-
-        await voiceaService.toggleTranscribing(true);
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
             body: {transcribe: {transcribing: true}},
           })
         );
-
-        assert.notCalled(announcementSpy);
-      });
-
-      it('turns on transcribing with CC disabled', async () => {
-        const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
-
-        voiceaService.listenToEvents();
-
-        await voiceaService.toggleTranscribing(true);
-        sinon.assert.calledWith(
-          voiceaService.request,
-          sinon.match({
-            method: 'PUT',
-            url: `${locusUrl}/controls/`,
-            body: {transcribe: {transcribing: true}},
-          })
-        );
-
-        assert.calledOnce(announcementSpy);
       });
 
       it('turns off transcribing', async () => {
-        await voiceaService.toggleTranscribing(true);
+        await voiceaChannel.toggleTranscribing(false);
 
-        const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
-
-        voiceaService.listenToEvents();
-
-        await voiceaService.toggleTranscribing(false);
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
-            body: {transcribe: {transcribing: true}},
+            body: {transcribe: {transcribing: false}},
           })
         );
+      });
 
-        assert.notCalled(announcementSpy);
+      it('calls turnOnCaptions when activating and captions not enabled', async () => {
+        voiceaChannel.areCaptionsEnabled = false;
+        const turnOnCaptionsSpy = sinon.spy(voiceaChannel, 'turnOnCaptions');
+
+        await voiceaChannel.toggleTranscribing(true, 'en');
+
+        assert.calledOnceWithExactly(turnOnCaptionsSpy, 'en');
+      });
+
+      it('does not call turnOnCaptions when captions already enabled', async () => {
+        voiceaChannel.areCaptionsEnabled = true;
+        const turnOnCaptionsSpy = sinon.spy(voiceaChannel, 'turnOnCaptions');
+
+        await voiceaChannel.toggleTranscribing(true);
+
+        assert.notCalled(turnOnCaptionsSpy);
       });
     });
 
     describe('#toggleManualCaption', () => {
-      beforeEach(async () => {
-        const mockWebSocket = new MockWebSocket();
-
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-        voiceaService.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.IDLE;
-      });
-
       it('turns on manual caption', async () => {
-        await voiceaService.toggleManualCaption(true);
+        await voiceaChannel.toggleManualCaption(true);
+
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
             body: {manualCaption: {enable: true}},
           })
         );
-
       });
 
-
       it('turns off manual caption', async () => {
-        await voiceaService.toggleManualCaption(false);
+        await voiceaChannel.toggleManualCaption(false);
+
         sinon.assert.calledWith(
-          voiceaService.request,
+          webex.request,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
             body: {manualCaption: {enable: false}},
           })
         );
-
       });
 
-      it('ignore toggle manual caption', async () => {
-        voiceaService.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.SENDING;
-        await voiceaService.toggleManualCaption(true);
-
-        sinon.assert.notCalled(voiceaService.request);
-
-      });
-    });
-
-    describe('#processCaptionLanguageResponse', () => {
-      it('responds to process caption language', async () => {
-        const triggerSpy = sinon.spy();
-        const functionSpy = sinon.spy(voiceaService, 'processCaptionLanguageResponse');
-
-        voiceaService.on(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, triggerSpy);
-        voiceaService.listenToEvents();
-
-        // eslint-disable-next-line no-underscore-dangle
-        voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {
-            relayType: 'voicea.transl.rsp',
-            voiceaPayload: {
-              statusCode: 200,
-            },
-          },
-        });
-
-        assert.calledOnceWithExactly(triggerSpy, {statusCode: 200});
-        assert.calledOnce(functionSpy);
+      it('ignores when already sending', async () => {
+        voiceaChannel.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.SENDING;
+        await voiceaChannel.toggleManualCaption(true);
+        sinon.assert.notCalled(webex.request);
       });
 
-      it('responds to process caption language for a failed response', async () => {
-        const triggerSpy = sinon.spy();
-        const functionSpy = sinon.spy(voiceaService, 'processCaptionLanguageResponse');
+      it('throws error on request failure', async () => {
+        webex.request.rejects(new Error('Request failed'));
 
-        voiceaService.on(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, triggerSpy);
-        voiceaService.listenToEvents();
+        await assert.isRejected(
+          voiceaChannel.toggleManualCaption(true),
+          'toggle manual captions fail'
+        );
+      });
 
-        const payload = {
-          errorCode: 300,
-          message: 'error text',
-        };
+      it('resets status to idle on error', async () => {
+        webex.request.rejects(new Error('Request failed'));
 
-        // eslint-disable-next-line no-underscore-dangle
-        voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transl.rsp', voiceaPayload: payload},
-        });
-        assert.calledOnce(functionSpy);
-        assert.calledOnceWithExactly(triggerSpy, {statusCode: 300, errorMessage: 'error text'});
+        try {
+          await voiceaChannel.toggleManualCaption(true);
+        } catch {
+          // expected
+        }
+
+        assert.equal(voiceaChannel.toggleManualCaptionStatus, TOGGLE_MANUAL_CAPTION_STATUS.IDLE);
       });
     });
 
-    describe('#processTranscription', () => {
-      let triggerSpy, functionSpy;
-
-      beforeEach(() => {
-        triggerSpy = sinon.spy();
-        functionSpy = sinon.spy(voiceaService, 'processTranscription');
-        voiceaService.listenToEvents();
-      });
-
-      it('processes interim transcription', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_CAPTION, triggerSpy);
-        const transcripts = [
-          {
-            text: 'Hello.',
-            csis: [3556942592],
-            transcript_language_code: 'en',
-            translations: {
-              fr: 'Bonjour.',
-            },
-          },
-          {
-            text: 'This is Webex',
-            csis: [3556942593],
-            transcript_language_code: 'en',
-            translations: {
-              fr: "C'est Webex",
-            },
-          },
-        ];
-        const voiceaPayload = {
-          audio_received_millis: 0,
-          command_response: '',
-          csis: [3556942592],
-          data: 'Hello.',
-          id: '38093ff5-f6a8-581c-9e59-035ec027994b',
-          meeting: '61d4e269-8419-42ab-9e56-3917974cda01',
-          transcript_id: '3ec73890-bffb-f28b-e77f-99dc13caea7e',
-          ts: 1611653204.3147924,
-          type: 'transcript_interim_results',
-
-          transcripts,
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: false,
-          transcriptId: '3ec73890-bffb-f28b-e77f-99dc13caea7e',
-          transcripts,
-        });
-      });
-
-      it('processes final transcription', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_CAPTION, triggerSpy);
-
-        const voiceaPayload = {
-          audio_received_millis: 0,
-          command_response: '',
-          csis: [3556942592],
-          data: 'Hello. This is Webex',
-          id: '38093ff5-f6a8-581c-9e59-035ec027994b',
-          meeting: '61d4e269-8419-42ab-9e56-3917974cda01',
-          transcript_id: '3ec73890-bffb-f28b-e77f-99dc13caea7e',
-          ts: 1611653204.3147924,
-          type: 'transcript_final_result',
-          translations: {
-            en: "Hello?",
-          },
-          transcript: {
-            alignments: [
-              {
-                end_millis: 12474,
-                start_millis: 12204,
-                word: 'Hello?',
-              },
-            ],
-            csis: [3556942592],
-            end_millis: 13044,
-            last_packet_timestamp_ms: 1611653206784,
-            start_millis: 12204,
-            text: 'Hello?',
-            transcript_language_code: 'en',
-            timestamp: '0:13'
-          },
-          transcripts: [
-            {
-              start_millis: 12204,
-              end_millis: 13044,
-              text: 'Hello.',
-              csis: [3556942592],
-              transcript_language_code: 'en',
-              translations: {
-                fr: 'Bonjour.',
-              },
-              timestamp: '0:13'
-            },
-            {
-              start_millis: 12204,
-              end_millis: 13044,
-              text: 'This is Webex',
-              csis: [3556942593],
-              transcript_language_code: 'en',
-              translations: {
-                fr: "C'est Webex",
-              },
-              timestamp: '0:13'
-            },
-          ],
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: true,
-          transcriptId: '3ec73890-bffb-f28b-e77f-99dc13caea7e',
-          transcripts: voiceaPayload.transcripts,
-        });
-      });
-
-      it('processes a eva wake up', async () => {
-        voiceaService.on(EVENT_TRIGGERS.EVA_COMMAND, triggerSpy);
-
-        const voiceaPayload = {
-          audio_received_millis: 1616137504810,
-          command_response: '',
-          id: '31fb2f81-fb55-4257-32a0-f421ef8ba4b0',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          trigger: {
-            detected_at: '2021-03-19T07:05:04.810669662Z',
-            ews_confidence: 0.99497044086456299,
-            ews_keyphrase: 'OkayWebEx',
-            model_version: 'WebEx',
-            offset_seconds: 2336.5900000000001,
-            recording_file_name:
-              'OkayWebEx_fd5bd0fc-06fb-4fd1-982b-554c4368f101_47900f3f-8579-25eb-3f6a-74d81a3c66a4_2335.8900000000003_2336.79.raw',
-            type: 'live-hotword',
-          },
-          ts: 1616137504.8107769,
-          type: 'eva_wake',
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-          isListening: true,
-        });
-      });
-
-      it('processes a eva thanks', async () => {
-        voiceaService.on(EVENT_TRIGGERS.EVA_COMMAND, triggerSpy);
-
-        const voiceaPayload = {
-          audio_received_millis: 0,
-          command_response: 'OK! Decision created.',
-          id: '9bc51440-1a22-7c81-6add-4b6ff7b59f7c',
-          intent: 'decision',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          ts: 1616135828.2552843,
-          type: 'eva_thanks',
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-          isListening: false,
-          text: 'OK! Decision created.',
-        });
-      });
-
-      it('processes a eva cancel', async () => {
-        voiceaService.on(EVENT_TRIGGERS.EVA_COMMAND, triggerSpy);
-
-        const voiceaPayload = {
-          audio_received_millis: 0,
-          command_response: '',
-          id: '9bc51440-1a22-7c81-6add-4b6ff7b59f7c',
-          intent: 'decision',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          ts: 1616135828.2552843,
-          type: 'eva_cancel',
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-
-        assert.calledOnceWithExactly(triggerSpy, {
-          isListening: false,
-        });
-      });
-
-      it('processes a highlight', async () => {
-        voiceaService.on(EVENT_TRIGGERS.HIGHLIGHT_CREATED, triggerSpy);
-        const voiceaPayload = {
-          audio_received_millis: 0,
-          command_response: '',
-          highlight: {
-            created_by_email: '',
-            csis: [3932881920],
-            end_millis: 660160,
-            highlight_id: '219af4b1-1579-5106-53ab-f621094a0c5a',
-            highlight_label: 'Decision',
-            highlight_source: 'voice-command',
-            start_millis: 652756,
-            transcript: 'Create a decision to move ahead with the last proposal.',
-            trigger_info: {type: 'live-hotword'},
-          },
-          id: 'e6df0262-6289-db2e-581a-d44bb41b1c9c',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          ts: 1616135858.5349569,
-          type: 'highlight_created',
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-          csis: [3932881920],
-          highlightId: '219af4b1-1579-5106-53ab-f621094a0c5a',
-          text: 'Create a decision to move ahead with the last proposal.',
-          highlightLabel: 'Decision',
-          highlightSource: 'voice-command',
-          timestamp: '11:00',
-        });
-      });
-
-      it('processes a language detected if language is in spoken languages', async () => {
-        voiceaService.on(EVENT_TRIGGERS.LANGUAGE_DETECTED, triggerSpy);
-
-        const voiceaPayload = {
-          id: '9bc51440-1a22-7c81-6add-4b6ff7b59f7c',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          type: 'language_detected',
-          language: 'en',
-          translation: {
-            allowed_languages: ['af', 'am'],
-            max_languages: 5,
-          },
-          ASR: {
-            spoken_languages: ['en', 'pl'],
-          },
-
-          version: 'v2',
-        };
-
-          const spy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
-        voiceaService.listenToEvents();
-        voiceaService.processAnnouncementMessage(voiceaPayload);
-
-          // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-        assert.calledOnceWithExactly(triggerSpy, {
-            languageCode: 'en',
-        });
-      });
-
-    });
-
-    describe('#processManualTranscription', () => {
-      let triggerSpy, functionSpy;
-
-      beforeEach(() => {
-        triggerSpy = sinon.spy();
-        functionSpy = sinon.spy(voiceaService, 'processManualTranscription');
-        voiceaService.listenToEvents();
-      });
-
-      it('processes interim manual transcription from aibridge', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, triggerSpy);
-
-        const transcriptPayload = {
-          id: "747d711d-3414-fd69-7081-e842649f2d28",
-          transcripts: [
-            {
-              text: "Good",
-            }
-          ],
-          type: "manual_caption_interim_result",
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'aibridge.manual_transcription', transcriptPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, {...transcriptPayload, sender: 'ws', data_source: 'aibridge.manual_transcription'});
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: false,
-          transcriptId: '747d711d-3414-fd69-7081-e842649f2d28',
-          transcripts: transcriptPayload.transcripts,
-          sender: 'ws',
-          source: 'aibridge.manual_transcription'
-        });
-      });
-
-      it('processes final manual transcription from aibridge', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, triggerSpy);
-
-        const transcriptPayload = {
-          id: "8d226d31-044a-8d11-cc39-cedbde183154",
-          transcripts: [
-            {
-              text: "Good Morning",
-              start_millis: 10420,
-              end_millis: 11380,
-            }
-          ],
-          type: "manual_caption_final_result",
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'aibridge.manual_transcription', transcriptPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, {...transcriptPayload, sender: 'ws', data_source: 'aibridge.manual_transcription'});
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: true,
-          transcriptId: '8d226d31-044a-8d11-cc39-cedbde183154',
-          transcripts: transcriptPayload.transcripts,
-          sender: 'ws',
-          source: 'aibridge.manual_transcription'
-        });
-      });
-
-      it('processes interim manual transcription from captioner', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, triggerSpy);
-
-        const transcriptPayload = {
-          id: "747d711d-3414-fd69-7081-e842649f2d28",
-          transcripts: [
-            {
-              text: "Good",
-            }
-          ],
-          type: "manual_caption_interim_result",
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: '654321'},
-          data: {relayType: 'client.manual_transcription', transcriptPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, {...transcriptPayload, sender: '654321', data_source: 'client.manual_transcription'});
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: false,
-          transcriptId: '747d711d-3414-fd69-7081-e842649f2d28',
-          transcripts: transcriptPayload.transcripts,
-          sender: '654321',
-          source: 'client.manual_transcription'
-        });
-      });
-
-      it('processes final manual transcription from captioner', async () => {
-        voiceaService.on(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, triggerSpy);
-
-        const transcriptPayload = {
-          id: "8d226d31-044a-8d11-cc39-cedbde183154",
-          transcripts: [
-            {
-              text: "Good Morning",
-              start_millis: 10420,
-              end_millis: 11380,
-            }
-          ],
-          type: "manual_caption_final_result",
-        };
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: '654321'},
-          data: {relayType: 'client.manual_transcription', transcriptPayload},
-        });
-
-        assert.calledOnceWithExactly(functionSpy, {...transcriptPayload, sender: '654321', data_source: 'client.manual_transcription'});
-        assert.calledOnceWithExactly(triggerSpy, {
-          isFinal: true,
-          transcriptId: '8d226d31-044a-8d11-cc39-cedbde183154',
-          transcripts: transcriptPayload.transcripts,
-          sender: '654321',
-          source: 'client.manual_transcription'
-        });
+    describe('#getCaptionStatus', () => {
+      it('returns current caption status', () => {
+        voiceaChannel.captionStatus = 'enabled';
+        assert.equal(voiceaChannel.getCaptionStatus(), 'enabled');
       });
     });
 
-    describe("#getCaptionStatus", () => {
-      it('works correctly', () => {
-        voiceaService.captionStatus = "enabled"
-        assert.equal(voiceaService.getCaptionStatus(), "enabled");
-      });
-    });
-
-    describe("#getAnnounceStatus", () => {
-      it('works correctly', () => {
-        voiceaService.announceStatus = "joined"
-        assert.equal(voiceaService.getAnnounceStatus(), "joined");
+    describe('#getAnnounceStatus', () => {
+      it('returns current announce status', () => {
+        voiceaChannel.announceStatus = 'joined';
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'joined');
       });
     });
 
     describe('#onSpokenLanguageUpdate', () => {
-      it('should trigger SPOKEN_LANGUAGE_UPDATE event with correct languageCode', () => {
+      it('should trigger SPOKEN_LANGUAGE_UPDATE event', () => {
         const triggerSpy = sinon.spy();
-        voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
+        voiceaChannel.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
 
-        const languageCode = 'fr';
-        voiceaService.onSpokenLanguageUpdate(languageCode, '123');
-        assert.equal(voiceaService.currentSpokenLanguage, languageCode);
-        assert.calledOnceWithExactly(triggerSpy, {languageCode, meetingId: '123'});
+        voiceaChannel.onSpokenLanguageUpdate('fr', '123');
+
+        assert.equal(voiceaChannel.currentSpokenLanguage, 'fr');
+        assert.calledOnceWithExactly(triggerSpy, {languageCode: 'fr', meetingId: '123'});
       });
     });
 
     describe('#onCaptionServiceIdUpdate', () => {
-      let mockWebSocket;
-
-      beforeEach(() => {
-        mockWebSocket = new MockWebSocket();
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
-        voiceaService.webex.internal.llm.isConnected.returns(true);
-        voiceaService.seqNum = 1;
-      });
-
       it('does nothing when serviceId is falsy', () => {
-        voiceaService.captionServiceId = 'existing-id';
-        voiceaService.currentCaptionLanguage = 'en';
-
-        voiceaService.onCaptionServiceIdUpdate(undefined);
-        voiceaService.onCaptionServiceIdUpdate('');
-
-        assert.equal(voiceaService.captionServiceId, 'existing-id');
-        assert.notCalled(voiceaService.webex.internal.llm.socket.send);
+        voiceaChannel.captionServiceId = 'existing-id';
+        voiceaChannel.onCaptionServiceIdUpdate(undefined);
+        voiceaChannel.onCaptionServiceIdUpdate('');
+        assert.equal(voiceaChannel.captionServiceId, 'existing-id');
       });
 
       it('sets captionServiceId when no currentCaptionLanguage', () => {
-        voiceaService.captionServiceId = undefined;
-        voiceaService.currentCaptionLanguage = undefined;
-
-        voiceaService.onCaptionServiceIdUpdate('svc-new');
-
-        assert.equal(voiceaService.captionServiceId, 'svc-new');
-        assert.notCalled(voiceaService.webex.internal.llm.socket.send);
+        voiceaChannel.captionServiceId = undefined;
+        voiceaChannel.currentCaptionLanguage = undefined;
+        voiceaChannel.onCaptionServiceIdUpdate('svc-new');
+        assert.equal(voiceaChannel.captionServiceId, 'svc-new');
       });
 
       it('re-sends language when serviceId changes and currentCaptionLanguage is set', () => {
-        voiceaService.captionServiceId = 'old-svc';
-        voiceaService.currentCaptionLanguage = 'es';
+        voiceaChannel.captionServiceId = 'old-svc';
+        voiceaChannel.currentCaptionLanguage = 'es';
 
-        voiceaService.onCaptionServiceIdUpdate('new-svc');
+        voiceaChannel.onCaptionServiceIdUpdate('new-svc');
 
-        assert.equal(voiceaService.captionServiceId, 'new-svc');
-        assert.calledOnce(voiceaService.webex.internal.llm.socket.send);
-
-        const callArgs = voiceaService.webex.internal.llm.socket.send.getCall(0).args[0];
-        expect(callArgs).to.have.nested.property('headers.to', 'new-svc');
-        expect(callArgs).to.have.nested.property('data.clientPayload.translationLanguage', 'es');
-      });
-
-      it('does not re-send language when serviceId is unchanged', () => {
-        voiceaService.captionServiceId = 'same-svc';
-        voiceaService.currentCaptionLanguage = 'de';
-
-        voiceaService.onCaptionServiceIdUpdate('same-svc');
-
-        assert.equal(voiceaService.captionServiceId, 'same-svc');
-        assert.notCalled(voiceaService.webex.internal.llm.socket.send);
+        assert.equal(voiceaChannel.captionServiceId, 'new-svc');
+        assert.calledOnce(mockLLMChannel.socket.send);
       });
     });
 
     describe('#updateSubchannelSubscriptions', () => {
-      beforeEach(() => {
-        const mockWebSocket = new MockWebSocket();
-
-        sinon.stub(voiceaService, 'getPublishTransport').returns({
-          socket: mockWebSocket,
-          datachannelUrl: 'mock-datachannel-uri',
-        });
-
-        voiceaService.seqNum = 1;
-
-        voiceaService.isLLMConnected = sinon.stub().returns(true);
-        voiceaService.webex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(true);
-      });
-
-      it('sends subchannelSubscriptionRequest with subscribe and unsubscribe lists', async () => {
-        await voiceaService.updateSubchannelSubscriptions({
+      it('sends subchannelSubscriptionRequest', async () => {
+        await voiceaChannel.updateSubchannelSubscriptions({
           subscribe: ['transcription'],
           unsubscribe: ['polls'],
         });
 
-        const socket = voiceaService.getPublishTransport().socket;
-
-        sinon.assert.calledOnceWithExactly(
-          socket.send,
-          {
-            id: '1',
-            type: 'subchannelSubscriptionRequest',
-            data: {
-              datachannelUri: 'mock-datachannel-uri',
-              subscribe: ['transcription'],
-              unsubscribe: ['polls'],
-            },
-            trackingId: sinon.match.string,
-          }
-        );
-
-        sinon.assert.match(voiceaService.seqNum, 2);
-      });
-
-      it('sends empty arrays when no subscribe/unsubscribe provided', async () => {
-        await voiceaService.updateSubchannelSubscriptions({});
-
-        const socket = voiceaService.getPublishTransport().socket;
-
-        sinon.assert.calledOnceWithExactly(
-          socket.send,
-          {
-            id: '1',
-            type: 'subchannelSubscriptionRequest',
-            data: {
-              datachannelUri: 'mock-datachannel-uri',
-              subscribe: [],
-              unsubscribe: [],
-            },
-            trackingId: sinon.match.string,
-          }
-        );
-
-        sinon.assert.match(voiceaService.seqNum, 2);
+        sinon.assert.calledOnceWithExactly(mockLLMChannel.socket.send, {
+          id: '1',
+          type: 'subchannelSubscriptionRequest',
+          data: {
+            datachannelUri: 'datachannelUrl',
+            subscribe: ['transcription'],
+            unsubscribe: ['polls'],
+          },
+          trackingId: sinon.match.string,
+        });
       });
 
       it('does nothing when LLM is not connected', async () => {
-        voiceaService.isLLMConnected = sinon.stub().returns(false);
+        mockLLMChannel.isConnected.returns(false);
 
-        await voiceaService.updateSubchannelSubscriptions({
-          subscribe: ['transcription'],
-        });
+        await voiceaChannel.updateSubchannelSubscriptions({subscribe: ['transcription']});
 
-        const socket = voiceaService.getPublishTransport().socket;
-
-        sinon.assert.notCalled(socket.send);
-        sinon.assert.match(voiceaService.seqNum, 1);
+        sinon.assert.notCalled(mockLLMChannel.socket.send);
       });
 
       it('does nothing when dataChannelToken is not enabled', async () => {
-        voiceaService.webex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(false);
+        mockLLMChannel.isDataChannelTokenEnabled.resolves(false);
 
-        await voiceaService.updateSubchannelSubscriptions({
-          subscribe: ['transcription'],
-        });
+        await voiceaChannel.updateSubchannelSubscriptions({subscribe: ['transcription']});
 
-        const socket = voiceaService.getPublishTransport().socket;
-
-        sinon.assert.notCalled(socket.send);
-        sinon.assert.match(voiceaService.seqNum, 1);
+        sinon.assert.notCalled(mockLLMChannel.socket.send);
       });
     });
 
-
     describe('#updateSubchannelSubscriptionsAndSyncCaptionState', () => {
-      beforeEach(() => {
-        const mockWebSocket = new MockWebSocket();
-        voiceaService.webex.internal.llm.socket = mockWebSocket;
+      it('updates caption intent and forwards to updateSubchannelSubscriptions', async () => {
+        const updateSpy = sinon.spy(voiceaChannel, 'updateSubchannelSubscriptions');
 
-        voiceaService.webex.internal.llm.getDatachannelUrl = sinon.stub().returns('mock-datachannel-uri');
-
-        voiceaService.seqNum = 1;
-
-        voiceaService.isLLMConnected = sinon.stub().returns(true);
-        voiceaService.webex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(true);
-
-        sinon.spy(voiceaService, 'updateSubchannelSubscriptions');
-      });
-
-      afterEach(() => {
-        sinon.restore();
-      });
-
-      it('updates caption intent and forwards subscribe/unsubscribe to updateSubchannelSubscriptions', async () => {
-        await voiceaService.updateSubchannelSubscriptionsAndSyncCaptionState(
-          {
-            subscribe: ['transcription'],
-            unsubscribe: ['polls'],
-          },
+        await voiceaChannel.updateSubchannelSubscriptionsAndSyncCaptionState(
+          {subscribe: ['transcription']},
           true
         );
 
-        assert.equal(voiceaService.keepTranscriptionSubscribed, true);
-
-        assert.calledOnceWithExactly(
-          voiceaService.updateSubchannelSubscriptions,
-          {
-            subscribe: ['transcription'],
-            unsubscribe: ['polls'],
-          }
-        );
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), true);
+        assert.calledOnceWithExactly(updateSpy, {subscribe: ['transcription']});
       });
 
       it('sets caption intent to false when isCCBoxOpen is false', async () => {
-        await voiceaService.updateSubchannelSubscriptionsAndSyncCaptionState(
-          { subscribe: ['transcription'] },
+        const updateSpy = sinon.spy(voiceaChannel, 'updateSubchannelSubscriptions');
+
+        await voiceaChannel.updateSubchannelSubscriptionsAndSyncCaptionState(
+          {subscribe: ['transcription']},
           false
         );
 
-        assert.equal(voiceaService.keepTranscriptionSubscribed, false);
-
-        assert.calledOnceWithExactly(
-          voiceaService.updateSubchannelSubscriptions,
-          { subscribe: ['transcription'] }
-        );
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), false);
+        assert.calledOnceWithExactly(updateSpy, {subscribe: ['transcription']});
       });
 
       it('defaults subscribe/unsubscribe to empty arrays when options is empty', async () => {
-        await voiceaService.updateSubchannelSubscriptionsAndSyncCaptionState({}, true);
+        const updateSpy = sinon.spy(voiceaChannel, 'updateSubchannelSubscriptions');
 
-        assert.equal(voiceaService.keepTranscriptionSubscribed, true);
+        await voiceaChannel.updateSubchannelSubscriptionsAndSyncCaptionState({}, true);
 
-        assert.calledOnceWithExactly(
-          voiceaService.updateSubchannelSubscriptions,
-          {}
-        );
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), true);
+        assert.calledOnceWithExactly(updateSpy, {});
       });
 
       it('still updates caption intent even if updateSubchannelSubscriptions does nothing (e.g., LLM not connected)', async () => {
-        voiceaService.isLLMConnected = sinon.stub().returns(false);
+        mockLLMChannel.isConnected.returns(false);
+        const updateSpy = sinon.spy(voiceaChannel, 'updateSubchannelSubscriptions');
 
-        await voiceaService.updateSubchannelSubscriptionsAndSyncCaptionState(
-          { subscribe: ['transcription'] },
+        await voiceaChannel.updateSubchannelSubscriptionsAndSyncCaptionState(
+          {subscribe: ['transcription']},
           true
         );
 
-        assert.equal(voiceaService.keepTranscriptionSubscribed, true);
-
-        assert.calledOnceWithExactly(
-          voiceaService.updateSubchannelSubscriptions,
-          { subscribe: ['transcription'] }
-        );
+        assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), true);
+        assert.calledOnceWithExactly(updateSpy, {subscribe: ['transcription']});
       });
     });
 
-    describe('#multiple llm connections', () => {
-      let defaultSocket;
-      let practiceSocket;
-      let isPracticeSessionConnected;
+    describe('#isAnnounceProcessed', () => {
+      it('returns true when status is joined', () => {
+        voiceaChannel.announceStatus = 'joined';
+        assert.equal(voiceaChannel.isAnnounceProcessed(), true);
+      });
+
+      it('returns false when status is idle', () => {
+        voiceaChannel.announceStatus = 'idle';
+        assert.equal(voiceaChannel.isAnnounceProcessed(), false);
+      });
+
+      it('returns false when status is joining', () => {
+        voiceaChannel.announceStatus = 'joining';
+        assert.equal(voiceaChannel.isAnnounceProcessed(), false);
+      });
+    });
+
+    describe('event processor', () => {
+      let eventHandler;
 
       beforeEach(() => {
-        defaultSocket = new MockWebSocket();
-        practiceSocket = new MockWebSocket();
-        isPracticeSessionConnected = true;
-
-        voiceaService.webex.internal.llm.socket = defaultSocket;
-        voiceaService.webex.internal.llm.isConnected.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION ? isPracticeSessionConnected : true
-        );
-        voiceaService.webex.internal.llm.getSocket.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION ? practiceSocket : undefined
-        );
-        voiceaService.webex.internal.llm.getBinding.callsFake((channel) =>
-          channel === LLM_PRACTICE_SESSION ? 'practice-binding' : 'default-binding'
-        );
-        voiceaService.seqNum = 1;
+        // Get the registered event handler
+        const onCall = mockLLMChannel.on
+          .getCalls()
+          .find((call) => call.args[0] === 'event:relay.event');
+        eventHandler = onCall?.args[1];
       });
 
-      it('sendAnnouncement uses the practice session socket and binding when available', () => {
-        voiceaService.announceStatus = 'idle';
+      it('processes voicea announcement events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
 
-        voiceaService.sendAnnouncement();
-
-        assert.calledOnce(practiceSocket.send);
-        assert.notCalled(defaultSocket.send);
-
-        const sent = practiceSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'practice-binding');
-      });
-
-      it('sendAnnouncement falls back to the default socket and binding when the practice session is not connected', () => {
-        voiceaService.announceStatus = 'idle';
-        isPracticeSessionConnected = false;
-
-        voiceaService.sendAnnouncement();
-
-        assert.calledOnce(defaultSocket.send);
-        assert.notCalled(practiceSocket.send);
-
-        const sent = defaultSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'default-binding');
-      });
-
-      it('requestLanguage uses the practice session socket and binding when available', () => {
-        voiceaService.requestLanguage('fr');
-
-        assert.calledOnce(practiceSocket.send);
-        assert.notCalled(defaultSocket.send);
-
-        const sent = practiceSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'practice-binding');
-        expect(sent).to.have.nested.property('data.clientPayload.translationLanguage', 'fr');
-      });
-
-      it('requestLanguage falls back to the default socket and binding when the practice session is not connected', () => {
-        isPracticeSessionConnected = false;
-
-        voiceaService.requestLanguage('fr');
-
-        assert.calledOnce(defaultSocket.send);
-        assert.notCalled(practiceSocket.send);
-
-        const sent = defaultSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'default-binding');
-        expect(sent).to.have.nested.property('data.clientPayload.translationLanguage', 'fr');
-      });
-
-      it('sendManualClosedCaption uses the practice session socket and binding when available', () => {
-        voiceaService.sendManualClosedCaption('caption', 123, [456], true);
-
-        assert.calledOnce(practiceSocket.send);
-        assert.notCalled(defaultSocket.send);
-
-        const sent = practiceSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'practice-binding');
-        expect(sent).to.have.nested.property(
-          'data.transcriptPayload.type',
-          'manual_caption_final_result'
-        );
-      });
-
-      it('sendManualClosedCaption falls back to the default socket and binding when the practice session is not connected', () => {
-        isPracticeSessionConnected = false;
-
-        voiceaService.sendManualClosedCaption('caption', 123, [456], false);
-
-        assert.calledOnce(defaultSocket.send);
-        assert.notCalled(practiceSocket.send);
-
-        const sent = defaultSocket.send.getCall(0).args[0];
-        expect(sent).to.have.nested.property('recipients[0].route', 'default-binding');
-        expect(sent).to.have.nested.property(
-          'data.transcriptPayload.type',
-          'manual_caption_interim_result'
-        );
-      });
-
-      it('processes relay events from the practice session channel', async () => {
-        const announcementSpy = sinon.spy(voiceaService, 'processAnnouncementMessage');
-
-        voiceaService.listenToEvents();
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit(`event:relay.event:${LLM_PRACTICE_SESSION}`, {
-          headers: {from: 'svc-practice'},
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {from: 'ws-service'},
           data: {
             relayType: 'voicea.annc',
             voiceaPayload: {
-              translation: {allowed_languages: ['en'], max_languages: 1},
+              translation: {allowed_languages: ['en', 'es'], max_languages: 3},
               ASR: {spoken_languages: ['en']},
             },
           },
-          sequenceNumber: 10,
         });
 
-        assert.calledOnce(announcementSpy);
-        assert.equal(voiceaService.captionServiceId, 'svc-practice');
+        assert.equal(voiceaChannel.getAnnounceStatus(), 'joined');
+        assert.calledOnceWithExactly(spy, {
+          captionLanguages: ['en', 'es'],
+          maxLanguages: 3,
+          spokenLanguages: ['en'],
+          currentSpokenLanguage: 'en',
+        });
+      });
+
+      it('processes voicea announcement with empty payload', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {from: 'ws-service'},
+          data: {
+            relayType: 'voicea.annc',
+            voiceaPayload: {},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {
+          captionLanguages: [],
+          maxLanguages: 0,
+          spokenLanguages: [],
+          currentSpokenLanguage: 'en',
+        });
+      });
+
+      it('processes transcription interim results', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.NEW_CAPTION, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {
+              type: 'transcript_interim_results',
+              transcript_id: 'tid-1',
+              transcripts: [{text: 'Hello'}],
+            },
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {
+          isFinal: false,
+          transcriptId: 'tid-1',
+          transcripts: [{text: 'Hello'}],
+        });
+      });
+
+      it('processes transcription final results', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.NEW_CAPTION, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {
+              type: 'transcript_final_result',
+              transcript_id: 'tid-2',
+              transcripts: [{text: 'Hello world', end_millis: 60000}],
+            },
+          },
+        });
+
+        assert.calledOnce(spy);
+        const call = spy.getCall(0);
+        assert.equal(call.args[0].isFinal, true);
+        assert.equal(call.args[0].transcriptId, 'tid-2');
+      });
+
+      it('processes caption language response success', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transl.rsp',
+            voiceaPayload: {statusCode: 200},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {statusCode: 200});
+      });
+
+      it('processes caption language response error', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transl.rsp',
+            voiceaPayload: {statusCode: 400, errorCode: 400, message: 'Bad request'},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {statusCode: 400, errorMessage: 'Bad request'});
+      });
+
+      it('processes manual transcription events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.NEW_MANUAL_CAPTION, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {from: 'user-1'},
+          data: {
+            relayType: 'client.manual_transcription',
+            transcriptPayload: {
+              type: 'manual_caption_final_result',
+              id: 'manual-id',
+              transcripts: [{text: 'Manual caption'}],
+            },
+          },
+        });
+
+        assert.calledOnce(spy);
+        const call = spy.getCall(0);
+        assert.equal(call.args[0].isFinal, true);
+        assert.equal(call.args[0].transcriptId, 'manual-id');
+      });
+
+      it('processes highlight created events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.HIGHLIGHT_CREATED, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {
+              type: 'highlight_created',
+              highlight: {
+                csis: [123],
+                highlight_id: 'h-1',
+                transcript: 'Highlighted text',
+                highlight_label: 'important',
+                highlight_source: 'user',
+                end_millis: 30000,
+              },
+            },
+          },
+        });
+
+        assert.calledOnce(spy);
+      });
+
+      it('processes eva wake events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.EVA_COMMAND, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {type: 'eva_wake'},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {isListening: true});
+      });
+
+      it('processes eva cancel events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.EVA_COMMAND, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {type: 'eva_cancel'},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {isListening: false});
+      });
+
+      it('processes eva thanks events', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.EVA_COMMAND, spy);
+
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {type: 'eva_thanks', command_response: 'OK, noted'},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {isListening: false, text: 'OK, noted'});
+      });
+
+      it('processes language detected when in spoken languages', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.LANGUAGE_DETECTED, spy);
+
+        // First set up spoken languages via announcement
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {from: 'ws-service'},
+          data: {
+            relayType: 'voicea.annc',
+            voiceaPayload: {
+              ASR: {spoken_languages: ['en', 'es', 'fr']},
+            },
+          },
+        });
+
+        // Then emit language detected
+        eventHandler({
+          sequenceNumber: 2,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {type: 'language_detected', language: 'es'},
+          },
+        });
+
+        assert.calledOnceWithExactly(spy, {languageCode: 'es'});
+      });
+
+      it('does not emit language detected when not in spoken languages', () => {
+        const spy = sinon.spy();
+        voiceaChannel.on(EVENT_TRIGGERS.LANGUAGE_DETECTED, spy);
+
+        // First set up spoken languages via announcement
+        eventHandler({
+          sequenceNumber: 1,
+          headers: {from: 'ws-service'},
+          data: {
+            relayType: 'voicea.annc',
+            voiceaPayload: {
+              ASR: {spoken_languages: ['en', 'es']},
+            },
+          },
+        });
+
+        // Then emit language detected for unsupported language
+        eventHandler({
+          sequenceNumber: 2,
+          headers: {},
+          data: {
+            relayType: 'voicea.transcription',
+            voiceaPayload: {type: 'language_detected', language: 'de'},
+          },
+        });
+
+        assert.notCalled(spy);
       });
     });
   });

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -36,7 +36,7 @@ describe('plugin-voicea', () => {
   const locusUrl = 'locusUrl';
 
   describe('VoiceaChannel', () => {
-    let webex, voiceaChannel, mockLLMChannel;
+    let webex, voiceaChannel, mockLLMChannel, requestStub;
 
     beforeEach(() => {
       webex = new MockWebex({
@@ -45,13 +45,13 @@ describe('plugin-voicea', () => {
         },
       });
 
-      mockLLMChannel = createMockLLMChannel({locusUrl});
-      voiceaChannel = new VoiceaChannel(mockLLMChannel, webex);
-
-      webex.request = sinon.stub().resolves({
+      requestStub = sinon.stub().resolves({
         headers: {},
         body: '',
       });
+
+      mockLLMChannel = createMockLLMChannel({locusUrl});
+      voiceaChannel = new VoiceaChannel(mockLLMChannel, requestStub);
     });
 
     afterEach(() => {
@@ -184,7 +184,7 @@ describe('plugin-voicea', () => {
 
       it('does not send if not connected', () => {
         const disconnectedChannel = createMockLLMChannel({isConnected: false});
-        const channel = new VoiceaChannel(disconnectedChannel, webex);
+        const channel = new VoiceaChannel(disconnectedChannel, requestStub);
 
         channel.sendManualClosedCaption('Should not send', 111, [1], true);
 
@@ -259,7 +259,7 @@ describe('plugin-voicea', () => {
 
       it('does not send when not connected', () => {
         const disconnectedChannel = createMockLLMChannel({isConnected: false});
-        const channel = new VoiceaChannel(disconnectedChannel, webex);
+        const channel = new VoiceaChannel(disconnectedChannel, requestStub);
 
         channel.requestLanguage('en');
 
@@ -278,7 +278,7 @@ describe('plugin-voicea', () => {
         assert.calledOnceWithExactly(triggerSpy, {languageCode});
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -298,7 +298,7 @@ describe('plugin-voicea', () => {
         await voiceaChannel.setSpokenLanguage(languageCode, languageAssignment);
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -348,20 +348,6 @@ describe('plugin-voicea', () => {
       });
     });
 
-    describe('#isAnnounceProcessing', () => {
-      ['joining', 'joined'].forEach((status) => {
-        it(`should return true when status is ${status}`, () => {
-          voiceaChannel.announceStatus = status;
-          assert.equal(voiceaChannel.isAnnounceProcessing(), true);
-        });
-      });
-
-      it('should return false when status is idle', () => {
-        voiceaChannel.announceStatus = 'idle';
-        assert.equal(voiceaChannel.isAnnounceProcessing(), false);
-      });
-    });
-
     describe('#announce', () => {
       it('announce to llm data channel', () => {
         const sendAnnouncementSpy = sinon.spy(voiceaChannel, 'sendAnnouncement');
@@ -382,20 +368,6 @@ describe('plugin-voicea', () => {
         const sendAnnouncementSpy = sinon.spy(voiceaChannel, 'sendAnnouncement');
         voiceaChannel.announce();
         assert.notCalled(sendAnnouncementSpy);
-      });
-    });
-
-    describe('#isCaptionProcessing', () => {
-      ['sending', 'enabled'].forEach((status) => {
-        it(`should return true when status is ${status}`, () => {
-          voiceaChannel.captionStatus = status;
-          assert.equal(voiceaChannel.isCaptionProcessing(), true);
-        });
-      });
-
-      it('should return false when status is idle', () => {
-        voiceaChannel.captionStatus = 'idle';
-        assert.equal(voiceaChannel.isCaptionProcessing(), false);
       });
     });
 
@@ -429,13 +401,13 @@ describe('plugin-voicea', () => {
       });
 
       it('throws error on request failure', async () => {
-        webex.request.rejects(new Error('Request failed'));
+        requestStub.rejects(new Error('Request failed'));
 
         await assert.isRejected(voiceaChannel.turnOnCaptions(), 'turn on captions fail');
       });
 
       it('resets caption status to idle on error', async () => {
-        webex.request.rejects(new Error('Request failed'));
+        requestStub.rejects(new Error('Request failed'));
 
         try {
           await voiceaChannel.turnOnCaptions();
@@ -452,7 +424,7 @@ describe('plugin-voicea', () => {
         await voiceaChannel.toggleTranscribing(true);
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -465,7 +437,7 @@ describe('plugin-voicea', () => {
         await voiceaChannel.toggleTranscribing(false);
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -498,7 +470,7 @@ describe('plugin-voicea', () => {
         await voiceaChannel.toggleManualCaption(true);
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -511,7 +483,7 @@ describe('plugin-voicea', () => {
         await voiceaChannel.toggleManualCaption(false);
 
         sinon.assert.calledWith(
-          webex.request,
+          requestStub,
           sinon.match({
             method: 'PUT',
             url: `${locusUrl}/controls/`,
@@ -523,11 +495,11 @@ describe('plugin-voicea', () => {
       it('ignores when already sending', async () => {
         voiceaChannel.toggleManualCaptionStatus = TOGGLE_MANUAL_CAPTION_STATUS.SENDING;
         await voiceaChannel.toggleManualCaption(true);
-        sinon.assert.notCalled(webex.request);
+        sinon.assert.notCalled(requestStub);
       });
 
       it('throws error on request failure', async () => {
-        webex.request.rejects(new Error('Request failed'));
+        requestStub.rejects(new Error('Request failed'));
 
         await assert.isRejected(
           voiceaChannel.toggleManualCaption(true),
@@ -536,7 +508,7 @@ describe('plugin-voicea', () => {
       });
 
       it('resets status to idle on error', async () => {
-        webex.request.rejects(new Error('Request failed'));
+        requestStub.rejects(new Error('Request failed'));
 
         try {
           await voiceaChannel.toggleManualCaption(true);
@@ -681,23 +653,6 @@ describe('plugin-voicea', () => {
 
         assert.equal(voiceaChannel.getKeepTranscriptionSubscribed(), true);
         assert.calledOnceWithExactly(updateSpy, {subscribe: ['transcription']});
-      });
-    });
-
-    describe('#isAnnounceProcessed', () => {
-      it('returns true when status is joined', () => {
-        voiceaChannel.announceStatus = 'joined';
-        assert.equal(voiceaChannel.isAnnounceProcessed(), true);
-      });
-
-      it('returns false when status is idle', () => {
-        voiceaChannel.announceStatus = 'idle';
-        assert.equal(voiceaChannel.isAnnounceProcessed(), false);
-      });
-
-      it('returns false when status is joining', () => {
-        voiceaChannel.announceStatus = 'joining';
-        assert.equal(voiceaChannel.isAnnounceProcessed(), false);
       });
     });
 
@@ -1055,7 +1010,7 @@ describe('plugin-voicea', () => {
 
       it('handles case when not previously subscribed to events', async () => {
         // Create a new channel that hasn't subscribed to events
-        const freshVoiceaChannel = new VoiceaChannel(mockLLMChannel, webex);
+        const freshVoiceaChannel = new VoiceaChannel(mockLLMChannel, requestStub);
         freshVoiceaChannel.hasSubscribedToEvents = false;
 
         const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -16,8 +16,6 @@ import {
 import {StrokeData, RequestData, IAnnotationChannel, CommandRequestBody} from './annotation.types';
 import {HTTP_VERBS, LOCUSEVENT} from '../constants';
 
-type ChannelType = 'default' | 'practice-session';
-
 /**
  * @description Annotation to handle LLM and Mercury message and locus API
  * @class
@@ -33,11 +31,11 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
   locusUrl!: string;
   deviceUrl!: string;
 
-  /** Registered LLM channels by type */
-  private channels: Map<ChannelType, LLMChannel> = new Map();
+  /** Currently registered LLM channel */
+  private channel?: LLMChannel;
 
-  /** Event handlers bound to each channel, for cleanup */
-  private channelHandlers: Map<ChannelType, (e: any) => void> = new Map();
+  /** Event handler bound to the channel, for cleanup */
+  private channelHandler?: (e: any) => void;
 
   /**
    * Initializes annotation module
@@ -48,64 +46,34 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
   }
 
   /**
-   * Register an LLMChannel with annotation
+   * Register an LLMChannel with annotation. Only one channel can be registered
+   * at a time - the owner is responsible for switching channels when context
+   * changes (e.g., entering/leaving practice session).
    * @param {LLMChannel} channel - The LLM channel to register
-   * @param {ChannelType} type - 'default' or 'practice-session'
    * @returns {void}
    */
-  public registerChannel(channel: LLMChannel, type: ChannelType): void {
-    // Unregister existing channel of this type first
-    if (this.channels.has(type)) {
-      this.unregisterChannel(type);
-    }
+  public registerChannel(channel: LLMChannel): void {
+    // Unregister existing channel first
+    this.unregisterChannel();
 
-    this.channels.set(type, channel);
+    this.channel = channel;
 
     // Subscribe to relay events from this channel
-    const handler = this.eventDataProcessor.bind(this);
-    this.channelHandlers.set(type, handler);
-    channel.on('event:relay.event', handler);
+    this.channelHandler = this.eventDataProcessor.bind(this);
+    channel.on('event:relay.event', this.channelHandler);
   }
 
   /**
-   * Unregister an LLMChannel from annotation
-   * @param {ChannelType} type - 'default' or 'practice-session'
+   * Unregister the current LLMChannel from annotation
    * @returns {void}
    */
-  public unregisterChannel(type: ChannelType): void {
-    const channel = this.channels.get(type);
-    const handler = this.channelHandlers.get(type);
-
-    if (channel && handler) {
-      channel.off('event:relay.event', handler);
+  public unregisterChannel(): void {
+    if (this.channel && this.channelHandler) {
+      this.channel.off('event:relay.event', this.channelHandler);
     }
 
-    this.channels.delete(type);
-    this.channelHandlers.delete(type);
-  }
-
-  /**
-   * Get the active LLM channel (prefers practice session if connected)
-   * @returns {LLMChannel | undefined}
-   */
-  private getActiveChannel(): LLMChannel | undefined {
-    const practiceChannel = this.channels.get('practice-session');
-    if (practiceChannel?.isConnected()) {
-      return practiceChannel;
-    }
-
-    return this.channels.get('default');
-  }
-
-  /**
-   * Indicates whether any registered LLM channel is connected.
-   * @returns {boolean}
-   */
-  private isLLMConnected(): boolean {
-    const defaultChannel = this.channels.get('default');
-    const practiceChannel = this.channels.get('practice-session');
-
-    return defaultChannel?.isConnected() || practiceChannel?.isConnected() || false;
+    this.channel = undefined;
+    this.channelHandler = undefined;
   }
 
   /**
@@ -202,10 +170,8 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
         this.eventCommandProcessor
       );
 
-      // Unregister all LLM channels
-      for (const type of this.channels.keys()) {
-        this.unregisterChannel(type);
-      }
+      // Unregister LLM channel
+      this.unregisterChannel();
 
       this.hasSubscribedToEvents = false;
     }
@@ -362,7 +328,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
    * @returns {void}
    */
   public sendStrokeData = (strokeData: StrokeData): void => {
-    if (!this.isLLMConnected()) return;
+    if (!this.channel?.isConnected()) return;
     this.encryptContent(strokeData.encryptionKeyUrl, strokeData.content).then(
       (encryptedContent) => {
         this.publishEncrypted(encryptedContent, strokeData);
@@ -377,12 +343,15 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
    * @returns {void}
    */
   private publishEncrypted(encryptedContent: string, strokeData: StrokeData) {
-    const channel = this.getActiveChannel();
-    if (!channel) return;
+    if (!this.channel) {
+      return;
+    }
 
-    const socket = channel.getSocket();
-    const binding = channel.getBinding();
-    if (!socket || !binding) return;
+    const socket = this.channel.getSocket();
+    const binding = this.channel.getBinding();
+    if (!socket || !binding) {
+      return;
+    }
 
     const data = {
       id: `${this.seqNum}`,

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -25,11 +25,11 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
 
   private seqNum: number;
 
-  hasSubscribedToEvents!: boolean;
+  hasSubscribedToEvents: boolean;
 
-  approvalUrl!: string;
-  locusUrl!: string;
-  deviceUrl!: string;
+  approvalUrl: string;
+  locusUrl: string;
+  deviceUrl: string;
 
   /** Currently registered LLM channel */
   private channel?: LLMChannel;

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -1,6 +1,7 @@
 import uuid from 'uuid';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {WebexPlugin, config} from '@webex/webex-core';
+import type LLMChannel from '@webex/internal-plugin-llm';
 import TriggerProxy from '../common/events/trigger-proxy';
 
 import {
@@ -13,7 +14,9 @@ import {
 } from './constants';
 
 import {StrokeData, RequestData, IAnnotationChannel, CommandRequestBody} from './annotation.types';
-import {HTTP_VERBS, LOCUSEVENT, LLM_PRACTICE_SESSION} from '../constants';
+import {HTTP_VERBS, LOCUSEVENT} from '../constants';
+
+type ChannelType = 'default' | 'practice-session';
 
 /**
  * @description Annotation to handle LLM and Mercury message and locus API
@@ -24,11 +27,17 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
 
   private seqNum: number;
 
-  hasSubscribedToEvents: boolean;
+  hasSubscribedToEvents!: boolean;
 
-  approvalUrl: string;
-  locusUrl: string;
-  deviceUrl: string;
+  approvalUrl!: string;
+  locusUrl!: string;
+  deviceUrl!: string;
+
+  /** Registered LLM channels by type */
+  private channels: Map<ChannelType, LLMChannel> = new Map();
+
+  /** Event handlers bound to each channel, for cleanup */
+  private channelHandlers: Map<ChannelType, (e: any) => void> = new Map();
 
   /**
    * Initializes annotation module
@@ -36,6 +45,67 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
   constructor(...args) {
     super(...args);
     this.seqNum = 1;
+  }
+
+  /**
+   * Register an LLMChannel with annotation
+   * @param {LLMChannel} channel - The LLM channel to register
+   * @param {ChannelType} type - 'default' or 'practice-session'
+   * @returns {void}
+   */
+  public registerChannel(channel: LLMChannel, type: ChannelType): void {
+    // Unregister existing channel of this type first
+    if (this.channels.has(type)) {
+      this.unregisterChannel(type);
+    }
+
+    this.channels.set(type, channel);
+
+    // Subscribe to relay events from this channel
+    const handler = this.eventDataProcessor.bind(this);
+    this.channelHandlers.set(type, handler);
+    channel.on('event:relay.event', handler);
+  }
+
+  /**
+   * Unregister an LLMChannel from annotation
+   * @param {ChannelType} type - 'default' or 'practice-session'
+   * @returns {void}
+   */
+  public unregisterChannel(type: ChannelType): void {
+    const channel = this.channels.get(type);
+    const handler = this.channelHandlers.get(type);
+
+    if (channel && handler) {
+      channel.off('event:relay.event', handler);
+    }
+
+    this.channels.delete(type);
+    this.channelHandlers.delete(type);
+  }
+
+  /**
+   * Get the active LLM channel (prefers practice session if connected)
+   * @returns {LLMChannel | undefined}
+   */
+  private getActiveChannel(): LLMChannel | undefined {
+    const practiceChannel = this.channels.get('practice-session');
+    if (practiceChannel?.isConnected()) {
+      return practiceChannel;
+    }
+
+    return this.channels.get('default');
+  }
+
+  /**
+   * Indicates whether any registered LLM channel is connected.
+   * @returns {boolean}
+   */
+  private isLLMConnected(): boolean {
+    const defaultChannel = this.channels.get('default');
+    const practiceChannel = this.channels.get('practice-session');
+
+    return defaultChannel?.isConnected() || practiceChannel?.isConnected() || false;
   }
 
   /**
@@ -104,6 +174,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
 
   /**
    * Listen to websocket messages
+   * @deprecated LLM event subscription is now handled by registerChannel()
    * @returns {undefined}
    */
   private listenToEvents() {
@@ -114,14 +185,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
         this.eventCommandProcessor,
         this
       );
-      // @ts-ignore
-      this.webex.internal.llm.on('event:relay.event', this.eventDataProcessor, this);
-      // @ts-ignore
-      this.webex.internal.llm.on(
-        `event:relay.event:${LLM_PRACTICE_SESSION}`,
-        this.eventDataProcessor,
-        this
-      );
+      // LLM event subscription is now handled by registerChannel()
       this.hasSubscribedToEvents = true;
     }
   }
@@ -138,13 +202,11 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
         this.eventCommandProcessor
       );
 
-      // @ts-ignore
-      this.webex.internal.llm.off('event:relay.event', this.eventDataProcessor);
-      // @ts-ignore
-      this.webex.internal.llm.off(
-        `event:relay.event:${LLM_PRACTICE_SESSION}`,
-        this.eventDataProcessor
-      );
+      // Unregister all LLM channels
+      for (const type of this.channels.keys()) {
+        this.unregisterChannel(type);
+      }
+
       this.hasSubscribedToEvents = false;
     }
   }
@@ -300,8 +362,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
    * @returns {void}
    */
   public sendStrokeData = (strokeData: StrokeData): void => {
-    // @ts-ignore
-    if (!this.webex.internal.llm.isConnected()) return;
+    if (!this.isLLMConnected()) return;
     this.encryptContent(strokeData.encryptionKeyUrl, strokeData.content).then(
       (encryptedContent) => {
         this.publishEncrypted(encryptedContent, strokeData);
@@ -316,13 +377,13 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
    * @returns {void}
    */
   private publishEncrypted(encryptedContent: string, strokeData: StrokeData) {
-    // @ts-ignore
-    const {llm} = this.webex.internal;
-    const isPracticeSessionConnected = llm.isConnected(LLM_PRACTICE_SESSION);
-    const socket =
-      (isPracticeSessionConnected && llm.getSocket(LLM_PRACTICE_SESSION)) || llm.socket;
-    const binding =
-      (isPracticeSessionConnected && llm.getBinding(LLM_PRACTICE_SESSION)) || llm.getBinding();
+    const channel = this.getActiveChannel();
+    if (!channel) return;
+
+    const socket = channel.getSocket();
+    const binding = channel.getBinding();
+    if (!socket || !binding) return;
+
     const data = {
       id: `${this.seqNum}`,
       type: 'publishRequest',

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -49,6 +49,8 @@ const Breakouts = WebexPlugin.extend({
     canManageBreakouts: 'boolean', // appear the ability to manage breakouts
     mainGroupId: 'string', // appears from the moment you enable breakouts
     mainSessionId: 'string', // appears from the moment you enable breakouts
+    hasSubscribedToMessage: 'boolean', // tracks if listening to LLM broadcast messages
+    _llmChannel: 'object', // registered LLM channel for broadcast messages
   },
   children: {
     currentBreakoutSession: Breakout,

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -3,6 +3,7 @@
  */
 import {WebexPlugin} from '@webex/webex-core';
 import {debounce, forEach} from 'lodash';
+import type LLMChannel from '@webex/internal-plugin-llm';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 import {BREAKOUTS, MEETINGS, HTTP_VERBS, _ID_} from '../constants';
@@ -260,15 +261,43 @@ const Breakouts = WebexPlugin.extend({
   },
 
   /**
+   * Registers the LLM channel for broadcast messages
+   * @param {LLMChannel} channel - The LLM channel to use for breakout messages
+   * @returns {void}
+   */
+  registerLLMChannel(channel: LLMChannel) {
+    // If already subscribed to a previous channel, clean it up
+    if (this.hasSubscribedToMessage && this._llmChannel) {
+      this.stopListening(this._llmChannel);
+      this.hasSubscribedToMessage = false;
+    }
+
+    this._llmChannel = channel;
+    this.listenToBroadcastMessages();
+  },
+
+  /**
+   * Unregisters the LLM channel
+   * @returns {void}
+   */
+  unregisterLLMChannel() {
+    if (this._llmChannel) {
+      this.stopListening(this._llmChannel);
+      this._llmChannel = undefined;
+      this.hasSubscribedToMessage = false;
+    }
+  },
+
+  /**
    * Sets up listener for broadcast messages sent to the breakout session
    * @returns {void}
    */
   listenToBroadcastMessages() {
-    if (!this.webex.internal.llm.isConnected() || this.hasSubscribedToMessage) {
+    if (!this._llmChannel?.isConnected() || this.hasSubscribedToMessage) {
       return;
     }
 
-    this.listenTo(this.webex.internal.llm, 'event:breakout.message', (event) => {
+    this.listenTo(this._llmChannel, 'event:breakout.message', (event) => {
       const {
         data: {senderUserId, sentTime, message},
       } = event;

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -374,6 +374,9 @@ export const EVENT_TRIGGERS = {
   MEETING_CONTROLS_MEETING_FULL_UPDATED: 'meeting:controls:meeting-full:updated',
   MEETING_CONTROLS_PRACTICE_SESSION_STATUS_UPDATED:
     'meeting:controls:practice-session-status:updated',
+  MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_READY: 'meeting:practiceSessionVoiceaChannelReady',
+  MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_CLEANED_UP:
+    'meeting:practiceSessionVoiceaChannelCleanedUp',
   MEETING_CONTROLS_ANNOTATION_UPDATED: 'meeting:controls:annotation:updated',
   MEETING_CONTROLS_REMOTE_DESKTOP_CONTROL_UPDATED:
     'meeting:controls:remote-desktop-control:updated',

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -374,9 +374,6 @@ export const EVENT_TRIGGERS = {
   MEETING_CONTROLS_MEETING_FULL_UPDATED: 'meeting:controls:meeting-full:updated',
   MEETING_CONTROLS_PRACTICE_SESSION_STATUS_UPDATED:
     'meeting:controls:practice-session-status:updated',
-  MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_READY: 'meeting:practiceSessionVoiceaChannelReady',
-  MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_CLEANED_UP:
-    'meeting:practiceSessionVoiceaChannelCleanedUp',
   MEETING_CONTROLS_ANNOTATION_UPDATED: 'meeting:controls:annotation:updated',
   MEETING_CONTROLS_REMOTE_DESKTOP_CONTROL_UPDATED:
     'meeting:controls:remote-desktop-control:updated',

--- a/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
@@ -3,11 +3,12 @@
  */
 
 import {Interceptor} from '@webex/http-core';
+
+// @ts-ignore - internal-plugin-llm types
 import LLMChannel from '@webex/internal-plugin-llm';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {DATA_CHANNEL_AUTH_HEADER, MAX_RETRY, RETRY_INTERVAL, RETRY_KEY} from './constant';
 import {isJwtTokenExpired} from './utils';
-import {LLM_DEFAULT_SESSION, LLM_PRACTICE_SESSION, LOCUS_URL} from '../constants';
 
 const retryCountMap = new Map();
 interface HttpLikeError extends Error {
@@ -40,93 +41,64 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
         return this.internal.llm.isDataChannelTokenEnabled();
       },
 
-      // Route refresh by request URL in two steps:
-      // 1) Match active LLM sessions (supports non-default/multiple sessions)
-      // 2) If no session matches, resolve locusUrl and refresh via owning meeting
-      // If neither route matches, fall back to the default-session refresh.
+      // Route refresh by request URL:
+      // 1) Find the LLM channel that matches the request URL
+      // 2) If found, use its refresh handler
+      // 3) If no channel matches, fall back to finding the meeting by locusUrl
       refreshDataChannelToken: async (requestUrl?: string) => {
-        let sessionId;
-        let meeting;
-
-        if (typeof requestUrl === 'string') {
-          // @ts-ignore
-          sessionId = this.internal.llm.getSessionIdByDatachannelUrl?.(requestUrl);
-
-          if (!sessionId) {
-            // @ts-ignore
-            const locusUrl = this.internal.llm.getLocusUrlByDatachannelUrl?.(requestUrl);
-
-            if (locusUrl) {
-              // @ts-ignore
-              meeting = this.meetings?.getMeetingByType?.(LOCUS_URL, locusUrl);
-            }
-          }
-
-          if (!meeting) {
-            // Fallback: registerAndConnect() pre-populates datachannelUrl in
-            // connections before calling register(), so getSessionIdByDatachannelUrl
-            // above should normally resolve. This scan covers any residual gap
-            // where connections are not yet populated (e.g. if setRefreshHandler
-            // is called on a session that has no connection entry at all).
-            // @ts-ignore
-            const allMeetings = this.meetings?.getAllMeetings?.() || {};
-
-            meeting = Object.values(allMeetings).find((activeMeeting: any) => {
-              const info = activeMeeting?.locusInfo?.info || {};
-
-              return (
-                (info.practiceSessionDatachannelUrl &&
-                  LLMChannel.matchesDatachannelRequestUrl(
-                    requestUrl,
-                    info.practiceSessionDatachannelUrl
-                  )) ||
-                (info.datachannelUrl &&
-                  LLMChannel.matchesDatachannelRequestUrl(requestUrl, info.datachannelUrl))
-              );
-            });
-
-            if (!sessionId) {
-              // @ts-ignore
-              const info = meeting?.locusInfo?.info || {};
-
-              if (
-                info.practiceSessionDatachannelUrl &&
-                LLMChannel.matchesDatachannelRequestUrl(
-                  requestUrl,
-                  info.practiceSessionDatachannelUrl
-                )
-              ) {
-                sessionId = LLM_PRACTICE_SESSION;
-              } else if (
-                info.datachannelUrl &&
-                LLMChannel.matchesDatachannelRequestUrl(requestUrl, info.datachannelUrl)
-              ) {
-                sessionId = LLM_DEFAULT_SESSION;
-              }
-            }
-          }
-        }
-
-        let result;
-        if (meeting) {
-          result = await meeting.refreshDataChannelToken();
-        } else {
-          // @ts-ignore
-          result = await this.internal.llm.refreshDataChannelToken(sessionId);
-        }
-
-        if (!result?.body) {
-          throw new Error('DataChannel token refresh returned no payload');
-        }
-        const {datachannelToken, dataChannelTokenType} = result.body;
-        const tokenStoreKey = dataChannelTokenType || sessionId;
-        const ownerMeetingId =
-          // @ts-ignore
-          meeting?.id || this.internal.llm.getOwnerMeetingId?.(tokenStoreKey);
         // @ts-ignore
-        this.internal.llm.setDatachannelToken(datachannelToken, ownerMeetingId, tokenStoreKey);
+        const channel = this.internal.llm.getConnectionByDatachannelUrl?.(requestUrl);
 
-        return datachannelToken;
+        if (channel) {
+          // Channel found - use its refresh handler
+          const result = await channel.refreshDataChannelToken();
+
+          if (!result?.body) {
+            throw new Error('DataChannel token refresh returned no payload');
+          }
+
+          const {datachannelToken} = result.body;
+          channel.setDatachannelToken(datachannelToken);
+
+          return datachannelToken;
+        }
+
+        // No channel found - fallback to finding meeting by matching datachannel URLs
+        // @ts-ignore
+        const allMeetings = this.meetings?.getAllMeetings?.() || {};
+
+        const meeting = Object.values(allMeetings).find((activeMeeting: any) => {
+          const info = activeMeeting?.locusInfo?.info || {};
+
+          return (
+            (info.practiceSessionDatachannelUrl &&
+              LLMChannel.matchesDatachannelRequestUrl(
+                requestUrl,
+                info.practiceSessionDatachannelUrl
+              )) ||
+            (info.datachannelUrl &&
+              LLMChannel.matchesDatachannelRequestUrl(requestUrl, info.datachannelUrl))
+          );
+        });
+
+        if (meeting) {
+          const result = await (meeting as any).refreshDataChannelToken();
+
+          if (!result?.body) {
+            throw new Error('DataChannel token refresh returned no payload');
+          }
+
+          const {datachannelToken} = result.body;
+
+          // Store token on the meeting's LLM channel if available
+          if ((meeting as any).llmChannel) {
+            (meeting as any).llmChannel.setDatachannelToken(datachannelToken);
+          }
+
+          return datachannelToken;
+        }
+
+        throw new Error('No LLM channel or meeting found for request URL');
       },
     });
   }

--- a/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
@@ -7,6 +7,7 @@ import {Interceptor} from '@webex/http-core';
 // @ts-ignore - internal-plugin-llm types
 import LLMChannel from '@webex/internal-plugin-llm';
 import LoggerProxy from '../common/logs/logger-proxy';
+import Meeting from '../meeting';
 import {DATA_CHANNEL_AUTH_HEADER, MAX_RETRY, RETRY_INTERVAL, RETRY_KEY} from './constant';
 import {isJwtTokenExpired} from './utils';
 
@@ -47,7 +48,7 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
       // 3) If no channel matches, fall back to finding the meeting by locusUrl
       refreshDataChannelToken: async (requestUrl?: string) => {
         // @ts-ignore
-        const channel = this.internal.llm.getConnectionByDatachannelUrl?.(requestUrl);
+        const channel = this.internal.llm.getConnectionByDatachannelUrl(requestUrl);
 
         if (channel) {
           // Channel found - use its refresh handler
@@ -65,9 +66,9 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
 
         // No channel found - fallback to finding meeting by matching datachannel URLs
         // @ts-ignore
-        const allMeetings = this.meetings?.getAllMeetings?.() || {};
+        const allMeetings: Record<string, Meeting> = this.meetings?.getAllMeetings?.() || {};
 
-        const meeting = Object.values(allMeetings).find((activeMeeting: any) => {
+        const meeting = Object.values(allMeetings).find((activeMeeting) => {
           const info = activeMeeting?.locusInfo?.info || {};
 
           return (
@@ -82,7 +83,7 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
         });
 
         if (meeting) {
-          const result = await (meeting as any).refreshDataChannelToken();
+          const result = await meeting.refreshDataChannelToken();
 
           if (!result?.body) {
             throw new Error('DataChannel token refresh returned no payload');
@@ -91,8 +92,10 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
           const {datachannelToken} = result.body;
 
           // Store token on the meeting's LLM channel if available
-          if ((meeting as any).llmChannel) {
-            (meeting as any).llmChannel.setDatachannelToken(datachannelToken);
+          // llmChannel is private, cast required for cross-module access
+          const {llmChannel} = meeting as any;
+          if (llmChannel) {
+            llmChannel.setDatachannelToken(datachannelToken);
           }
 
           return datachannelToken;

--- a/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
@@ -66,7 +66,7 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
 
         // No channel found - fallback to finding meeting by matching datachannel URLs
         // @ts-ignore
-        const allMeetings: Record<string, Meeting> = this.meetings?.getAllMeetings?.() || {};
+        const allMeetings: Record<string, Meeting> = this.meetings?.getAllMeetings() || {};
 
         const meeting = Object.values(allMeetings).find((activeMeeting) => {
           const info = activeMeeting?.locusInfo?.info || {};
@@ -92,11 +92,7 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
           const {datachannelToken} = result.body;
 
           // Store token on the meeting's LLM channel if available
-          // llmChannel is private, cast required for cross-module access
-          const {llmChannel} = meeting as any;
-          if (llmChannel) {
-            llmChannel.setDatachannelToken(datachannelToken);
-          }
+          meeting.setLLMChannelDataToken(datachannelToken);
 
           return datachannelToken;
         }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -51,6 +51,7 @@ import {
   EVENT_TRIGGERS as VOICEAEVENTS,
   TURN_ON_CAPTION_STATUS,
   type MeetingTranscriptPayload,
+  type VoiceaChannel,
 } from '@webex/internal-plugin-voicea';
 
 import {
@@ -820,6 +821,11 @@ export default class Meeting extends StatelessWebexPlugin {
    * Created in updateLLMConnection, cleaned up in cleanupLLMConneciton.
    */
   private llmChannel?: LLMChannel;
+
+  /**
+   * The Voicea channel for transcription/captions, bound to this meeting's LLM channel.
+   */
+  voiceaChannel?: VoiceaChannel;
 
   /**
    * Pending datachannel token saved from join response, used when creating the LLM channel.
@@ -2679,29 +2685,28 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   private setUpVoiceaListeners() {
-    // @ts-ignore
-    this.webex.internal.voicea.listenToEvents();
+    if (!this.voiceaChannel) {
+      LoggerProxy.logger.warn('Meeting:index#setUpVoiceaListeners --> voiceaChannel not available');
 
-    // @ts-ignore
-    this.webex.internal.voicea.on(
+      return;
+    }
+
+    this.voiceaChannel.on(
       VOICEAEVENTS.VOICEA_ANNOUNCEMENT,
       this.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.on(
+    this.voiceaChannel.on(
       VOICEAEVENTS.CAPTIONS_TURNED_ON,
       this.voiceaListenerCallbacks[VOICEAEVENTS.CAPTIONS_TURNED_ON]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.on(
+    this.voiceaChannel.on(
       VOICEAEVENTS.EVA_COMMAND,
       this.voiceaListenerCallbacks[VOICEAEVENTS.EVA_COMMAND]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.on(
+    this.voiceaChannel.on(
       VOICEAEVENTS.NEW_CAPTION,
       this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
     );
@@ -3070,8 +3075,7 @@ export default class Meeting extends StatelessWebexPlugin {
           if (this.transcription?.languageOptions) {
             this.transcription.languageOptions.currentSpokenLanguage = spokenLanguage;
           }
-          // @ts-ignore
-          this.webex.internal.voicea.onSpokenLanguageUpdate(spokenLanguage, this.id);
+          this.voiceaChannel?.onSpokenLanguageUpdate(spokenLanguage, this.id);
 
           Trigger.trigger(
             this,
@@ -3100,8 +3104,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
     this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_MEETING_HESIOD_LLM_ID_UPDATED, ({hesiodLlmId}) => {
       if (hesiodLlmId) {
-        // @ts-ignore
-        this.webex.internal.voicea.onCaptionServiceIdUpdate(hesiodLlmId);
+        this.voiceaChannel?.onCaptionServiceIdUpdate(hesiodLlmId);
       }
     });
 
@@ -6050,8 +6053,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       try {
         const voiceaListenerCaptionUpdate = (payload) => {
-          // @ts-ignore
-          this.webex.internal.voicea.off(
+          this.voiceaChannel?.off(
             VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE,
             voiceaListenerCaptionUpdate
           );
@@ -6067,13 +6069,8 @@ export default class Meeting extends StatelessWebexPlugin {
             reject(payload);
           }
         };
-        // @ts-ignore
-        this.webex.internal.voicea.on(
-          VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE,
-          voiceaListenerCaptionUpdate
-        );
-        // @ts-ignore
-        this.webex.internal.voicea.requestLanguage(language);
+        this.voiceaChannel?.on(VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE, voiceaListenerCaptionUpdate);
+        this.voiceaChannel?.requestLanguage(language);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#setCaptionLanguage --> ${error}`);
 
@@ -6107,8 +6104,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       try {
         const voiceaListenerLanguageUpdate = (payload) => {
-          // @ts-ignore
-          this.webex.internal.voicea.off(
+          this.voiceaChannel?.off(
             VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE,
             voiceaListenerLanguageUpdate
           );
@@ -6125,14 +6121,9 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         };
 
-        // @ts-ignore
-        this.webex.internal.voicea.on(
-          VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE,
-          voiceaListenerLanguageUpdate
-        );
+        this.voiceaChannel?.on(VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE, voiceaListenerLanguageUpdate);
 
-        // @ts-ignore
-        this.webex.internal.voicea.setSpokenLanguage(language);
+        this.voiceaChannel?.setSpokenLanguage(language);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#setSpokenLanguage --> ${error}`);
 
@@ -6154,12 +6145,18 @@ export default class Meeting extends StatelessWebexPlugin {
       );
 
       try {
+        if (!this.voiceaChannel) {
+          LoggerProxy.logger.warn(
+            'Meeting:index#startTranscription --> voiceaChannel not available'
+          );
+
+          return;
+        }
+
         if (!this.areVoiceaEventsSetup) {
           this.setUpVoiceaListeners();
         }
-
-        // @ts-ignore
-        await this.webex.internal.voicea.turnOnCaptions(options?.spokenLanguage);
+        await this.voiceaChannel.turnOnCaptions(options?.spokenLanguage);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
@@ -6286,32 +6283,27 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {void}
    */
   stopTranscription() {
-    // @ts-ignore
-    this.webex.internal.voicea.off(
+    this.voiceaChannel?.off(
       VOICEAEVENTS.VOICEA_ANNOUNCEMENT,
       this.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.off(
+    this.voiceaChannel?.off(
       VOICEAEVENTS.CAPTIONS_TURNED_ON,
       this.voiceaListenerCallbacks[VOICEAEVENTS.CAPTIONS_TURNED_ON]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.off(
+    this.voiceaChannel?.off(
       VOICEAEVENTS.EVA_COMMAND,
       this.voiceaListenerCallbacks[VOICEAEVENTS.EVA_COMMAND]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.off(
+    this.voiceaChannel?.off(
       VOICEAEVENTS.NEW_CAPTION,
       this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
     );
 
-    // @ts-ignore
-    this.webex.internal.voicea.deregisterEvents();
+    this.voiceaChannel?.deregisterEvents();
 
     this.areVoiceaEventsSetup = false;
     this.triggerStopReceivingTranscriptionEvent();
@@ -6344,16 +6336,13 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private restoreLLMSubscriptionsIfNeeded(): void {
     try {
-      const keepTranscriptionSubscribed =
-        // @ts-ignore
-        this.webex.internal.voicea?.getKeepTranscriptionSubscribed?.();
+      const keepTranscriptionSubscribed = this.voiceaChannel?.getKeepTranscriptionSubscribed();
 
       if (!keepTranscriptionSubscribed) {
         return;
       }
 
-      // @ts-ignore
-      this.webex.internal.voicea.updateSubchannelSubscriptions({subscribe: ['transcription']});
+      this.voiceaChannel?.updateSubchannelSubscriptions({subscribe: ['transcription']});
     } catch (error) {
       const msg = error?.message || String(error);
 
@@ -6680,6 +6669,8 @@ export default class Meeting extends StatelessWebexPlugin {
     this.llmChannel?.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
     this.llmChannel?.off('online', this.handleLLMOnline);
     this.breakouts?.unregisterLLMChannel();
+    this.voiceaChannel?.deregisterEvents();
+    this.voiceaChannel = undefined;
     this.clearLLMHealthCheckTimer();
   }
 
@@ -6836,16 +6827,23 @@ export default class Meeting extends StatelessWebexPlugin {
     const isJoined = this.isJoined();
     const dataChannelUrl = datachannelUrl;
 
-    // If already connected to same URLs, skip reconnect
-    if (this.llmChannel?.isConnected()) {
-      if (
+    // If we have an existing channel, check if we should reuse it or clean it up
+    if (this.llmChannel) {
+      const isSameUrls =
         url === this.llmChannel.getLocusUrl() &&
-        dataChannelUrl === this.llmChannel.getDatachannelUrl() &&
-        isJoined
-      ) {
+        dataChannelUrl === this.llmChannel.getDatachannelUrl();
+
+      // If already connected to same URLs, skip reconnect
+      if (this.llmChannel.isConnected() && isSameUrls && isJoined) {
         return undefined;
       }
-      // URLs changed, disconnect existing channel
+
+      // If currently connecting to same URLs, wait for that to complete
+      if (this.llmChannel.isConnecting() && isSameUrls && isJoined) {
+        return undefined;
+      }
+
+      // URLs changed or not joined, disconnect existing channel
       await this.cleanupLLMConneciton();
     }
 
@@ -6889,6 +6887,9 @@ export default class Meeting extends StatelessWebexPlugin {
         // Register breakouts channel
         this.breakouts.registerLLMChannel(this.llmChannel);
 
+        // Create VoiceaChannel for this meeting
+        // @ts-ignore - Fix type
+        this.voiceaChannel = this.webex.internal.voicea.createChannel(this.llmChannel);
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
         );

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6153,7 +6153,6 @@ export default class Meeting extends StatelessWebexPlugin {
         }
         await this.voiceaChannel.turnOnCaptions(options?.spokenLanguage);
 
-        // Also enable captions on practice session channel if in practice session
         await this.webinar?.turnOnCaptions(options?.spokenLanguage);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
@@ -6223,7 +6222,7 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     // Also check practice session binding for webinars
-    const practiceSessionBinding = this.webinar?.practiceSessionLLMChannel?.getBinding();
+    const practiceSessionBinding = this.webinar?.getPracticeSessionBinding();
 
     if (practiceSessionBinding && route === practiceSessionBinding) {
       return true;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -825,7 +825,7 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * The Voicea channel for transcription/captions, bound to this meeting's LLM channel.
    */
-  private voiceaChannel?: VoiceaChannel;
+  voiceaChannel?: VoiceaChannel;
 
   /**
    * Pending datachannel token saved from join response, used when creating the LLM channel.
@@ -6894,7 +6894,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
         // Register annotation channel only if not in practice session
         // (practice session manages its own annotation channel via updatePSDataChannel)
-        if (!this.webinar?.isPracticeSessionLLMChannelConnected()) {
+        if (!this.webinar?.isJoinPracticeSessionDataChannel()) {
           this.annotation.registerChannel(this.llmChannel);
         }
 
@@ -11171,6 +11171,34 @@ export default class Meeting extends StatelessWebexPlugin {
 
       return null;
     }
+  }
+
+  /**
+   * Checks if the LLM channel is connected.
+   * Handles practice session context automatically - returns practice session
+   * LLM channel status when in practice session, main LLM channel status otherwise.
+   * @returns {boolean} True if the appropriate LLM channel is connected
+   */
+  public isLLMConnected(): boolean {
+    if (this.webinar?.isJoinPracticeSessionDataChannel()) {
+      return this.webinar.isPracticeSessionLLMChannelConnected();
+    }
+
+    return this.llmChannel?.isConnected() ?? false;
+  }
+
+  /**
+   * Gets the locus URL from the LLM channel.
+   * Handles practice session context automatically - returns practice session
+   * LLM channel's locus URL when in practice session, main LLM channel's locus URL otherwise.
+   * @returns {string | undefined} The locus URL or undefined
+   */
+  public getLLMLocusUrl(): string | undefined {
+    if (this.webinar?.isJoinPracticeSessionDataChannel()) {
+      return this.webinar.getPracticeSessionLocusUrl();
+    }
+
+    return this.llmChannel?.getLocusUrl();
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -34,6 +34,7 @@ import {
 } from '@webex/internal-media-core';
 
 import {DataChannelTokenType, type RegisterAndConnectTiming} from '@webex/internal-plugin-llm';
+import type LLMChannel from '@webex/internal-plugin-llm';
 
 import {
   LocalStream,
@@ -138,8 +139,6 @@ import {
   STAGE_MANAGER_TYPE,
   LOCUSEVENT,
   LOCUS_LLM_EVENT,
-  LLM_DEFAULT_SESSION,
-  LLM_PRACTICE_SESSION,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import ParameterError from '../common/errors/parameter';
@@ -815,6 +814,22 @@ export default class Meeting extends StatelessWebexPlugin {
   private logUploadIntervalIndex: number;
   private mediaServerIp: string;
   private llmHealthCheckTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * The LLM channel owned by this meeting for datachannel communication.
+   * Created in updateLLMConnection, cleaned up in cleanupLLMConneciton.
+   */
+  private llmChannel?: LLMChannel;
+
+  /**
+   * Pending datachannel token saved from join response, used when creating the LLM channel.
+   */
+  private _pendingDatachannelToken?: string;
+
+  /**
+   * Pending practice session datachannel token, passed to webinar for its LLM channel.
+   */
+  private _pendingPracticeSessionDatachannelToken?: string;
 
   /**
    * @param {Object} attrs
@@ -6194,6 +6209,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
   /**
    * Verifies the relay event was delivered for the active LLM session binding.
+   * With the factory pattern, each meeting owns its channel, so we just verify
+   * the route matches our channel's binding.
    * @param {RelayEvent} event Event object coming from LLM Connection
    * @returns {boolean}
    */
@@ -6204,11 +6221,7 @@ export default class Meeting extends StatelessWebexPlugin {
       return true;
     }
 
-    const {llm} = (this as any).webex.internal;
-    const isPracticeSession = llm.isConnected(LLM_PRACTICE_SESSION);
-    const expectedBinding = isPracticeSession
-      ? llm.getBinding(LLM_PRACTICE_SESSION)
-      : llm.getBinding();
+    const expectedBinding = this.llmChannel?.getBinding();
 
     if (!expectedBinding || route === expectedBinding) {
       return true;
@@ -6591,10 +6604,6 @@ export default class Meeting extends StatelessWebexPlugin {
         this.saveDataChannelToken(join);
         // @ts-ignore - config coming from registerPlugin
         if (this.config.enableAutomaticLLM) {
-          // @ts-ignore
-          this.webex.internal.llm.off('online', this.handleLLMOnline);
-          // @ts-ignore
-          this.webex.internal.llm.on('online', this.handleLLMOnline);
           this.updateLLMConnection({isInitialJoinPhase: true})
             .catch((error) => {
               LoggerProxy.logger.error(
@@ -6629,12 +6638,10 @@ export default class Meeting extends StatelessWebexPlugin {
     this.clearLLMHealthCheckTimer();
 
     this.llmHealthCheckTimer = setTimeout(() => {
-      // @ts-ignore
-      const isConnected = this.webex.internal.llm.isConnected();
+      const isConnected = this.llmChannel?.isConnected() ?? false;
 
       if (!isConnected) {
-        // @ts-ignore
-        const {hasEverConnected} = this.webex.internal.llm;
+        const hasEverConnected = this.llmChannel?.hasEverConnected ?? false;
 
         // only send metric if not connected - to avoid too many metrics
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LLM_HEALTHCHECK_FAILURE, {
@@ -6669,10 +6676,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {void}
    */
   private stopListeningForLLMEvents() {
-    // @ts-ignore - fix types
-    this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
-    // @ts-ignore - fix types
-    this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+    this.llmChannel?.off('event:relay.event', this.processRelayEvent);
+    this.llmChannel?.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+    this.llmChannel?.off('online', this.handleLLMOnline);
     this.clearLLMHealthCheckTimer();
   }
 
@@ -6703,51 +6709,32 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * Disconnects and cleans up the default LLM session listeners/timers.
-   *
-   * Ownership-aware: only calls `disconnectLLM` when this meeting is the
-   * current owner of the default LLM session (or when no owner is recorded).
-   * Event listeners belonging to this meeting instance are always detached
-   * so they do not receive another meeting's relay events.
+   * Disconnects and cleans up the LLM channel owned by this meeting.
    *
    * @param {Object} options
-   * @param {boolean} [options.removeOnlineListener=true] removes the one-time online listener
    * @param {boolean} [options.throwOnError=true] rethrows disconnect errors when true
    * @returns {Promise<void>}
    */
   private cleanupLLMConneciton = async ({
-    removeOnlineListener = true,
     throwOnError = true,
   }: {
-    removeOnlineListener?: boolean;
     throwOnError?: boolean;
   } = {}): Promise<void> => {
-    // @ts-ignore - Fix type
-    // @ts-ignore - Fix type
-    const {currentOwner, isOwner} = this.webex.internal.llm.resolveSessionOwnership(
-      this.id,
-      LLM_DEFAULT_SESSION
-    );
+    // Always clear the timer, even if there's no channel
+    this.clearLLMHealthCheckTimer();
+
+    if (!this.llmChannel) {
+      return;
+    }
 
     try {
-      if (isOwner) {
-        // @ts-ignore - Fix type
-        await this.webex.internal.llm.disconnectLLM(
-          {
-            code: 3050,
-            reason: 'done (permanent)',
-          },
-          LLM_DEFAULT_SESSION,
-          this.id
-        );
-      } else {
-        LoggerProxy.logger.info(
-          `Meeting:index#cleanupLLMConneciton --> skipping disconnect; LLM owned by meeting ${currentOwner}, not ${this.id}`
-        );
-      }
+      await this.llmChannel.disconnect({
+        code: 3050,
+        reason: 'done (permanent)',
+      });
     } catch (error) {
       LoggerProxy.logger.error(
-        'Meeting:index#cleanupLLMConneciton --> Failed to disconnect default LLM session',
+        'Meeting:index#cleanupLLMConneciton --> Failed to disconnect LLM channel',
         error
       );
 
@@ -6755,42 +6742,15 @@ export default class Meeting extends StatelessWebexPlugin {
         throw error;
       }
     } finally {
-      if (removeOnlineListener) {
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off('online', this.handleLLMOnline);
-      }
       this.stopListeningForLLMEvents();
-
-      // Re-check ownership after awaiting disconnectLLM. If ownership changed
-      // while cleanup was in flight, do not clear another meeting's owner tag.
-      if (isOwner) {
-        const {currentOwner: currentOwnerAfterCleanup} =
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.resolveSessionOwnership(this.id, LLM_DEFAULT_SESSION);
-
-        if (currentOwnerAfterCleanup === this.id) {
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.setOwnerMeetingId?.(undefined);
-        }
-      }
+      this.llmChannel = undefined;
     }
   };
 
   /**
-   * Clears data channel tokens associated with this meeting ownership.
-   * Ownership checks are enforced in internal-plugin-llm.
-   * @returns {void}
-   */
-  clearDataChannelToken(): void {
-    // @ts-ignore
-    this.webex.internal.llm.clearDatachannelToken(LLM_DEFAULT_SESSION, this.id);
-    // @ts-ignore
-    this.webex.internal.llm.clearDatachannelToken(LLM_PRACTICE_SESSION, this.id);
-  }
-
-  /**
-   * Saves the data channel tokens from the join response into LLM so that
-   * updateLLMConnection / updatePSDataChannel don't need to fetch them from locusInfo.
+   * Saves the data channel tokens from the join response.
+   * Default session token is stored on this.llmChannel when available.
+   * Practice session token is stored on the webinar's practice LLM channel.
    * @param {Object} join - The parsed join response (from MeetingUtil.parseLocusJoin)
    * @returns {void}
    */
@@ -6798,18 +6758,19 @@ export default class Meeting extends StatelessWebexPlugin {
     const datachannelToken = join?.locus?.self?.datachannelToken;
     const practiceSessionDatachannelToken = join?.locus?.self?.practiceSessionDatachannelToken;
 
-    if (datachannelToken) {
-      // @ts-ignore
-      this.webex.internal.llm.setDatachannelToken(datachannelToken, this.id, LLM_DEFAULT_SESSION);
+    // Store default session token on our LLM channel if it exists
+    if (datachannelToken && this.llmChannel) {
+      this.llmChannel.setDatachannelToken(datachannelToken);
     }
 
+    // Store the token temporarily for use when channel is created
+    if (datachannelToken) {
+      this._pendingDatachannelToken = datachannelToken;
+    }
+
+    // Practice session token is handled by webinar's practice LLM channel
     if (practiceSessionDatachannelToken) {
-      // @ts-ignore
-      this.webex.internal.llm.setDatachannelToken(
-        practiceSessionDatachannelToken,
-        this.id,
-        LLM_PRACTICE_SESSION
-      );
+      this._pendingPracticeSessionDatachannelToken = practiceSessionDatachannelToken;
     }
   }
 
@@ -6820,11 +6781,8 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private async ensureDefaultDatachannelTokenAfterAdmit(): Promise<boolean> {
     try {
-      // @ts-ignore
-      const datachannelToken = this.webex.internal.llm.getDatachannelToken(
-        LLM_DEFAULT_SESSION,
-        this.id
-      );
+      const datachannelToken =
+        this.llmChannel?.getDatachannelToken() ?? this._pendingDatachannelToken;
       // @ts-ignore
       const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
 
@@ -6843,12 +6801,12 @@ export default class Meeting extends StatelessWebexPlugin {
         return false;
       }
 
-      // @ts-ignore
-      this.webex.internal.llm.setDatachannelToken(
-        fetchedDatachannelToken,
-        this.id,
-        LLM_DEFAULT_SESSION
-      );
+      // Store on channel if exists, otherwise save as pending
+      if (this.llmChannel) {
+        this.llmChannel.setDatachannelToken(fetchedDatachannelToken);
+      } else {
+        this._pendingDatachannelToken = fetchedDatachannelToken;
+      }
 
       return true;
     } catch (error) {
@@ -6875,133 +6833,55 @@ export default class Meeting extends StatelessWebexPlugin {
     const {url = undefined, info: {datachannelUrl = undefined} = {}} = this.locusInfo || {};
 
     const isJoined = this.isJoined();
-
     const dataChannelUrl = datachannelUrl;
 
-    // Ownership guard: when the default LLM session is already connected and
-    // owned by a *different* Meeting instance, do not disconnect or reconfigure
-    // it. Another meeting's `updateLLMConnection` must be ignored here to
-    // avoid killing the socket it relies on. We only proceed to manage the
-    // connection when this meeting is the current owner, or when no owner is
-    // set yet (first claim).
-    // @ts-ignore - Fix type
-    const {currentOwner} = this.webex.internal.llm.resolveSessionOwnership(
-      this.id,
-      LLM_DEFAULT_SESSION
-    );
-
-    // Capture connectivity before any reconnect attempt. If LLM was already
-    // connected, we must respect current ownership. If it was disconnected,
-    // this flow may reclaim stale owner tags after a fresh connect.
-    // @ts-ignore - Fix type
-    const wasConnected = this.webex.internal.llm.isConnected();
-
-    // Prefer ownership-scoped token read. For disconnected stale-owner reclaim
-    // flows, fallback to ownerless read so initial register can still carry a
-    // token and recover from stale ownership without 401/403 dead-end.
-    // @ts-ignore - Fix type
-    let datachannelToken = this.webex.internal.llm.getDatachannelToken(
-      LLM_DEFAULT_SESSION,
-      this.id
-    );
-
-    if (!datachannelToken && !wasConnected && currentOwner && currentOwner !== this.id) {
-      // @ts-ignore - Fix type
-      datachannelToken = this.webex.internal.llm.getDatachannelToken(LLM_DEFAULT_SESSION);
-    }
-
-    // @ts-ignore - Fix type
-    if (wasConnected) {
-      if (currentOwner && currentOwner !== this.id) {
-        // Another meeting owns the live LLM socket. We must not disconnect
-        // or reconfigure it -- doing so would tear down a session the
-        // owning meeting still relies on. Locus/datachannel URL mismatch is
-        // expected here (each meeting has its own locus URL) and is NOT a
-        // valid signal of staleness, so we never reclaim from this path.
-        // The only safe reclaim mechanism is the `finally`-block owner-tag
-        // release in `cleanupLLMConneciton`, which fires when this meeting
-        // itself is being torn down.
-        LoggerProxy.logger.info(
-          `Meeting:index#updateLLMConnection --> skipping; LLM owned by meeting ${currentOwner}, not ${this.id}`
-        );
-
-        return undefined;
-      }
-
+    // If already connected to same URLs, skip reconnect
+    if (this.llmChannel?.isConnected()) {
       if (
-        // @ts-ignore - Fix type
-        url === this.webex.internal.llm.getLocusUrl() &&
-        // @ts-ignore - Fix type
-        dataChannelUrl === this.webex.internal.llm.getDatachannelUrl() &&
+        url === this.llmChannel.getLocusUrl() &&
+        dataChannelUrl === this.llmChannel.getDatachannelUrl() &&
         isJoined
       ) {
         return undefined;
       }
-      await this.cleanupLLMConneciton({removeOnlineListener: false});
+      // URLs changed, disconnect existing channel
+      await this.cleanupLLMConneciton();
     }
 
     if (!isJoined) {
       return undefined;
     }
 
-    // Bind refresh handler before registration so interceptor-triggered token
-    // refresh during register POST can resolve a valid handler.
-    // Prefer this meeting as owner, but allow owner-less fallback when a stale
-    // foreign owner tag is present on a disconnected session.
-    const refreshHandlerOwnerMeetingId =
-      currentOwner && currentOwner !== this.id ? undefined : this.id;
-    const shouldAlignRefreshHandlerAfterOwnershipClaim = refreshHandlerOwnerMeetingId !== this.id;
+    // Create a new LLM channel for this meeting
     // @ts-ignore - Fix type
-    this.webex.internal.llm.setRefreshHandler(
-      () => this.refreshDataChannelToken(),
-      refreshHandlerOwnerMeetingId,
-      LLM_DEFAULT_SESSION
-    );
+    this.llmChannel = this.webex.internal.llm.createConnection();
 
-    // @ts-ignore - Fix type
-    return this.webex.internal.llm
+    // Get token from pending (saved from join response) or channel
+    const datachannelToken = this._pendingDatachannelToken ?? this.llmChannel.getDatachannelToken();
+
+    // Set up refresh handler before registration so interceptor-triggered token
+    // refresh during register POST can resolve a valid handler.
+    this.llmChannel.setRefreshHandler(() => this.refreshDataChannelToken());
+
+    // If we have a pending token, store it on the channel
+    if (this._pendingDatachannelToken) {
+      this.llmChannel.setDatachannelToken(this._pendingDatachannelToken);
+      this._pendingDatachannelToken = undefined;
+    }
+
+    return this.llmChannel
       .registerAndConnect(url, dataChannelUrl, datachannelToken)
       .then((registerAndConnectResult) => {
         this.locusInfo.syncAllHashTreeDatasets({onlyLLM: true});
-        // Record ownership of the default LLM session for this meeting so
-        // subsequent cross-meeting `updateLLMConnection` / `cleanupLLMConneciton`
-        // calls can detect and skip work that doesn't belong to them.
-        // @ts-ignore - Fix type
-        const {isOwner} = this.webex.internal.llm.resolveSessionOwnership(
-          this.id,
-          LLM_DEFAULT_SESSION
-        );
-        const canReclaimAfterDisconnectedStart = !wasConnected;
 
-        // Refresh handler is pre-bound before registerAndConnect so token
-        // refresh can work even during the registration request itself.
-        if (isOwner || canReclaimAfterDisconnectedStart) {
-          // Record ownership of the default LLM session for this meeting so
-          // subsequent cross-meeting `updateLLMConnection` / `cleanupLLMConneciton`
-          // calls can detect and skip work that doesn't belong to them.
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.setOwnerMeetingId?.(this.id);
+        // Register event listeners on the channel
+        this.llmChannel.off('event:relay.event', this.processRelayEvent);
+        this.llmChannel.on('event:relay.event', this.processRelayEvent);
+        this.llmChannel.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+        this.llmChannel.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+        this.llmChannel.off('online', this.handleLLMOnline);
+        this.llmChannel.on('online', this.handleLLMOnline);
 
-          // If we pre-bound refresh ownerlessly (stale-owner reclaim path),
-          // align the handler with the newly claimed owner immediately after
-          // ownership is updated.
-          if (shouldAlignRefreshHandlerAfterOwnershipClaim) {
-            // @ts-ignore - Fix type
-            this.webex.internal.llm.setRefreshHandler(
-              () => this.refreshDataChannelToken(),
-              this.id,
-              LLM_DEFAULT_SESSION
-            );
-          }
-        }
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
         );
@@ -7037,6 +6917,9 @@ export default class Meeting extends StatelessWebexPlugin {
           llmLatency,
           error,
         });
+
+        // Clean up the channel on failure
+        this.llmChannel = undefined;
 
         return Promise.reject(error);
       });
@@ -10529,12 +10412,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
     // Listener teardown (transcription, annotation, llm/mercury) runs in
     // stopListeningForMeetingEvents() before /leave and /end so events
-    // received mid-teardown do not trigger Locus syncs. Calling it here
-    // again would double-emit MEETING_STOPPED_RECEIVING_TRANSCRIPTION
-    // because stopTranscription() always fires its trigger.
-    //
-    // Ownership-aware token clear is encapsulated inside clearDataChannelToken().
-    this.clearDataChannelToken();
+    // received mid-teardown do not trigger Locus syncs.
+    // Token cleanup happens automatically when cleanupLLMConneciton destroys the channel.
 
     await this.cleanupLLMConneciton({throwOnError: false});
   };

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6882,6 +6882,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.llmChannel.off('online', this.handleLLMOnline);
         this.llmChannel.on('online', this.handleLLMOnline);
 
+        // Register annotation channel
+        this.annotation.registerChannel(this.llmChannel, 'default');
+
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
         );

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -825,7 +825,7 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * The Voicea channel for transcription/captions, bound to this meeting's LLM channel.
    */
-  voiceaChannel?: VoiceaChannel;
+  private voiceaChannel?: VoiceaChannel;
 
   /**
    * Pending datachannel token saved from join response, used when creating the LLM channel.
@@ -6152,8 +6152,6 @@ export default class Meeting extends StatelessWebexPlugin {
           this.setUpVoiceaListeners();
         }
         await this.voiceaChannel.turnOnCaptions(options?.spokenLanguage);
-
-        await this.webinar?.turnOnCaptions(options?.spokenLanguage);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
@@ -6215,16 +6213,15 @@ export default class Meeting extends StatelessWebexPlugin {
       return true;
     }
 
-    const expectedBinding = this.llmChannel?.getBinding();
+    // With the factory pattern, both channels may be connected simultaneously.
+    // Determine which session is "active" based on whether PS channel is connected.
+    const isPracticeSession = this.webinar?.isPracticeSessionLLMChannelConnected() ?? false;
+
+    const expectedBinding = isPracticeSession
+      ? this.webinar?.getPracticeSessionBinding()
+      : this.llmChannel?.getBinding();
 
     if (!expectedBinding || route === expectedBinding) {
-      return true;
-    }
-
-    // Also check practice session binding for webinars
-    const practiceSessionBinding = this.webinar?.getPracticeSessionBinding();
-
-    if (practiceSessionBinding && route === practiceSessionBinding) {
       return true;
     }
 
@@ -6744,6 +6741,16 @@ export default class Meeting extends StatelessWebexPlugin {
   };
 
   /**
+   * Sets the datachannel token on the meeting's LLM channel.
+   * Used by the DataChannelAuthTokenInterceptor after refreshing tokens.
+   * @param {string} token - The new datachannel token
+   * @returns {void}
+   */
+  setLLMChannelDataToken(token: string): void {
+    this.llmChannel?.setDatachannelToken(token);
+  }
+
+  /**
    * Saves the data channel tokens from the join response.
    * Default session token is stored on this.llmChannel when available.
    * Practice session token is stored on the webinar's practice LLM channel.
@@ -6765,8 +6772,8 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     // Practice session token is handled by webinar
-    if (practiceSessionDatachannelToken && this.webinar) {
-      this.webinar._pendingPracticeSessionDatachannelToken = practiceSessionDatachannelToken;
+    if (practiceSessionDatachannelToken) {
+      this.webinar.setPracticeSessionDatachannelToken(practiceSessionDatachannelToken);
     }
   }
 
@@ -6885,8 +6892,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this.llmChannel.off('online', this.handleLLMOnline);
         this.llmChannel.on('online', this.handleLLMOnline);
 
-        // Register annotation channel
-        this.annotation.registerChannel(this.llmChannel);
+        // Register annotation channel only if not in practice session
+        // (practice session manages its own annotation channel via updatePSDataChannel)
+        if (!this.webinar?.isPracticeSessionLLMChannelConnected()) {
+          this.annotation.registerChannel(this.llmChannel);
+        }
 
         // Register breakouts channel
         this.breakouts.registerLLMChannel(this.llmChannel);

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6157,6 +6157,14 @@ export default class Meeting extends StatelessWebexPlugin {
           this.setUpVoiceaListeners();
         }
         await this.voiceaChannel.turnOnCaptions(options?.spokenLanguage);
+
+        // Also enable captions on practice session channel if in practice session
+        if (this.webinar?.practiceSessionVoiceaChannel) {
+          LoggerProxy.logger.info(
+            'Meeting:index#startTranscription --> Also enabling captions on practice session channel'
+          );
+          await this.webinar.practiceSessionVoiceaChannel.turnOnCaptions(options?.spokenLanguage);
+        }
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
@@ -6207,7 +6215,7 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Verifies the relay event was delivered for the active LLM session binding.
    * With the factory pattern, each meeting owns its channel, so we just verify
-   * the route matches our channel's binding.
+   * the route matches our channel's binding or the practice session binding.
    * @param {RelayEvent} event Event object coming from LLM Connection
    * @returns {boolean}
    */
@@ -6221,6 +6229,13 @@ export default class Meeting extends StatelessWebexPlugin {
     const expectedBinding = this.llmChannel?.getBinding();
 
     if (!expectedBinding || route === expectedBinding) {
+      return true;
+    }
+
+    // Also check practice session binding for webinars
+    const practiceSessionBinding = this.webinar?.practiceSessionLLMChannel?.getBinding();
+
+    if (practiceSessionBinding && route === practiceSessionBinding) {
       return true;
     }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -833,11 +833,6 @@ export default class Meeting extends StatelessWebexPlugin {
   private _pendingDatachannelToken?: string;
 
   /**
-   * Pending practice session datachannel token, passed to webinar for its LLM channel.
-   */
-  private _pendingPracticeSessionDatachannelToken?: string;
-
-  /**
    * @param {Object} attrs
    * @param {Object} options
    * @param {Function} callback - if provided, it will be called with the newly created meeting object as soon as the meeting.id is set
@@ -6159,12 +6154,7 @@ export default class Meeting extends StatelessWebexPlugin {
         await this.voiceaChannel.turnOnCaptions(options?.spokenLanguage);
 
         // Also enable captions on practice session channel if in practice session
-        if (this.webinar?.practiceSessionVoiceaChannel) {
-          LoggerProxy.logger.info(
-            'Meeting:index#startTranscription --> Also enabling captions on practice session channel'
-          );
-          await this.webinar.practiceSessionVoiceaChannel.turnOnCaptions(options?.spokenLanguage);
-        }
+        await this.webinar?.turnOnCaptions(options?.spokenLanguage);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
@@ -6775,9 +6765,9 @@ export default class Meeting extends StatelessWebexPlugin {
       this._pendingDatachannelToken = datachannelToken;
     }
 
-    // Practice session token is handled by webinar's practice LLM channel
-    if (practiceSessionDatachannelToken) {
-      this._pendingPracticeSessionDatachannelToken = practiceSessionDatachannelToken;
+    // Practice session token is handled by webinar
+    if (practiceSessionDatachannelToken && this.webinar) {
+      this.webinar._pendingPracticeSessionDatachannelToken = practiceSessionDatachannelToken;
     }
   }
 
@@ -6897,7 +6887,7 @@ export default class Meeting extends StatelessWebexPlugin {
         this.llmChannel.on('online', this.handleLLMOnline);
 
         // Register annotation channel
-        this.annotation.registerChannel(this.llmChannel, 'default');
+        this.annotation.registerChannel(this.llmChannel);
 
         // Register breakouts channel
         this.breakouts.registerLLMChannel(this.llmChannel);

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6679,6 +6679,7 @@ export default class Meeting extends StatelessWebexPlugin {
     this.llmChannel?.off('event:relay.event', this.processRelayEvent);
     this.llmChannel?.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
     this.llmChannel?.off('online', this.handleLLMOnline);
+    this.breakouts?.unregisterLLMChannel();
     this.clearLLMHealthCheckTimer();
   }
 
@@ -6884,6 +6885,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
         // Register annotation channel
         this.annotation.registerChannel(this.llmChannel, 'default');
+
+        // Register breakouts channel
+        this.breakouts.registerLLMChannel(this.llmChannel);
 
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -52,6 +52,7 @@ const Webinar = WebexPlugin.extend({
   /**
    * Pending practice session datachannel token, saved from join response.
    * Used when creating the practice session LLM channel.
+   * @private
    * @type {string|undefined}
    */
   _pendingPracticeSessionDatachannelToken: undefined as string | undefined,
@@ -193,6 +194,14 @@ const Webinar = WebexPlugin.extend({
    */
   isPracticeSessionLLMChannelConnected() {
     return this._practiceSessionLLMChannel?.isConnected() ?? false;
+  },
+
+  /**
+   * Returns the practice session LLM channel's locus URL, if available.
+   * @returns {string|undefined}
+   */
+  getPracticeSessionLocusUrl() {
+    return this._practiceSessionLLMChannel?.getLocusUrl();
   },
 
   /**

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -5,6 +5,7 @@ import {WebexPlugin, config} from '@webex/webex-core';
 import uuid from 'uuid';
 import {get} from 'lodash';
 import type LLMChannel from '@webex/internal-plugin-llm';
+import type {VoiceaChannel} from '@webex/internal-plugin-voicea';
 import {
   _ID_,
   HEADERS,
@@ -45,6 +46,12 @@ const Webinar = WebexPlugin.extend({
    * @type {LLMChannel|undefined}
    */
   practiceSessionLLMChannel: undefined as LLMChannel | undefined,
+
+  /**
+   * Voicea channel for practice session, bound to practiceSessionLLMChannel.
+   * @type {VoiceaChannel|undefined}
+   */
+  practiceSessionVoiceaChannel: undefined as VoiceaChannel | undefined,
 
   /**
    * Calls this to clean up listeners
@@ -179,6 +186,12 @@ const Webinar = WebexPlugin.extend({
       const meeting = this.getValidatedWebinarMeeting();
       meeting?.llmChannel?.off('online', this._pendingOnlineListener);
       this._pendingOnlineListener = null;
+    }
+
+    // Clean up practice session voicea channel
+    if (this.practiceSessionVoiceaChannel) {
+      this.practiceSessionVoiceaChannel.deregisterEvents();
+      this.practiceSessionVoiceaChannel = undefined;
     }
 
     if (!this.practiceSessionLLMChannel) {
@@ -387,10 +400,21 @@ const Webinar = WebexPlugin.extend({
         // Register annotation channel for practice session
         meeting.annotation.registerChannel(this.practiceSessionLLMChannel, 'practice-session');
 
-        // Announce voicea on practice session channel
-        meeting.voiceaChannel?.announce?.();
+        // Create VoiceaChannel for practice session bound to practiceSessionLLMChannel
+        // @ts-ignore - Fix type
+        this.practiceSessionVoiceaChannel = this.webex.internal.voicea.createChannel(
+          this.practiceSessionLLMChannel
+        );
+
+        // Set up voicea listeners for practice session channel
+        this.setupPracticeSessionVoiceaListeners(meeting);
+
+        // Announce and enable captions on practice session channel
+        this.practiceSessionVoiceaChannel?.announce?.();
         if (keepTranscriptionSubscribed) {
-          meeting.voiceaChannel?.updateSubchannelSubscriptions({subscribe: ['transcription']});
+          this.practiceSessionVoiceaChannel?.updateSubchannelSubscriptions({
+            subscribe: ['transcription'],
+          });
         }
         LoggerProxy.logger.info(
           'Webinar:index#updatePSDataChannel --> enabled to receive relay events for practice session!'
@@ -403,6 +427,23 @@ const Webinar = WebexPlugin.extend({
         this.practiceSessionLLMChannel = undefined;
         throw error;
       });
+  },
+
+  /**
+   * Sets up voicea listeners for practice session channel to forward events to the meeting.
+   * This allows captions to work during practice session.
+   * @param {object} meeting - The meeting instance
+   * @returns {void}
+   */
+  setupPracticeSessionVoiceaListeners(meeting) {
+    if (!this.practiceSessionVoiceaChannel || !meeting) {
+      return;
+    }
+
+    // Forward voicea events from practice session channel to meeting's voicea callbacks
+    Object.keys(meeting.voiceaListenerCallbacks).forEach((eventName) => {
+      this.practiceSessionVoiceaChannel.on(eventName, meeting.voiceaListenerCallbacks[eventName]);
+    });
   },
 
   /**

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -44,9 +44,10 @@ const Webinar = WebexPlugin.extend({
 
   /**
    * LLM channel for practice session, owned by this webinar instance.
+   * @private
    * @type {LLMChannel|undefined}
    */
-  practiceSessionLLMChannel: undefined as LLMChannel | undefined,
+  _practiceSessionLLMChannel: undefined as LLMChannel | undefined,
 
   /**
    * Pending practice session datachannel token, saved from join response.
@@ -183,7 +184,25 @@ const Webinar = WebexPlugin.extend({
    * @returns {string|undefined}
    */
   getPracticeSessionBinding() {
-    return this.practiceSessionLLMChannel?.getBinding();
+    return this._practiceSessionLLMChannel?.getBinding();
+  },
+
+  /**
+   * Returns whether the practice session LLM channel is connected.
+   * @returns {boolean}
+   */
+  isPracticeSessionLLMChannelConnected() {
+    return this._practiceSessionLLMChannel?.isConnected() ?? false;
+  },
+
+  /**
+   * Stores the practice session datachannel token for later use when
+   * creating the practice session LLM channel.
+   * @param {string} token - The datachannel token to store
+   * @returns {void}
+   */
+  setPracticeSessionDatachannelToken(token: string) {
+    this._pendingPracticeSessionDatachannelToken = token;
   },
 
   /**
@@ -204,12 +223,12 @@ const Webinar = WebexPlugin.extend({
       await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
     }
 
-    if (!this.practiceSessionLLMChannel) {
+    if (!this._practiceSessionLLMChannel) {
       return;
     }
 
     try {
-      await this.practiceSessionLLMChannel.disconnect({
+      await this._practiceSessionLLMChannel.disconnect({
         code: 3050,
         reason: 'done (permanent)',
       });
@@ -222,16 +241,16 @@ const Webinar = WebexPlugin.extend({
     } finally {
       // Remove listeners from the channel
       if (meeting) {
-        this.practiceSessionLLMChannel?.off('event:relay.event', meeting.processRelayEvent);
-        this.practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
-        this.practiceSessionLLMChannel?.off('online', meeting.handleLLMOnline);
+        this._practiceSessionLLMChannel?.off('event:relay.event', meeting.processRelayEvent);
+        this._practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        this._practiceSessionLLMChannel?.off('online', meeting.handleLLMOnline);
 
         // Switch annotation back to the meeting's default channel
         if (meeting.llmChannel) {
           meeting.annotation.registerChannel(meeting.llmChannel);
         }
       }
-      this.practiceSessionLLMChannel = undefined;
+      this._practiceSessionLLMChannel = undefined;
     }
   },
 
@@ -252,7 +271,7 @@ const Webinar = WebexPlugin.extend({
 
     // Check for cached token on the channel or pending token
     const cachedToken =
-      this.practiceSessionLLMChannel?.getDatachannelToken() ??
+      this._practiceSessionLLMChannel?.getDatachannelToken() ??
       this._pendingPracticeSessionDatachannelToken;
 
     if (cachedToken) {
@@ -268,8 +287,8 @@ const Webinar = WebexPlugin.extend({
       }
 
       // Store token on the channel if it exists, otherwise save for later
-      if (this.practiceSessionLLMChannel) {
-        this.practiceSessionLLMChannel.setDatachannelToken(datachannelToken);
+      if (this._practiceSessionLLMChannel) {
+        this._practiceSessionLLMChannel.setDatachannelToken(datachannelToken);
       } else {
         this._pendingPracticeSessionDatachannelToken = datachannelToken;
       }
@@ -314,10 +333,10 @@ const Webinar = WebexPlugin.extend({
     }
 
     // If already connected to same URLs, skip reconnect
-    if (this.practiceSessionLLMChannel?.isConnected()) {
+    if (this._practiceSessionLLMChannel?.isConnected()) {
       if (
-        url === this.practiceSessionLLMChannel.getLocusUrl() &&
-        practiceSessionDatachannelUrl === this.practiceSessionLLMChannel.getDatachannelUrl()
+        url === this._practiceSessionLLMChannel.getLocusUrl() &&
+        practiceSessionDatachannelUrl === this._practiceSessionLLMChannel.getDatachannelUrl()
       ) {
         return undefined;
       }
@@ -355,7 +374,7 @@ const Webinar = WebexPlugin.extend({
     // Get token from pending or refresh if needed
     let practiceSessionDatachannelToken =
       this._pendingPracticeSessionDatachannelToken ??
-      this.practiceSessionLLMChannel?.getDatachannelToken();
+      this._practiceSessionLLMChannel?.getDatachannelToken();
 
     const refreshedToken = await this.ensurePracticeSessionDatachannelToken(meeting);
 
@@ -383,7 +402,7 @@ const Webinar = WebexPlugin.extend({
     // Create a new practice session LLM channel
     // @ts-ignore - Fix type
     const psChannel = this.webex.internal.llm.createConnection();
-    this.practiceSessionLLMChannel = psChannel;
+    this._practiceSessionLLMChannel = psChannel;
 
     // Set up refresh handler before registration
     psChannel.setRefreshHandler(() => meeting.refreshDataChannelToken());
@@ -398,7 +417,7 @@ const Webinar = WebexPlugin.extend({
       .registerAndConnect(url, practiceSessionDatachannelUrl, practiceSessionDatachannelToken)
       .then(async (registerAndConnectResult) => {
         // Check if this channel is still the current one (race condition guard)
-        if (this.practiceSessionLLMChannel !== psChannel) {
+        if (this._practiceSessionLLMChannel !== psChannel) {
           psChannel.disconnect({code: 3050, reason: 'replaced'}).catch(() => {});
 
           return undefined;
@@ -428,8 +447,8 @@ const Webinar = WebexPlugin.extend({
       })
       .catch((error) => {
         // Clean up the channel on failure, but only if it's still the current one
-        if (this.practiceSessionLLMChannel === psChannel) {
-          this.practiceSessionLLMChannel = undefined;
+        if (this._practiceSessionLLMChannel === psChannel) {
+          this._practiceSessionLLMChannel = undefined;
         }
         throw error;
       });

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -4,6 +4,7 @@
 import {WebexPlugin, config} from '@webex/webex-core';
 import uuid from 'uuid';
 import {get} from 'lodash';
+import type LLMChannel from '@webex/internal-plugin-llm';
 import {
   _ID_,
   HEADERS,
@@ -12,7 +13,6 @@ import {
   SELF_ROLES,
   SHARE_STATUS,
   DEFAULT_LARGE_SCALE_WEBINAR_ATTENDEE_SEARCH_LIMIT,
-  LLM_PRACTICE_SESSION,
   LOCUS_LLM_EVENT,
 } from '../constants';
 
@@ -20,19 +20,6 @@ import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
 import MeetingUtil from '../meeting/util';
 import {sanitizeParams} from './utils';
-
-const PS_LLM_EVENTS = [
-  {
-    event: `event:relay.event:${LLM_PRACTICE_SESSION}`,
-    listenerKey: 'relay',
-    handlerKey: 'processRelayEvent',
-  },
-  {
-    event: `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-    listenerKey: 'locusLLM',
-    handlerKey: 'processLocusLLMEvent',
-  },
-];
 
 /**
  * @class Webinar
@@ -52,6 +39,12 @@ const Webinar = WebexPlugin.extend({
     practiceSessionEnabled: 'boolean', // practice session enabled
     meetingId: 'string',
   },
+
+  /**
+   * LLM channel for practice session, owned by this webinar instance.
+   * @type {LLMChannel|undefined}
+   */
+  practiceSessionLLMChannel: undefined as LLMChannel | undefined,
 
   /**
    * Calls this to clean up listeners
@@ -177,67 +170,41 @@ const Webinar = WebexPlugin.extend({
   },
 
   /**
-   * Disconnects the practice session data channel and removes its relay listener.
-   * The listener reference removed here is the exact callback captured at subscribe
-   * time (see updatePSDataChannel) so that cleanup is correct even if the underlying
-   * meeting can no longer be resolved (e.g. locusUrl mismatch).
+   * Disconnects the practice session LLM channel and cleans up listeners.
    * @returns {Promise<void>}
    */
   async cleanupPSDataChannel() {
-    const {isOwner} = this.webex.internal.llm.resolveSessionOwnership(
-      this.meetingId,
-      LLM_PRACTICE_SESSION
-    );
-    this.llmListeners = this.llmListeners || {};
-
+    // Remove pending online listener if any
     if (this._pendingOnlineListener) {
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.off('online', this._pendingOnlineListener);
+      const meeting = this.getValidatedWebinarMeeting();
+      meeting?.llmChannel?.off('online', this._pendingOnlineListener);
       this._pendingOnlineListener = null;
     }
 
+    if (!this.practiceSessionLLMChannel) {
+      return;
+    }
+
     try {
-      // @ts-ignore - Fix type
-      const disconnected = await this.webex.internal.llm.disconnectLLM(
-        {
-          code: 3050,
-          reason: 'done (permanent)',
-        },
-        LLM_PRACTICE_SESSION,
-        this.meetingId
-      );
-
-      if (!disconnected) {
-        LoggerProxy.logger.info(
-          `Webinar:index#cleanupPSDataChannel --> skipping disconnect; practice-session LLM is not owned by meeting ${this.meetingId}`
-        );
-      }
+      await this.practiceSessionLLMChannel.disconnect({
+        code: 3050,
+        reason: 'done (permanent)',
+      });
     } catch (error) {
-      // disconnectLLM clears ownership only on success; release a stale owner
-      // tag here so other meeting instances can reclaim practice-session LLM.
-      if (isOwner) {
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.setOwnerMeetingId?.(undefined, LLM_PRACTICE_SESSION);
-      }
-
+      LoggerProxy.logger.error(
+        'Webinar:index#cleanupPSDataChannel --> Failed to disconnect practice session LLM channel',
+        error
+      );
       throw error;
     } finally {
-      if (this._practiceSessionRelayListener) {
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off(
-          `event:relay.event:${LLM_PRACTICE_SESSION}`,
-          this._practiceSessionRelayListener
-        );
+      // Remove listeners from the channel
+      const meeting = this.getValidatedWebinarMeeting();
+      if (meeting) {
+        this.practiceSessionLLMChannel?.off('event:relay.event', meeting.processRelayEvent);
+        this.practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        this.practiceSessionLLMChannel?.off('online', meeting.handleLLMOnline);
       }
-      this._practiceSessionRelayListener = null;
-
-      for (const {event, listenerKey} of PS_LLM_EVENTS) {
-        if (this.llmListeners[listenerKey]) {
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.off(event, this.llmListeners[listenerKey]);
-          this.llmListeners[listenerKey] = null;
-        }
-      }
+      this.practiceSessionLLMChannel = undefined;
     }
   },
 
@@ -256,11 +223,10 @@ const Webinar = WebexPlugin.extend({
       return undefined;
     }
 
-    // @ts-ignore
-    const cachedToken = this.webex.internal.llm.getDatachannelToken(
-      LLM_PRACTICE_SESSION,
-      this.meetingId
-    );
+    // Check for cached token on the channel or pending token on the meeting
+    const cachedToken =
+      this.practiceSessionLLMChannel?.getDatachannelToken() ??
+      meeting._pendingPracticeSessionDatachannelToken;
 
     if (cachedToken) {
       return cachedToken;
@@ -268,18 +234,18 @@ const Webinar = WebexPlugin.extend({
 
     try {
       const refreshResponse = await meeting.refreshDataChannelToken();
-      const {datachannelToken, dataChannelTokenType} = refreshResponse?.body ?? {};
+      const {datachannelToken} = refreshResponse?.body ?? {};
 
       if (!datachannelToken) {
         return undefined;
       }
 
-      // @ts-ignore
-      this.webex.internal.llm.setDatachannelToken(
-        datachannelToken,
-        this.meetingId,
-        dataChannelTokenType || LLM_PRACTICE_SESSION
-      );
+      // Store token on the channel if it exists, otherwise on meeting for later
+      if (this.practiceSessionLLMChannel) {
+        this.practiceSessionLLMChannel.setDatachannelToken(datachannelToken);
+      } else {
+        meeting._pendingPracticeSessionDatachannelToken = datachannelToken;
+      }
 
       return datachannelToken;
     } catch (error) {
@@ -294,33 +260,20 @@ const Webinar = WebexPlugin.extend({
   },
 
   /**
-   * Connects to low latency mercury and reconnects if the address has changed
-   * It will also disconnect if called when the meeting has ended
+   * Connects practice session LLM channel. Creates a new channel if needed.
+   * Will disconnect if the meeting has ended or is no longer in practice session mode.
+   * Waits for the main LLM channel to be connected before connecting practice session.
    * @returns {Promise}
    */
   async updatePSDataChannel() {
-    this.llmListeners = this.llmListeners || {};
-
     this._updatePSDataChannelSequence = (this._updatePSDataChannelSequence || 0) + 1;
     const invocationSequence = this._updatePSDataChannelSequence;
 
     const meeting = this.getValidatedWebinarMeeting();
     const isPracticeSession = meeting?.isJoined() && this.isJoinPracticeSessionDataChannel();
-    const {currentOwner, isOwner} = this.webex.internal.llm.resolveSessionOwnership(
-      this.meetingId,
-      LLM_PRACTICE_SESSION
-    );
 
     if (!isPracticeSession) {
       await this.cleanupPSDataChannel();
-
-      return undefined;
-    }
-
-    if (!isOwner) {
-      LoggerProxy.logger.info(
-        `Webinar:index#updatePSDataChannel --> skipping; practice-session LLM owned by meeting ${currentOwner}, not ${this.meetingId}`
-      );
 
       return undefined;
     }
@@ -329,49 +282,36 @@ const Webinar = WebexPlugin.extend({
     const {url = undefined, info: {practiceSessionDatachannelUrl = undefined} = {}} =
       meeting?.locusInfo || {};
 
-    // @ts-ignore
-    let practiceSessionDatachannelToken = this.webex.internal.llm.getDatachannelToken(
-      LLM_PRACTICE_SESSION,
-      this.meetingId
-    );
-
-    const keepTranscriptionSubscribed = this.webex.internal.voicea.getKeepTranscriptionSubscribed();
-
     if (!practiceSessionDatachannelUrl) {
       return undefined;
     }
-    // @ts-ignore - Fix type
-    if (this.webex.internal.llm.isConnected(LLM_PRACTICE_SESSION)) {
+
+    // If already connected to same URLs, skip reconnect
+    if (this.practiceSessionLLMChannel?.isConnected()) {
       if (
-        // @ts-ignore - Fix type
-        url === this.webex.internal.llm.getLocusUrl(LLM_PRACTICE_SESSION) &&
-        // @ts-ignore - Fix type
-        practiceSessionDatachannelUrl ===
-          this.webex.internal.llm.getDatachannelUrl(LLM_PRACTICE_SESSION)
+        url === this.practiceSessionLLMChannel.getLocusUrl() &&
+        practiceSessionDatachannelUrl === this.practiceSessionLLMChannel.getDatachannelUrl()
       ) {
         return undefined;
       }
-
+      // URLs changed, disconnect existing channel
       await this.cleanupPSDataChannel();
     }
 
-    // Ensure the default session data channel is connected before connecting the practice session.
+    // Ensure the default session LLM channel is connected before connecting the practice session.
     // Subscribe before checking isConnected() to avoid a race where the 'online' event fires
-    // between the check and the subscription — Mercury does not replay missed events.
-    if (!this._pendingOnlineListener) {
+    // between the check and the subscription — the channel does not replay missed events.
+    if (!this._pendingOnlineListener && meeting?.llmChannel) {
       const onDefaultSessionConnected = () => {
         this._pendingOnlineListener = null;
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off('online', onDefaultSessionConnected);
+        meeting.llmChannel?.off('online', onDefaultSessionConnected);
         this.updatePSDataChannel();
       };
       this._pendingOnlineListener = onDefaultSessionConnected;
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.on('online', onDefaultSessionConnected);
+      meeting.llmChannel.on('online', onDefaultSessionConnected);
     }
 
-    // @ts-ignore - Fix type
-    if (!this.webex.internal.llm.isConnected()) {
+    if (!meeting?.llmChannel?.isConnected()) {
       LoggerProxy.logger.info(
         'Webinar:index#updatePSDataChannel --> default session not yet connected, deferring practice session connect.'
       );
@@ -381,12 +321,18 @@ const Webinar = WebexPlugin.extend({
 
     // Default session is already connected — cancel the pending listener and proceed
     if (this._pendingOnlineListener) {
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.off('online', this._pendingOnlineListener);
+      meeting.llmChannel.off('online', this._pendingOnlineListener);
       this._pendingOnlineListener = null;
     }
 
-    const refreshedPracticeSessionToken = await this.ensurePracticeSessionDatachannelToken(meeting);
+    const isCaptionBoxOn = this.webex.internal.voicea.getIsCaptionBoxOn();
+
+    // Get token from pending on meeting or refresh if needed
+    let practiceSessionDatachannelToken =
+      meeting._pendingPracticeSessionDatachannelToken ??
+      this.practiceSessionLLMChannel?.getDatachannelToken();
+
+    const refreshedToken = await this.ensurePracticeSessionDatachannelToken(meeting);
 
     const latestPracticeSessionDatachannelUrl = get(
       meeting,
@@ -405,93 +351,50 @@ const Webinar = WebexPlugin.extend({
       return undefined;
     }
 
-    if (refreshedPracticeSessionToken) {
-      practiceSessionDatachannelToken = refreshedPracticeSessionToken;
+    if (refreshedToken) {
+      practiceSessionDatachannelToken = refreshedToken;
     }
 
-    const {currentOwner: currentOwnerBeforeConnect, isOwner: isOwnerBeforeConnect} =
-      this.webex.internal.llm.resolveSessionOwnership(this.meetingId, LLM_PRACTICE_SESSION);
+    // Create a new practice session LLM channel
+    // @ts-ignore - Fix type
+    this.practiceSessionLLMChannel = this.webex.internal.llm.createConnection();
 
-    if (!isOwnerBeforeConnect) {
-      LoggerProxy.logger.info(
-        `Webinar:index#updatePSDataChannel --> skipping pre-connect owner write; practice-session LLM owned by meeting ${currentOwnerBeforeConnect}, not ${this.meetingId}`
+    // Set up refresh handler before registration
+    this.practiceSessionLLMChannel.setRefreshHandler(() => meeting.refreshDataChannelToken());
+
+    // If we have a pending token, store it on the channel
+    if (meeting._pendingPracticeSessionDatachannelToken) {
+      this.practiceSessionLLMChannel.setDatachannelToken(
+        meeting._pendingPracticeSessionDatachannelToken
       );
-
-      return undefined;
+      meeting._pendingPracticeSessionDatachannelToken = undefined;
     }
 
-    // Ensure refresh for practice datachannel requests is routed to this
-    // meeting only when we are actually about to connect the practice session.
-    // This avoids claiming ownership in flows that return early (e.g. missing
-    // practiceSessionDatachannelUrl or waiting for default session online).
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.setRefreshHandler(
-      () => meeting.refreshDataChannelToken(),
-      this.meetingId,
-      LLM_PRACTICE_SESSION
-    );
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.setOwnerMeetingId?.(this.meetingId, LLM_PRACTICE_SESSION);
-
-    // @ts-ignore - Fix type
-    return this.webex.internal.llm
-      .registerAndConnect(
-        url,
-        practiceSessionDatachannelUrl,
-        practiceSessionDatachannelToken,
-        LLM_PRACTICE_SESSION
-      )
+    return this.practiceSessionLLMChannel
+      .registerAndConnect(url, practiceSessionDatachannelUrl, practiceSessionDatachannelToken)
       .then((registerAndConnectResult) => {
-        const {currentOwner: currentOwnerAfterConnect, isOwner: isOwnerAfterConnect} =
-          this.webex.internal.llm.resolveSessionOwnership(this.meetingId, LLM_PRACTICE_SESSION);
+        // Register event listeners on the practice session channel
+        this.practiceSessionLLMChannel.off('event:relay.event', meeting.processRelayEvent);
+        this.practiceSessionLLMChannel.on('event:relay.event', meeting.processRelayEvent);
+        this.practiceSessionLLMChannel.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        this.practiceSessionLLMChannel.on(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        this.practiceSessionLLMChannel.off('online', meeting.handleLLMOnline);
+        this.practiceSessionLLMChannel.on('online', meeting.handleLLMOnline);
 
-        if (this.meetingId && isOwnerAfterConnect) {
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.setOwnerMeetingId?.(this.meetingId, LLM_PRACTICE_SESSION);
-        } else {
-          LoggerProxy.logger.info(
-            `Webinar:index#updatePSDataChannel --> skipping post-connect owner write; practice-session LLM owned by meeting ${currentOwnerAfterConnect}, not ${this.meetingId}`
-          );
-        }
-
-        // Track the exact listener references so cleanupPSDataChannel can
-        // unsubscribe deterministically, even if the meeting can no longer
-        // be resolved at cleanup time.
-        for (const {event, listenerKey, handlerKey} of PS_LLM_EVENTS) {
-          if (this.llmListeners[listenerKey]) {
-            // @ts-ignore - Fix type
-            this.webex.internal.llm.off(event, this.llmListeners[listenerKey]);
-          }
-          this.llmListeners[listenerKey] = meeting?.[handlerKey];
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.on(event, this.llmListeners[listenerKey]);
-        }
         // @ts-ignore - Fix type
         this.webex.internal.voicea?.announce?.();
         if (keepTranscriptionSubscribed) {
           this.webex.internal.voicea.updateSubchannelSubscriptions({subscribe: ['transcription']});
         }
         LoggerProxy.logger.info(
-          `Webinar:index#updatePSDataChannel --> enabled to receive relay events for default session for ${LLM_PRACTICE_SESSION}!`
+          'Webinar:index#updatePSDataChannel --> enabled to receive relay events for practice session!'
         );
 
         return Promise.resolve(registerAndConnectResult);
       })
       .catch((error) => {
-        const {
-          currentOwner: currentOwnerAfterRegisterFailure,
-          isOwner: isOwnerAfterRegisterFailure,
-        } = this.webex.internal.llm.resolveSessionOwnership(this.meetingId, LLM_PRACTICE_SESSION);
-
-        if (isOwnerAfterRegisterFailure) {
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.setOwnerMeetingId?.(undefined, LLM_PRACTICE_SESSION);
-        } else {
-          LoggerProxy.logger.info(
-            `Webinar:index#updatePSDataChannel --> skipping failure owner release; practice-session LLM owned by meeting ${currentOwnerAfterRegisterFailure}, not ${this.meetingId}`
-          );
-        }
-
+        // Clean up the channel on failure
+        this.practiceSessionLLMChannel = undefined;
         throw error;
       });
   },

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -203,6 +203,9 @@ const Webinar = WebexPlugin.extend({
         this.practiceSessionLLMChannel?.off('event:relay.event', meeting.processRelayEvent);
         this.practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
         this.practiceSessionLLMChannel?.off('online', meeting.handleLLMOnline);
+
+        // Unregister annotation from practice session
+        meeting.annotation.unregisterChannel('practice-session');
       }
       this.practiceSessionLLMChannel = undefined;
     }
@@ -380,6 +383,9 @@ const Webinar = WebexPlugin.extend({
         this.practiceSessionLLMChannel.on(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
         this.practiceSessionLLMChannel.off('online', meeting.handleLLMOnline);
         this.practiceSessionLLMChannel.on('online', meeting.handleLLMOnline);
+
+        // Register annotation channel for practice session
+        meeting.annotation.registerChannel(this.practiceSessionLLMChannel, 'practice-session');
 
         // @ts-ignore - Fix type
         this.webex.internal.voicea?.announce?.();

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -328,7 +328,7 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    const isCaptionBoxOn = this.webex.internal.voicea.getIsCaptionBoxOn();
+    const keepTranscriptionSubscribed = meeting.voiceaChannel?.getKeepTranscriptionSubscribed();
 
     // Get token from pending on meeting or refresh if needed
     let practiceSessionDatachannelToken =
@@ -387,10 +387,10 @@ const Webinar = WebexPlugin.extend({
         // Register annotation channel for practice session
         meeting.annotation.registerChannel(this.practiceSessionLLMChannel, 'practice-session');
 
-        // @ts-ignore - Fix type
-        this.webex.internal.voicea?.announce?.();
+        // Announce voicea on practice session channel
+        meeting.voiceaChannel?.announce?.();
         if (keepTranscriptionSubscribed) {
-          this.webex.internal.voicea.updateSubchannelSubscriptions({subscribe: ['transcription']});
+          meeting.voiceaChannel?.updateSubchannelSubscriptions({subscribe: ['transcription']});
         }
         LoggerProxy.logger.info(
           'Webinar:index#updatePSDataChannel --> enabled to receive relay events for practice session!'

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -8,6 +8,7 @@ import type LLMChannel from '@webex/internal-plugin-llm';
 import type {VoiceaChannel} from '@webex/internal-plugin-voicea';
 import {
   _ID_,
+  EVENT_TRIGGERS,
   HEADERS,
   HTTP_VERBS,
   MEETINGS,
@@ -16,6 +17,7 @@ import {
   DEFAULT_LARGE_SCALE_WEBINAR_ATTENDEE_SEARCH_LIMIT,
   LOCUS_LLM_EVENT,
 } from '../constants';
+import Trigger from '../common/events/trigger-proxy';
 
 import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -52,6 +54,13 @@ const Webinar = WebexPlugin.extend({
    * @type {VoiceaChannel|undefined}
    */
   practiceSessionVoiceaChannel: undefined as VoiceaChannel | undefined,
+
+  /**
+   * Pending practice session datachannel token, saved from join response.
+   * Used when creating the practice session LLM channel.
+   * @type {string|undefined}
+   */
+  _pendingPracticeSessionDatachannelToken: undefined as string | undefined,
 
   /**
    * Calls this to clean up listeners
@@ -189,9 +198,23 @@ const Webinar = WebexPlugin.extend({
     }
 
     // Clean up practice session voicea channel
+    const hadVoiceaChannel = !!this.practiceSessionVoiceaChannel;
     if (this.practiceSessionVoiceaChannel) {
       this.practiceSessionVoiceaChannel.deregisterEvents();
       this.practiceSessionVoiceaChannel = undefined;
+    }
+
+    // Emit cleanup event so clients can update their state
+    if (hadVoiceaChannel) {
+      const meeting = this.getValidatedWebinarMeeting();
+      if (meeting) {
+        Trigger.trigger(
+          meeting,
+          {file: 'webinar/index', function: 'cleanupPSDataChannel'},
+          EVENT_TRIGGERS.MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_CLEANED_UP,
+          {}
+        );
+      }
     }
 
     if (!this.practiceSessionLLMChannel) {
@@ -217,8 +240,10 @@ const Webinar = WebexPlugin.extend({
         this.practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
         this.practiceSessionLLMChannel?.off('online', meeting.handleLLMOnline);
 
-        // Unregister annotation from practice session
-        meeting.annotation.unregisterChannel('practice-session');
+        // Switch annotation back to the meeting's default channel
+        if (meeting.llmChannel) {
+          meeting.annotation.registerChannel(meeting.llmChannel);
+        }
       }
       this.practiceSessionLLMChannel = undefined;
     }
@@ -239,10 +264,10 @@ const Webinar = WebexPlugin.extend({
       return undefined;
     }
 
-    // Check for cached token on the channel or pending token on the meeting
+    // Check for cached token on the channel or pending token
     const cachedToken =
       this.practiceSessionLLMChannel?.getDatachannelToken() ??
-      meeting._pendingPracticeSessionDatachannelToken;
+      this._pendingPracticeSessionDatachannelToken;
 
     if (cachedToken) {
       return cachedToken;
@@ -256,11 +281,11 @@ const Webinar = WebexPlugin.extend({
         return undefined;
       }
 
-      // Store token on the channel if it exists, otherwise on meeting for later
+      // Store token on the channel if it exists, otherwise save for later
       if (this.practiceSessionLLMChannel) {
         this.practiceSessionLLMChannel.setDatachannelToken(datachannelToken);
       } else {
-        meeting._pendingPracticeSessionDatachannelToken = datachannelToken;
+        this._pendingPracticeSessionDatachannelToken = datachannelToken;
       }
 
       return datachannelToken;
@@ -343,9 +368,9 @@ const Webinar = WebexPlugin.extend({
 
     const keepTranscriptionSubscribed = meeting.voiceaChannel?.getKeepTranscriptionSubscribed();
 
-    // Get token from pending on meeting or refresh if needed
+    // Get token from pending or refresh if needed
     let practiceSessionDatachannelToken =
-      meeting._pendingPracticeSessionDatachannelToken ??
+      this._pendingPracticeSessionDatachannelToken ??
       this.practiceSessionLLMChannel?.getDatachannelToken();
 
     const refreshedToken = await this.ensurePracticeSessionDatachannelToken(meeting);
@@ -373,48 +398,58 @@ const Webinar = WebexPlugin.extend({
 
     // Create a new practice session LLM channel
     // @ts-ignore - Fix type
-    this.practiceSessionLLMChannel = this.webex.internal.llm.createConnection();
+    const psChannel = this.webex.internal.llm.createConnection();
+    this.practiceSessionLLMChannel = psChannel;
 
     // Set up refresh handler before registration
-    this.practiceSessionLLMChannel.setRefreshHandler(() => meeting.refreshDataChannelToken());
+    psChannel.setRefreshHandler(() => meeting.refreshDataChannelToken());
 
     // If we have a pending token, store it on the channel
-    if (meeting._pendingPracticeSessionDatachannelToken) {
-      this.practiceSessionLLMChannel.setDatachannelToken(
-        meeting._pendingPracticeSessionDatachannelToken
-      );
-      meeting._pendingPracticeSessionDatachannelToken = undefined;
+    if (this._pendingPracticeSessionDatachannelToken) {
+      psChannel.setDatachannelToken(this._pendingPracticeSessionDatachannelToken);
+      this._pendingPracticeSessionDatachannelToken = undefined;
     }
 
-    return this.practiceSessionLLMChannel
+    return psChannel
       .registerAndConnect(url, practiceSessionDatachannelUrl, practiceSessionDatachannelToken)
-      .then((registerAndConnectResult) => {
-        // Register event listeners on the practice session channel
-        this.practiceSessionLLMChannel.off('event:relay.event', meeting.processRelayEvent);
-        this.practiceSessionLLMChannel.on('event:relay.event', meeting.processRelayEvent);
-        this.practiceSessionLLMChannel.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
-        this.practiceSessionLLMChannel.on(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
-        this.practiceSessionLLMChannel.off('online', meeting.handleLLMOnline);
-        this.practiceSessionLLMChannel.on('online', meeting.handleLLMOnline);
+      .then(async (registerAndConnectResult) => {
+        // Check if this channel is still the current one (race condition guard)
+        if (this.practiceSessionLLMChannel !== psChannel) {
+          psChannel.disconnect({code: 3050, reason: 'replaced'}).catch(() => {});
 
-        // Register annotation channel for practice session
-        meeting.annotation.registerChannel(this.practiceSessionLLMChannel, 'practice-session');
+          return undefined;
+        }
+        // Register event listeners on the practice session channel
+        psChannel.off('event:relay.event', meeting.processRelayEvent);
+        psChannel.on('event:relay.event', meeting.processRelayEvent);
+        psChannel.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        psChannel.on(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+        psChannel.off('online', meeting.handleLLMOnline);
+        psChannel.on('online', meeting.handleLLMOnline);
+
+        // Switch annotation to practice session channel
+        meeting.annotation.registerChannel(psChannel);
 
         // Create VoiceaChannel for practice session bound to practiceSessionLLMChannel
         // @ts-ignore - Fix type
-        this.practiceSessionVoiceaChannel = this.webex.internal.voicea.createChannel(
-          this.practiceSessionLLMChannel
-        );
+        this.practiceSessionVoiceaChannel = this.webex.internal.voicea.createChannel(psChannel);
 
         // Set up voicea listeners for practice session channel
         this.setupPracticeSessionVoiceaListeners(meeting);
 
+        // Emit event so clients can register listeners on the new channel
+        Trigger.trigger(
+          meeting,
+          {file: 'webinar/index', function: 'updatePSDataChannel'},
+          EVENT_TRIGGERS.MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_READY,
+          {practiceSessionVoiceaChannel: this.practiceSessionVoiceaChannel}
+        );
+
         // Announce and enable captions on practice session channel
         this.practiceSessionVoiceaChannel?.announce?.();
         if (keepTranscriptionSubscribed) {
-          this.practiceSessionVoiceaChannel?.updateSubchannelSubscriptions({
-            subscribe: ['transcription'],
-          });
+          // Turn on captions for the practice session channel (not just subscribe to events)
+          await this.practiceSessionVoiceaChannel?.turnOnCaptions?.();
         }
         LoggerProxy.logger.info(
           'Webinar:index#updatePSDataChannel --> enabled to receive relay events for practice session!'
@@ -423,8 +458,10 @@ const Webinar = WebexPlugin.extend({
         return Promise.resolve(registerAndConnectResult);
       })
       .catch((error) => {
-        // Clean up the channel on failure
-        this.practiceSessionLLMChannel = undefined;
+        // Clean up the channel on failure, but only if it's still the current one
+        if (this.practiceSessionLLMChannel === psChannel) {
+          this.practiceSessionLLMChannel = undefined;
+        }
         throw error;
       });
   },
@@ -444,6 +481,18 @@ const Webinar = WebexPlugin.extend({
     Object.keys(meeting.voiceaListenerCallbacks).forEach((eventName) => {
       this.practiceSessionVoiceaChannel.on(eventName, meeting.voiceaListenerCallbacks[eventName]);
     });
+  },
+
+  /**
+   * Turns on captions for the practice session voicea channel if it exists.
+   * Encapsulates access to practiceSessionVoiceaChannel.
+   * @param {string} [spokenLanguage] - Optional spoken language to use
+   * @returns {Promise<void>}
+   */
+  async turnOnCaptions(spokenLanguage?: string): Promise<void> {
+    if (this.practiceSessionVoiceaChannel) {
+      await this.practiceSessionVoiceaChannel.turnOnCaptions(spokenLanguage);
+    }
   },
 
   /**

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -186,6 +186,14 @@ const Webinar = WebexPlugin.extend({
   },
 
   /**
+   * Returns the practice session LLM channel binding, if connected.
+   * @returns {string|undefined}
+   */
+  getPracticeSessionBinding() {
+    return this.practiceSessionLLMChannel?.getBinding();
+  },
+
+  /**
    * Disconnects the practice session LLM channel and cleans up listeners.
    * @returns {Promise<void>}
    */

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -5,7 +5,6 @@ import {WebexPlugin, config} from '@webex/webex-core';
 import uuid from 'uuid';
 import {get} from 'lodash';
 import type LLMChannel from '@webex/internal-plugin-llm';
-import type {VoiceaChannel} from '@webex/internal-plugin-voicea';
 import {
   _ID_,
   EVENT_TRIGGERS,
@@ -48,12 +47,6 @@ const Webinar = WebexPlugin.extend({
    * @type {LLMChannel|undefined}
    */
   practiceSessionLLMChannel: undefined as LLMChannel | undefined,
-
-  /**
-   * Voicea channel for practice session, bound to practiceSessionLLMChannel.
-   * @type {VoiceaChannel|undefined}
-   */
-  practiceSessionVoiceaChannel: undefined as VoiceaChannel | undefined,
 
   /**
    * Pending practice session datachannel token, saved from join response.
@@ -205,24 +198,10 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    // Clean up practice session voicea channel
-    const hadVoiceaChannel = !!this.practiceSessionVoiceaChannel;
-    if (this.practiceSessionVoiceaChannel) {
-      this.practiceSessionVoiceaChannel.deregisterEvents();
-      this.practiceSessionVoiceaChannel = undefined;
-    }
-
-    // Emit cleanup event so clients can update their state
-    if (hadVoiceaChannel) {
-      const meeting = this.getValidatedWebinarMeeting();
-      if (meeting) {
-        Trigger.trigger(
-          meeting,
-          {file: 'webinar/index', function: 'cleanupPSDataChannel'},
-          EVENT_TRIGGERS.MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_CLEANED_UP,
-          {}
-        );
-      }
+    // Switch voicea back to main meeting LLM channel before disconnecting PS channel
+    const meeting = this.getValidatedWebinarMeeting();
+    if (meeting?.voiceaChannel && meeting?.llmChannel) {
+      await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
     }
 
     if (!this.practiceSessionLLMChannel) {
@@ -242,7 +221,6 @@ const Webinar = WebexPlugin.extend({
       throw error;
     } finally {
       // Remove listeners from the channel
-      const meeting = this.getValidatedWebinarMeeting();
       if (meeting) {
         this.practiceSessionLLMChannel?.off('event:relay.event', meeting.processRelayEvent);
         this.practiceSessionLLMChannel?.off(LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
@@ -374,8 +352,6 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    const keepTranscriptionSubscribed = meeting.voiceaChannel?.getKeepTranscriptionSubscribed();
-
     // Get token from pending or refresh if needed
     let practiceSessionDatachannelToken =
       this._pendingPracticeSessionDatachannelToken ??
@@ -438,27 +414,12 @@ const Webinar = WebexPlugin.extend({
         // Switch annotation to practice session channel
         meeting.annotation.registerChannel(psChannel);
 
-        // Create VoiceaChannel for practice session bound to practiceSessionLLMChannel
-        // @ts-ignore - Fix type
-        this.practiceSessionVoiceaChannel = this.webex.internal.voicea.createChannel(psChannel);
-
-        // Set up voicea listeners for practice session channel
-        this.setupPracticeSessionVoiceaListeners(meeting);
-
-        // Emit event so clients can register listeners on the new channel
-        Trigger.trigger(
-          meeting,
-          {file: 'webinar/index', function: 'updatePSDataChannel'},
-          EVENT_TRIGGERS.MEETING_PRACTICE_SESSION_VOICEA_CHANNEL_READY,
-          {practiceSessionVoiceaChannel: this.practiceSessionVoiceaChannel}
-        );
-
-        // Announce and enable captions on practice session channel
-        this.practiceSessionVoiceaChannel?.announce?.();
-        if (keepTranscriptionSubscribed) {
-          // Turn on captions for the practice session channel (not just subscribe to events)
-          await this.practiceSessionVoiceaChannel?.turnOnCaptions?.();
+        // Switch meeting's voicea channel to use the PS LLM connection
+        // This preserves caption state and re-announces automatically
+        if (meeting.voiceaChannel) {
+          await meeting.voiceaChannel.switchLLMChannel(psChannel);
         }
+
         LoggerProxy.logger.info(
           'Webinar:index#updatePSDataChannel --> enabled to receive relay events for practice session!'
         );
@@ -472,35 +433,6 @@ const Webinar = WebexPlugin.extend({
         }
         throw error;
       });
-  },
-
-  /**
-   * Sets up voicea listeners for practice session channel to forward events to the meeting.
-   * This allows captions to work during practice session.
-   * @param {object} meeting - The meeting instance
-   * @returns {void}
-   */
-  setupPracticeSessionVoiceaListeners(meeting) {
-    if (!this.practiceSessionVoiceaChannel || !meeting) {
-      return;
-    }
-
-    // Forward voicea events from practice session channel to meeting's voicea callbacks
-    Object.keys(meeting.voiceaListenerCallbacks).forEach((eventName) => {
-      this.practiceSessionVoiceaChannel.on(eventName, meeting.voiceaListenerCallbacks[eventName]);
-    });
-  },
-
-  /**
-   * Turns on captions for the practice session voicea channel if it exists.
-   * Encapsulates access to practiceSessionVoiceaChannel.
-   * @param {string} [spokenLanguage] - Optional spoken language to use
-   * @returns {Promise<void>}
-   */
-  async turnOnCaptions(spokenLanguage?: string): Promise<void> {
-    if (this.practiceSessionVoiceaChannel) {
-      await this.practiceSessionVoiceaChannel.turnOnCaptions(spokenLanguage);
-    }
   },
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -7,14 +7,34 @@ import LLMChannel from '@webex/internal-plugin-llm';
 
 import AnnotationService from '../../../../src/annotation/index';
 import {ANNOTATION_RELAY_TYPES, ANNOTATION_REQUEST_TYPE, EVENT_TRIGGERS} from '../../../../src/annotation/constants';
-import {LLM_PRACTICE_SESSION} from '../../../../src/constants';
 
+/**
+ * Creates a mock LLM channel for testing
+ * @param {Object} [options] - Options for the mock channel
+ * @param {boolean} [options.isConnected=true] - Whether the channel is connected
+ * @param {string} [options.binding] - The binding string
+ * @returns {Object} Mock channel
+ */
+function createMockLLMChannel(options: {isConnected?: boolean; binding?: string} = {}) {
+  const mockWebSocket = new MockWebSocket();
+  const {isConnected = true, binding = 'binding'} = options;
+
+  return {
+    isConnected: sinon.stub().returns(isConnected),
+    getSocket: sinon.stub().returns(mockWebSocket),
+    getBinding: sinon.stub().returns(binding),
+    getLocusUrl: sinon.stub().returns('locusUrl'),
+    on: sinon.stub(),
+    off: sinon.stub(),
+    socket: mockWebSocket,
+  };
+}
 
 describe('live-annotation', () => {
   const locusUrl = 'https://locus.wbx2.com/locus/api/v1/loci/163c1787-c1f5-47cc-95eb-ab2d660999e6';
 
   describe('annotation', () => {
-    let webex, annotationService;
+    let webex, annotationService, mockChannel;
 
     beforeEach(() => {
       webex = new MockWebex({
@@ -25,26 +45,56 @@ describe('live-annotation', () => {
         },
       });
 
-
       annotationService = webex.internal.annotation;
-      annotationService.connect = sinon.stub().resolves(true);
-      annotationService.webex.internal.llm.isConnected = sinon.stub().returns(true);
-      annotationService.webex.internal.llm.getSocket = sinon.stub().returns(undefined);
-      annotationService.webex.internal.llm.getBinding = sinon.stub().returns(undefined);
-      annotationService.webex.internal.llm.getLocusUrl = sinon.stub().returns(locusUrl);
       annotationService.approvalUrl = 'url/approval';
       annotationService.locusUrl = locusUrl;
 
+      mockChannel = createMockLLMChannel();
 
       webex.request = sinon.stub().returns(Promise.resolve('REQUEST_RETURN_VALUE'));
-      annotationService.register = sinon.stub().resolves({
-        body: {
-          binding: 'binding',
-          webSocketUrl: 'url',
-        },
+    });
+
+    afterEach(() => {
+      annotationService.unregisterChannel();
+      sinon.restore();
+    });
+
+    describe('#registerChannel', () => {
+      it('registers an LLM channel and subscribes to relay events', () => {
+        annotationService.registerChannel(mockChannel);
+
+        assert.calledOnceWithExactly(mockChannel.on, 'event:relay.event', sinon.match.func);
+        assert.equal(annotationService.channel, mockChannel);
+      });
+
+      it('unregisters existing channel before registering new one', () => {
+        const oldChannel = createMockLLMChannel();
+        annotationService.registerChannel(oldChannel);
+
+        const newChannel = createMockLLMChannel();
+        annotationService.registerChannel(newChannel);
+
+        assert.calledOnceWithExactly(oldChannel.off, 'event:relay.event', sinon.match.func);
+        assert.calledOnceWithExactly(newChannel.on, 'event:relay.event', sinon.match.func);
+        assert.equal(annotationService.channel, newChannel);
       });
     });
 
+    describe('#unregisterChannel', () => {
+      it('unregisters the current channel', () => {
+        annotationService.registerChannel(mockChannel);
+        annotationService.unregisterChannel();
+
+        assert.calledOnceWithExactly(mockChannel.off, 'event:relay.event', sinon.match.func);
+        assert.equal(annotationService.channel, undefined);
+      });
+
+      it('does nothing if no channel is registered', () => {
+        annotationService.unregisterChannel();
+        // Should not throw
+        assert.equal(annotationService.channel, undefined);
+      });
+    });
 
     describe('event message processing', () => {
       beforeEach(async () => {
@@ -57,10 +107,8 @@ describe('live-annotation', () => {
         annotationService.eventCommandProcessor({});
         assert.notCalled(spy);
 
-
         annotationService.eventCommandProcessor({
-          data: {
-          }
+          data: {}
         });
         assert.notCalled(spy);
 
@@ -94,10 +142,8 @@ describe('live-annotation', () => {
             }
           }
         });
-        assert.notCalled(spy)
+        assert.notCalled(spy);
       });
-
-
 
       it('eventCommandProcessor call success', () => {
         const spy = sinon.spy();
@@ -123,79 +169,81 @@ describe('live-annotation', () => {
       });
 
       it('eventDataProcessor call failed', () => {
-
-        const spy = sinon.spy(annotationService, "processStrokeMessage");
+        const spy = sinon.spy(annotationService, 'processStrokeMessage');
 
         annotationService.eventDataProcessor();
-
         assert.notCalled(spy);
 
         annotationService.eventDataProcessor({data: {}});
-
         assert.notCalled(spy);
 
         annotationService.eventDataProcessor({data: {relayType: 'NOT:annotation.client'}});
-
         assert.notCalled(spy);
       });
 
-
       it('eventDataProcessor call success', () => {
+        const spy = sinon.spy(annotationService, 'processStrokeMessage');
 
-        const spy = sinon.spy(annotationService, "processStrokeMessage");
-
-        annotationService.eventDataProcessor({data: {relayType: 'annotation.client', request:{value:{encryptionKeyUrl:"encryptionKeyUrl"}}}});
+        annotationService.eventDataProcessor({
+          data: {
+            relayType: 'annotation.client',
+            request: {value: {encryptionKeyUrl: 'encryptionKeyUrl'}}
+          }
+        });
 
         assert.calledOnceWithExactly(spy, {
           relayType: 'annotation.client',
-          request: { value: { encryptionKeyUrl: 'encryptionKeyUrl' } }
-        } );
-
+          request: {value: {encryptionKeyUrl: 'encryptionKeyUrl'}}
+        });
       });
-
 
       it('processStrokeMessage', async () => {
         const spy = sinon.spy();
         annotationService.on(EVENT_TRIGGERS.ANNOTATION_STROKE_DATA, spy);
 
-        await annotationService.processStrokeMessage({request:{value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}}});
-
-        assert.calledOnceWithExactly(spy, {
-          payload:{request:{value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'}}} ,
+        await annotationService.processStrokeMessage({
+          request: {value: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}}
         });
 
+        assert.calledOnceWithExactly(spy, {
+          payload: {request: {value: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'}}},
+        });
       });
-
     });
 
-    describe('event message processing',() =>{
+    describe('event registration via registerChannel', () => {
+      it('registers relay event handler when channel is registered', () => {
+        annotationService.registerChannel(mockChannel);
 
-      it('listens to mercury events once', () => {
+        assert.calledOnceWithExactly(mockChannel.on, 'event:relay.event', sinon.match.func);
+      });
 
+      it('processes events through the registered handler', () => {
+        annotationService.decryptContent = sinon.stub().returns(Promise.resolve('decryptedContent'));
+        annotationService.registerChannel(mockChannel);
+
+        // Get the handler that was registered
+        const handler = mockChannel.on.getCall(0).args[1];
+
+        const spy = sinon.spy(annotationService, 'processStrokeMessage');
+        handler({
+          data: {
+            relayType: 'annotation.client',
+            request: {value: {encryptionKeyUrl: 'key'}}
+          }
+        });
+
+        assert.calledOnce(spy);
+      });
+
+      it('listens to mercury events via listenToEvents', () => {
         const spy = sinon.spy(annotationService.webex.internal.mercury, 'on');
 
         annotationService.listenToEvents();
 
-        assert.calledOnceWithExactly(spy, 'event:locus.approval_request', sinon.match.func,sinon.match.object);
+        assert.calledOnceWithExactly(spy, 'event:locus.approval_request', sinon.match.func, sinon.match.object);
       });
-
-      it('listens to llm events once', () => {
-
-        const spy = sinon.spy(webex.internal.llm, 'on');
-
-        annotationService.listenToEvents();
-
-        assert.calledWithExactly(spy.firstCall, 'event:relay.event', sinon.match.func, sinon.match.object);
-        assert.calledWithExactly(
-          spy.secondCall,
-          `event:relay.event:${LLM_PRACTICE_SESSION}`,
-          sinon.match.func,
-          sinon.match.object
-        );
-      });
-
     });
-
 
     describe('encrypt/decrypt Content', () => {
       beforeEach(async () => {
@@ -204,59 +252,64 @@ describe('live-annotation', () => {
       });
 
       it('encryptContent', async () => {
-        const result = await annotationService.encryptContent("encryptionKeyUrl", "content");
-        assert.calledOnceWithExactly(webex.internal.encryption.encryptText, "encryptionKeyUrl", "content");
-        assert.equal(result, 'RETURN_VALUE')
+        const result = await annotationService.encryptContent('encryptionKeyUrl', 'content');
+        assert.calledOnceWithExactly(webex.internal.encryption.encryptText, 'encryptionKeyUrl', 'content');
+        assert.equal(result, 'RETURN_VALUE');
       });
 
-      it('decryptContent', async() => {
-        const result =  await annotationService.decryptContent("decryptionKeyUrl", "content");
-        assert.calledOnceWithExactly(webex.internal.encryption.decryptText, "decryptionKeyUrl", "content");
-        assert.equal(result, 'RETURN_VALUE')
+      it('decryptContent', async () => {
+        const result = await annotationService.decryptContent('decryptionKeyUrl', 'content');
+        assert.calledOnceWithExactly(webex.internal.encryption.decryptText, 'decryptionKeyUrl', 'content');
+        assert.equal(result, 'RETURN_VALUE');
       });
-
     });
 
-
-
-    describe('publish Stroke Data with LLM is not connected', () => {
-
-      beforeEach(async () => {
-        annotationService.webex.internal.llm.socket = new MockWebSocket();
-        annotationService.webex.internal.llm.isConnected = sinon.stub().returns(false);
+    describe('publish Stroke Data with no channel registered', () => {
+      it('does not send when no channel is registered', async () => {
+        annotationService.sendStrokeData({});
+        // Should not throw, just return early
       });
+    });
 
-      it('publish Stroke Data with LLM is not connected', async () => {
-        annotationService.sendStrokeData("", {});
-        assert.notCalled(annotationService.webex.internal.llm.socket.send);
+    describe('publish Stroke Data with channel not connected', () => {
+      it('does not send when channel is not connected', async () => {
+        const disconnectedChannel = createMockLLMChannel({isConnected: false});
+        annotationService.registerChannel(disconnectedChannel);
+
+        annotationService.sendStrokeData({});
+        assert.notCalled(disconnectedChannel.socket.send);
       });
-
     });
 
     describe('sendStrokeData', () => {
       let strokeData;
 
       beforeEach(async () => {
-        annotationService.webex.internal.llm.socket = new MockWebSocket();
+        annotationService.registerChannel(mockChannel);
+        annotationService.webex.internal.encryption.encryptText = sinon.stub().returns(Promise.resolve('encryptedContent'));
+
         strokeData = {
           content: {
-            "contentsBuffer": [{
-              "contentArray": [{
-                "curveId": "58dcf45c-1fc5-46bf-a902-053621dd8977",
-                "curvePoints": [592.593, 352.963, 3.400, 596.710, 352.963, 3.400, 600.000, 352.963, 3.398, 600.000, 352.963, 3.398],
-                "stride": 3
-              }], "type": "curve", "name": "contentUpdate"
-            }], "action": "contentUpdate", "sender": {"name": "perfect", "id": "4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741"}
+            contentsBuffer: [{
+              contentArray: [{
+                curveId: '58dcf45c-1fc5-46bf-a902-053621dd8977',
+                curvePoints: [592.593, 352.963, 3.400, 596.710, 352.963, 3.400],
+                stride: 3
+              }],
+              type: 'curve',
+              name: 'contentUpdate'
+            }],
+            action: 'contentUpdate',
+            sender: {name: 'perfect', id: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741'}
           },
-          deviceId: "525ead98-6c93-4fcb-899d-517305c47513",
+          deviceId: '525ead98-6c93-4fcb-899d-517305c47513',
           requesterId: '525ead98-6c93-4fcb-899d-517305c47513',
-          toUserId: "987ead98-6c93-4fcb-899d-517305c47503",
+          toUserId: '987ead98-6c93-4fcb-899d-517305c47503',
           shareInstanceId: '7fa6fe07-dcb1-41ad-973d-7bcf65fab55d',
-          encryptionKeyUrl: "encryptionKeyUrl",
+          encryptionKeyUrl: 'encryptionKeyUrl',
           version: '1',
         };
       });
-
 
       it('works on publish Stroke Data', async () => {
         annotationService.publishEncrypted(strokeData.content, strokeData);
@@ -264,7 +317,7 @@ describe('live-annotation', () => {
         const sendObject = {
           id: sinon.match.string,
           type: 'publishRequest',
-          recipients: {route: undefined},
+          recipients: {route: 'binding'},
           headers: {to: '987ead98-6c93-4fcb-899d-517305c47503'},
           data: {
             eventType: 'relay.event',
@@ -274,7 +327,7 @@ describe('live-annotation', () => {
                 type: ANNOTATION_REQUEST_TYPE.ANNOTATION_MESSAGE,
                 content: strokeData.content,
                 version: '1',
-                seq:sinon.match.number,
+                seq: sinon.match.number,
                 deviceId: sinon.match.string,
                 requesterId: sinon.match.string,
                 shareInstanceId: strokeData.shareInstanceId,
@@ -288,66 +341,48 @@ describe('live-annotation', () => {
           filterMessage: false,
         };
 
-        assert.calledOnceWithExactly(annotationService.webex.internal.llm.socket.send, sendObject);
+        assert.calledOnceWithExactly(mockChannel.socket.send, sendObject);
       });
 
-      it('uses the practice-session socket and binding only when the practice-session session is connected', () => {
-        const practiceSocket = new MockWebSocket();
+      it('does not send if socket is not available', () => {
+        const channelWithoutSocket = createMockLLMChannel();
+        channelWithoutSocket.getSocket.returns(undefined);
+        annotationService.registerChannel(channelWithoutSocket);
 
-        annotationService.webex.internal.llm.isConnected.callsFake((sessionId) =>
-          sessionId === LLM_PRACTICE_SESSION
+        annotationService.publishEncrypted(strokeData.content, strokeData);
+
+        assert.notCalled(channelWithoutSocket.socket.send);
+      });
+
+      it('does not send if binding is not available', () => {
+        const channelWithoutBinding = createMockLLMChannel({binding: undefined});
+        channelWithoutBinding.getBinding.returns(undefined);
+        annotationService.registerChannel(channelWithoutBinding);
+
+        annotationService.publishEncrypted(strokeData.content, strokeData);
+
+        assert.notCalled(channelWithoutBinding.socket.send);
+      });
+
+      it('encrypts content before publishing', async () => {
+        await annotationService.sendStrokeData(strokeData);
+
+        assert.calledOnceWithExactly(
+          webex.internal.encryption.encryptText,
+          strokeData.encryptionKeyUrl,
+          strokeData.content
         );
-        annotationService.webex.internal.llm.getSocket
-          .withArgs(LLM_PRACTICE_SESSION)
-          .returns(practiceSocket);
-        annotationService.webex.internal.llm.getBinding
-          .withArgs(LLM_PRACTICE_SESSION)
-          .returns('practice-binding');
-
-        annotationService.publishEncrypted(strokeData.content, strokeData);
-
-        assert.calledOnce(practiceSocket.send);
-        assert.notCalled(annotationService.webex.internal.llm.socket.send);
-
-        const sent = practiceSocket.send.getCall(0).args[0];
-        assert.equal(sent.recipients.route, 'practice-binding');
       });
-
-      it('falls back to the default socket and binding when the practice-session socket exists but is not connected', () => {
-        const practiceSocket = new MockWebSocket();
-
-        annotationService.webex.internal.llm.isConnected.callsFake((sessionId) => !sessionId);
-        annotationService.webex.internal.llm.getSocket
-          .withArgs(LLM_PRACTICE_SESSION)
-          .returns(practiceSocket);
-        annotationService.webex.internal.llm.getBinding
-          .withArgs(LLM_PRACTICE_SESSION)
-          .returns('practice-binding');
-        annotationService.webex.internal.llm.getBinding.returns('default-binding');
-
-        annotationService.publishEncrypted(strokeData.content, strokeData);
-
-        assert.notCalled(practiceSocket.send);
-        assert.calledOnce(annotationService.webex.internal.llm.socket.send);
-
-        const sent = annotationService.webex.internal.llm.socket.send.getCall(0).args[0];
-        assert.equal(sent.recipients.route, 'default-binding');
-      });
-
     });
 
-
     describe('Locus API collection', () => {
-
       describe('send approve request', () => {
-        it('makes  send request approved annotation as expected', async () => {
-          const
-            requestData = {
-              toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
-              toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
-              shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
-            };
-
+        it('makes send request approved annotation as expected', async () => {
+          const requestData = {
+            toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
+            toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
+            shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
+          };
 
           const result = await annotationService.approveAnnotation(requestData);
           assert.calledOnceWithExactly(webex.request, {
@@ -364,22 +399,20 @@ describe('live-annotation', () => {
             }
           });
 
-          assert.equal(result, 'REQUEST_RETURN_VALUE')
+          assert.equal(result, 'REQUEST_RETURN_VALUE');
         });
       });
 
       describe('cancel Approve request', () => {
         it('makes the cancel Approve request annotation as expected', async () => {
-          const
-            requestData = {
-              toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
-              toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
-              shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
-            };
-          const approval = {url:"url/cancel"};
+          const requestData = {
+            toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
+            toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
+            shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
+          };
+          const approval = {url: 'url/cancel'};
 
-
-          const result = await annotationService.cancelApproveAnnotation(requestData,approval);
+          const result = await annotationService.cancelApproveAnnotation(requestData, approval);
           assert.calledOnceWithExactly(webex.request, {
             method: 'PUT',
             url: 'url/cancel',
@@ -390,21 +423,17 @@ describe('live-annotation', () => {
             }
           });
 
-          assert.equal(result, 'REQUEST_RETURN_VALUE')
+          assert.equal(result, 'REQUEST_RETURN_VALUE');
         });
       });
 
-
-
       describe('close annotation', () => {
         it('makes the close annotation as expected', async () => {
-          const
-            requestData = {
-              toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
-              toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
-              shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
-            };
-
+          const requestData = {
+            toUserId: '4dd5eaf9-4cf8-4f0f-a1d6-014bf5d00741',
+            toDeviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/a3018aa9-70cb-4142-ae9a-f03db4fe1057',
+            shareInstanceId: '9428c492-da14-476f-a36c-b377ee8c4009',
+          };
 
           const result = await annotationService.closeAnnotation(requestData);
           assert.calledOnceWithExactly(webex.request, {
@@ -421,16 +450,15 @@ describe('live-annotation', () => {
             }
           });
 
-          assert.equal(result, 'REQUEST_RETURN_VALUE')
+          assert.equal(result, 'REQUEST_RETURN_VALUE');
         });
       });
-
 
       describe('declined annotation', () => {
         it('makes the declined annotation as expected', async () => {
           const approval = {
             url: 'approvalUrl'
-          }
+          };
           const result = await annotationService.declineRequest(approval);
           assert.calledOnceWithExactly(webex.request, {
             method: 'PUT',
@@ -441,7 +469,7 @@ describe('live-annotation', () => {
             }
           });
 
-          assert.equal(result, 'REQUEST_RETURN_VALUE')
+          assert.equal(result, 'REQUEST_RETURN_VALUE');
         });
       });
 
@@ -449,7 +477,7 @@ describe('live-annotation', () => {
         it('makes the accepted annotation as expected', async () => {
           const approval = {
             url: 'approvalUrl'
-          }
+          };
           const result = await annotationService.acceptRequest(approval);
           assert.calledOnceWithExactly(webex.request, {
             method: 'PUT',
@@ -460,65 +488,69 @@ describe('live-annotation', () => {
             }
           });
 
-          assert.equal(result, 'REQUEST_RETURN_VALUE')
+          assert.equal(result, 'REQUEST_RETURN_VALUE');
         });
       });
     });
 
     describe('#deregisterEvents', () => {
-      let llmOn;
-      let llmOff;
       let mercuryOn;
       let mercuryOff;
 
       beforeEach(() => {
-        llmOn = sinon.spy(webex.internal.llm, 'on');
-        llmOff = sinon.spy(webex.internal.llm, 'off');
         mercuryOn = sinon.spy(webex.internal.mercury, 'on');
         mercuryOff = sinon.spy(webex.internal.mercury, 'off');
       });
 
-      it('cleans up events', () => {
+      it('cleans up mercury events and unregisters channel', () => {
+        annotationService.registerChannel(mockChannel);
         annotationService.locusUrlUpdate(locusUrl);
+
         assert.calledWith(
           mercuryOn,
           'event:locus.approval_request',
           annotationService.eventCommandProcessor,
           annotationService
         );
-        assert.calledWith(
-          llmOn,
-          'event:relay.event',
-          annotationService.eventDataProcessor,
-          annotationService
-        );
-        assert.calledWith(
-          llmOn,
-          `event:relay.event:${LLM_PRACTICE_SESSION}`,
-          annotationService.eventDataProcessor,
-          annotationService
-        );
         assert.match(annotationService.hasSubscribedToEvents, true);
 
         annotationService.deregisterEvents();
-        assert.calledWith(llmOff, 'event:relay.event', annotationService.eventDataProcessor);
-        assert.calledWith(
-          llmOff,
-          `event:relay.event:${LLM_PRACTICE_SESSION}`,
-          annotationService.eventDataProcessor
-        );
+
         assert.calledWith(
           mercuryOff,
           'event:locus.approval_request',
           annotationService.eventCommandProcessor
         );
+        assert.calledOnceWithExactly(mockChannel.off, 'event:relay.event', sinon.match.func);
+        assert.equal(annotationService.channel, undefined);
         assert.match(annotationService.hasSubscribedToEvents, false);
       });
 
-      it('does not call llm off if events have not been registered', () => {
+      it('does not call off if events have not been registered', () => {
         annotationService.deregisterEvents();
-        assert.notCalled(llmOff);
         assert.notCalled(mercuryOff);
+      });
+    });
+
+    describe('#locusUrlUpdate', () => {
+      it('updates locusUrl and calls listenToEvents', () => {
+        const newLocusUrl = 'https://new-locus-url.com';
+        const listenSpy = sinon.spy(annotationService, 'listenToEvents');
+
+        annotationService.locusUrlUpdate(newLocusUrl);
+
+        assert.equal(annotationService.locusUrl, newLocusUrl);
+        assert.calledOnce(listenSpy);
+      });
+    });
+
+    describe('#approvalUrlUpdate', () => {
+      it('updates approvalUrl', () => {
+        const newApprovalUrl = 'https://new-approval-url.com';
+
+        annotationService.approvalUrlUpdate(newApprovalUrl);
+
+        assert.equal(annotationService.approvalUrl, newApprovalUrl);
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -640,40 +640,138 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#registerLLMChannel', () => {
+      it('registers an LLM channel', () => {
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+
+        breakouts.registerLLMChannel(mockChannel);
+
+        assert.equal(breakouts._llmChannel, mockChannel);
+      });
+
+      it('cleans up previous channel before registering new one', () => {
+        const oldChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        const newChannel = {
+          isConnected: sinon.stub().returns(false),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+
+        breakouts.registerLLMChannel(oldChannel);
+        // After registering connected channel, hasSubscribedToMessage becomes true
+        assert.equal(breakouts.hasSubscribedToMessage, true);
+
+        const stopListeningSpy = sinon.spy(breakouts, 'stopListening');
+        breakouts.registerLLMChannel(newChannel);
+
+        // Should have called stopListening to clean up old channel
+        assert.calledWith(stopListeningSpy, oldChannel);
+        assert.equal(breakouts._llmChannel, newChannel);
+        // Since newChannel is not connected, hasSubscribedToMessage stays false
+        assert.equal(breakouts.hasSubscribedToMessage, false);
+      });
+    });
+
+    describe('#unregisterLLMChannel', () => {
+      it('unregisters the LLM channel', () => {
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+
+        breakouts.registerLLMChannel(mockChannel);
+        breakouts.hasSubscribedToMessage = true;
+
+        breakouts.unregisterLLMChannel();
+
+        assert.equal(breakouts._llmChannel, undefined);
+        assert.equal(breakouts.hasSubscribedToMessage, false);
+      });
+
+      it('does nothing if no channel is registered', () => {
+        breakouts.unregisterLLMChannel();
+        assert.equal(breakouts._llmChannel, undefined);
+      });
+    });
+
     describe('#listenToBroadcastMessages', () => {
-      it('do not subscribe message if llm not connected', () => {
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-        breakouts.listenTo = sinon.stub();
+      it('do not subscribe message if no channel registered', () => {
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
         breakouts.locusUrlUpdate('newUrl');
         assert.equal(breakouts.locusUrl, 'newUrl');
-        assert.notCalled(breakouts.listenTo);
+        assert.notCalled(listenToSpy);
+      });
+
+      it('do not subscribe message if channel not connected', () => {
+        const mockChannel = {
+          isConnected: sinon.stub().returns(false),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        breakouts._llmChannel = mockChannel;
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
+        breakouts.listenToBroadcastMessages();
+        assert.notCalled(listenToSpy);
       });
 
       it('do not subscribe message if already done', () => {
-        webex.internal.llm.isConnected = sinon.stub().returns(true);
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        breakouts._llmChannel = mockChannel;
         breakouts.hasSubscribedToMessage = true;
-        breakouts.listenTo = sinon.stub();
-        breakouts.locusUrlUpdate('newUrl');
-        assert.equal(breakouts.locusUrl, 'newUrl');
-        assert.notCalled(breakouts.listenTo);
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
+        breakouts.listenToBroadcastMessages();
+        assert.notCalled(listenToSpy);
+      });
+
+      it('subscribes to breakout.message events on connected channel', () => {
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        breakouts._llmChannel = mockChannel;
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
+        breakouts.listenToBroadcastMessages();
+
+        assert.calledOnce(listenToSpy);
+        assert.calledWith(listenToSpy, mockChannel, 'event:breakout.message', sinon.match.func);
+        assert.equal(breakouts.hasSubscribedToMessage, true);
       });
 
       it('triggers message event when a message received', () => {
-        webex.internal.llm.isConnected = sinon.stub().returns(true);
-        breakouts.locusUrlUpdate('newUrl');
-        const call = webex.internal.llm.on.getCall(0);
-        const callback = call.args[1];
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        breakouts._llmChannel = mockChannel;
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
+        breakouts.listenToBroadcastMessages();
 
-        assert.equal(call.args[0], 'event:breakout.message');
+        // Get the callback passed to listenTo
+        const callback = listenToSpy.getCall(0).args[2];
 
         let message;
-
         breakouts.listenTo(breakouts, BREAKOUTS.EVENTS.MESSAGE, (event) => {
           message = event;
         });
 
         breakouts.currentBreakoutSession.sessionId = 'sessionId';
 
+        // Simulate the LLM channel event
         callback({
           data: {
             senderUserId: 'senderUserId',
@@ -1627,7 +1725,7 @@ describe('plugin-meetings', () => {
           state: 'LOCKED',
         };
 
-        await expect(breakouts.lockBreakout()).to.be.rejectedWith('Breakout already locked');
+        await assert.isRejected(breakouts.lockBreakout(), Error, 'Breakout already locked');
       });
 
       it('lock breakout without editLock', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
@@ -249,9 +249,7 @@ describe('plugin-meetings', () => {
                 dataChannelTokenType: 'llm-practice-session',
               },
             }),
-            llmChannel: {
-              setDatachannelToken: sinon.stub(),
-            },
+            setLLMChannelDataToken: sinon.stub(),
           };
 
           llmMock = {
@@ -322,7 +320,7 @@ describe('plugin-meetings', () => {
           expect(token).to.equal('token-from-meeting-a');
           sinon.assert.calledOnceWithExactly(meetingA.refreshDataChannelToken);
           sinon.assert.calledOnceWithExactly(
-            meetingA.llmChannel.setDatachannelToken,
+            meetingA.setLLMChannelDataToken,
             'token-from-meeting-a'
           );
 
@@ -363,7 +361,7 @@ describe('plugin-meetings', () => {
           const meetingWithNoPayload = {
             id: 'meeting-b',
             refreshDataChannelToken: sinon.stub().resolves(null),
-            llmChannel: {setDatachannelToken: sinon.stub()},
+            setLLMChannelDataToken: sinon.stub(),
           };
 
           meetingsMock.getAllMeetings.returns({

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
@@ -249,23 +249,18 @@ describe('plugin-meetings', () => {
                 dataChannelTokenType: 'llm-practice-session',
               },
             }),
+            llmChannel: {
+              setDatachannelToken: sinon.stub(),
+            },
           };
 
           llmMock = {
             isDataChannelTokenEnabled: sinon.stub().resolves(true),
-            getSessionIdByDatachannelUrl: sinon.stub(),
-            getOwnerMeetingId: sinon.stub().returns(undefined),
-            refreshDataChannelToken: sinon.stub().resolves({
-              body: {
-                datachannelToken: 'token-from-llm-fallback',
-                dataChannelTokenType: 'llm-default-session',
-              },
-            }),
-            setDatachannelToken: sinon.stub(),
+            getConnectionByDatachannelUrl: sinon.stub().returns(undefined),
           };
 
           meetingsMock = {
-            getMeetingByType: sinon.stub(),
+            getAllMeetings: sinon.stub().returns({}),
           };
 
           const context = {
@@ -276,76 +271,41 @@ describe('plugin-meetings', () => {
           dispatcherInterceptor = Reflect.apply(DataChannelAuthTokenInterceptor.create, context, []);
         });
 
-        it('routes PS request URL to PS session handler', async () => {
-          llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns('llm-practice-session');
-          llmMock.refreshDataChannelToken
-            .withArgs('llm-practice-session')
-            .resolves({
+        it('routes request URL to matching channel', async () => {
+          const mockChannel = {
+            refreshDataChannelToken: sinon.stub().resolves({
               body: {
-                datachannelToken: 'token-from-ps-session',
+                datachannelToken: 'token-from-channel',
                 dataChannelTokenType: 'llm-practice-session',
               },
-            });
+            }),
+            setDatachannelToken: sinon.stub(),
+          };
+          llmMock.getConnectionByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(mockChannel);
 
           const token = await dispatcherInterceptor._refreshDataChannelToken(PS_DATACHANNEL_URL);
 
-          expect(token).to.equal('token-from-ps-session');
-          sinon.assert.calledOnceWithExactly(llmMock.refreshDataChannelToken, 'llm-practice-session');
+          expect(token).to.equal('token-from-channel');
           sinon.assert.calledOnceWithExactly(
-            llmMock.setDatachannelToken,
-            'token-from-ps-session',
-            undefined,
-            'llm-practice-session'
+            llmMock.getConnectionByDatachannelUrl,
+            PS_DATACHANNEL_URL
           );
+          sinon.assert.calledOnceWithExactly(mockChannel.refreshDataChannelToken);
+          sinon.assert.calledOnceWithExactly(mockChannel.setDatachannelToken, 'token-from-channel');
         });
 
-        it('routes non-PS URL to default session handler', async () => {
-          llmMock.getSessionIdByDatachannelUrl.withArgs(DEFAULT_DATACHANNEL_URL).returns('llm-default-session');
-          llmMock.refreshDataChannelToken
-            .withArgs('llm-default-session')
-            .resolves({
-              body: {
-                datachannelToken: 'token-from-default-session',
-                dataChannelTokenType: 'llm-default-session',
-              },
+        it('falls back to meeting lookup when no channel matches', async () => {
+          llmMock.getConnectionByDatachannelUrl.returns(undefined);
+
+          // Import the static method for matching datachannel URLs
+          const LLMChannel = require('@webex/internal-plugin-llm').default;
+          sinon
+            .stub(LLMChannel, 'matchesDatachannelRequestUrl')
+            .callsFake((requestUrl, datachannelUrl) => {
+              return requestUrl === PS_DATACHANNEL_URL && datachannelUrl === PS_DATACHANNEL_URL;
             });
 
-          const token = await dispatcherInterceptor._refreshDataChannelToken(DEFAULT_DATACHANNEL_URL);
-
-          expect(token).to.equal('token-from-default-session');
-          sinon.assert.calledOnceWithExactly(llmMock.refreshDataChannelToken, 'llm-default-session');
-          sinon.assert.calledOnceWithExactly(
-            llmMock.setDatachannelToken,
-            'token-from-default-session',
-            undefined,
-            'llm-default-session'
-          );
-        });
-
-        it('falls back to default refresh when URL does not match any session or meeting route', async () => {
-          llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
-          llmMock.refreshDataChannelToken.withArgs(undefined).resolves({
-            body: {
-              datachannelToken: 'token-from-default-fallback',
-              dataChannelTokenType: 'llm-default-session',
-            },
-          });
-
-          const token = await dispatcherInterceptor._refreshDataChannelToken(PS_DATACHANNEL_URL);
-
-          expect(token).to.equal('token-from-default-fallback');
-          sinon.assert.calledOnceWithExactly(llmMock.refreshDataChannelToken, undefined);
-          sinon.assert.calledOnceWithExactly(
-            llmMock.setDatachannelToken,
-            'token-from-default-fallback',
-            undefined,
-            'llm-default-session'
-          );
-        });
-
-        it('falls back to active meeting datachannel URL lookup when session/locus routing is unavailable', async () => {
-          llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
-          meetingsMock.getAllMeetings = sinon.stub().returns({
+          meetingsMock.getAllMeetings.returns({
             'meeting-a': {
               ...meetingA,
               locusInfo: {
@@ -361,25 +321,68 @@ describe('plugin-meetings', () => {
 
           expect(token).to.equal('token-from-meeting-a');
           sinon.assert.calledOnceWithExactly(meetingA.refreshDataChannelToken);
-          sinon.assert.notCalled(llmMock.refreshDataChannelToken);
           sinon.assert.calledOnceWithExactly(
-            llmMock.setDatachannelToken,
-            'token-from-meeting-a',
-            'meeting-a',
-            'llm-practice-session'
+            meetingA.llmChannel.setDatachannelToken,
+            'token-from-meeting-a'
           );
+
+          LLMChannel.matchesDatachannelRequestUrl.restore();
         });
 
-        it('throws when refresh returns no payload', async () => {
-          llmMock.getSessionIdByDatachannelUrl.returns('llm-default-session');
-          llmMock.refreshDataChannelToken.withArgs('llm-default-session').resolves(null);
+        it('throws when no channel or meeting matches', async () => {
+          llmMock.getConnectionByDatachannelUrl.returns(undefined);
+          meetingsMock.getAllMeetings.returns({});
 
           await assert.isRejected(
             dispatcherInterceptor._refreshDataChannelToken(
               'https://unknown-datachannel.example.com/registrations'
             ),
+            /No LLM channel or meeting found for request URL/
+          );
+        });
+
+        it('throws when channel refresh returns no payload', async () => {
+          const mockChannel = {
+            refreshDataChannelToken: sinon.stub().resolves(null),
+            setDatachannelToken: sinon.stub(),
+          };
+          llmMock.getConnectionByDatachannelUrl.returns(mockChannel);
+
+          await assert.isRejected(
+            dispatcherInterceptor._refreshDataChannelToken(PS_DATACHANNEL_URL),
             /DataChannel token refresh returned no payload/
           );
+        });
+
+        it('throws when meeting refresh returns no payload', async () => {
+          llmMock.getConnectionByDatachannelUrl.returns(undefined);
+
+          const LLMChannel = require('@webex/internal-plugin-llm').default;
+          sinon.stub(LLMChannel, 'matchesDatachannelRequestUrl').returns(true);
+
+          const meetingWithNoPayload = {
+            id: 'meeting-b',
+            refreshDataChannelToken: sinon.stub().resolves(null),
+            llmChannel: {setDatachannelToken: sinon.stub()},
+          };
+
+          meetingsMock.getAllMeetings.returns({
+            'meeting-b': {
+              ...meetingWithNoPayload,
+              locusInfo: {
+                info: {
+                  datachannelUrl: PS_DATACHANNEL_URL,
+                },
+              },
+            },
+          });
+
+          await assert.isRejected(
+            dispatcherInterceptor._refreshDataChannelToken(PS_DATACHANNEL_URL),
+            /DataChannel token refresh returned no payload/
+          );
+
+          LLMChannel.matchesDatachannelRequestUrl.restore();
         });
       });
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
@@ -6,8 +6,10 @@ import {WebexHttpError} from '@webex/webex-core';
 import DataChannelAuthTokenInterceptor from '@webex/plugin-meetings/src/interceptors/dataChannelAuthToken';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import * as utils from '@webex/plugin-meetings/src/interceptors/utils';
-import {DATA_CHANNEL_AUTH_HEADER, MAX_RETRY} from '@webex/plugin-meetings/src/interceptors/constant';
-import {LOCUS_URL} from '@webex/plugin-meetings/src/constants';
+import {
+  DATA_CHANNEL_AUTH_HEADER,
+  MAX_RETRY,
+} from '@webex/plugin-meetings/src/interceptors/constant';
 
 describe('plugin-meetings', () => {
   describe('Interceptors', () => {
@@ -252,7 +254,6 @@ describe('plugin-meetings', () => {
           llmMock = {
             isDataChannelTokenEnabled: sinon.stub().resolves(true),
             getSessionIdByDatachannelUrl: sinon.stub(),
-            getLocusUrlByDatachannelUrl: sinon.stub(),
             getOwnerMeetingId: sinon.stub().returns(undefined),
             refreshDataChannelToken: sinon.stub().resolves({
               body: {
@@ -323,7 +324,6 @@ describe('plugin-meetings', () => {
 
         it('falls back to default refresh when URL does not match any session or meeting route', async () => {
           llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
-          llmMock.getLocusUrlByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
           llmMock.refreshDataChannelToken.withArgs(undefined).resolves({
             body: {
               datachannelToken: 'token-from-default-fallback',
@@ -343,27 +343,8 @@ describe('plugin-meetings', () => {
           );
         });
 
-        it('falls back to meeting lookup by locusUrl when session cannot be resolved', async () => {
-          llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
-          llmMock.getLocusUrlByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns('https://locus-a.example.com');
-          meetingsMock.getMeetingByType.withArgs(LOCUS_URL, 'https://locus-a.example.com').returns(meetingA);
-
-          const token = await dispatcherInterceptor._refreshDataChannelToken(PS_DATACHANNEL_URL);
-
-          expect(token).to.equal('token-from-meeting-a');
-          sinon.assert.calledOnceWithExactly(meetingA.refreshDataChannelToken);
-          sinon.assert.notCalled(llmMock.refreshDataChannelToken);
-          sinon.assert.calledOnceWithExactly(
-            llmMock.setDatachannelToken,
-            'token-from-meeting-a',
-            'meeting-a',
-            'llm-practice-session'
-          );
-        });
-
         it('falls back to active meeting datachannel URL lookup when session/locus routing is unavailable', async () => {
           llmMock.getSessionIdByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
-          llmMock.getLocusUrlByDatachannelUrl.withArgs(PS_DATACHANNEL_URL).returns(undefined);
           meetingsMock.getAllMeetings = sinon.stub().returns({
             'meeting-a': {
               ...meetingA,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2790,28 +2790,74 @@ describe('plugin-meetings', () => {
         });
 
         [
+          // Main session scenarios (no practice session active)
           {
-            title: 'should skip a reaction when the relay route does not match the LLM binding',
+            title:
+              'should skip a reaction when the relay route does not match the LLM binding (main session)',
             route: 'wrong-route',
-            channelBinding: 'correct-route',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: false,
+            practiceSessionBinding: undefined,
             shouldProcess: false,
           },
           {
-            title: 'should process a reaction when the relay route matches the LLM binding',
-            route: 'correct-route',
-            channelBinding: 'correct-route',
+            title:
+              'should process a reaction when the relay route matches the LLM binding (main session)',
+            route: 'main-binding',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: false,
+            practiceSessionBinding: undefined,
             shouldProcess: true,
           },
           {
             title: 'should process a reaction when no LLM channel exists',
             route: 'some-route',
             channelBinding: null, // No channel
+            practiceSessionConnected: false,
+            practiceSessionBinding: undefined,
             shouldProcess: true,
           },
           {
             title: 'should process a reaction when LLM channel has no binding',
             route: 'some-route',
             channelBinding: undefined, // Channel exists but no binding
+            practiceSessionConnected: false,
+            practiceSessionBinding: undefined,
+            shouldProcess: true,
+          },
+          // Practice session active scenarios
+          {
+            title: 'should skip a reaction routed to main binding when practice session is active',
+            route: 'main-binding',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: true,
+            practiceSessionBinding: 'ps-binding',
+            shouldProcess: false,
+          },
+          {
+            title: 'should process a reaction routed to PS binding when practice session is active',
+            route: 'ps-binding',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: true,
+            practiceSessionBinding: 'ps-binding',
+            shouldProcess: true,
+          },
+          {
+            title:
+              'should skip a reaction routed to PS binding when practice session is NOT active',
+            route: 'ps-binding',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: false,
+            practiceSessionBinding: 'ps-binding',
+            shouldProcess: false,
+          },
+          {
+            title:
+              'should process a reaction routed to main binding when practice session is NOT active',
+            route: 'main-binding',
+            channelBinding: 'main-binding',
+            practiceSessionConnected: false,
+            practiceSessionBinding: 'ps-binding',
             shouldProcess: true,
           },
         ].forEach(
@@ -2819,6 +2865,8 @@ describe('plugin-meetings', () => {
             title,
             route,
             channelBinding,
+            practiceSessionConnected,
+            practiceSessionBinding,
             shouldProcess,
           }) => {
             it(title, () => {
@@ -2826,7 +2874,7 @@ describe('plugin-meetings', () => {
               meeting.config.receiveReactions = true;
               const fakeSendersName = 'Fake reactors name';
               meeting.members.membersCollection.get = sinon.stub().returns({name: fakeSendersName});
-              
+
               // Mock the llmChannel on the meeting
               if (channelBinding === null) {
                 meeting.llmChannel = undefined;
@@ -2835,6 +2883,18 @@ describe('plugin-meetings', () => {
                   getBinding: sinon.stub().returns(channelBinding),
                 };
               }
+
+              // Mock the webinar with practice session state
+              meeting.webinar = {
+                _practiceSessionLLMChannel: practiceSessionConnected
+                  ? {isConnected: sinon.stub().returns(true)}
+                  : undefined,
+                isPracticeSessionLLMChannelConnected: sinon
+                  .stub()
+                  .returns(practiceSessionConnected),
+                getPracticeSessionBinding: sinon.stub().returns(practiceSessionBinding),
+              };
+
               const fakeReactionPayload = {
                 type: 'fake_type',
                 codepoints: 'fake_codepoints',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -14833,7 +14833,7 @@ describe('plugin-meetings', () => {
       describe('#saveDataChannelToken', () => {
         beforeEach(() => {
           meeting._pendingDatachannelToken = undefined;
-          meeting._pendingPracticeSessionDatachannelToken = undefined;
+          meeting.webinar._pendingPracticeSessionDatachannelToken = undefined;
         });
 
         it('saves datachannelToken to _pendingDatachannelToken', () => {
@@ -14846,14 +14846,14 @@ describe('plugin-meetings', () => {
           assert.equal(meeting._pendingDatachannelToken, 'default-token');
         });
 
-        it('saves practiceSessionDatachannelToken to _pendingPracticeSessionDatachannelToken', () => {
+        it('saves practiceSessionDatachannelToken to webinar._pendingPracticeSessionDatachannelToken', () => {
           meeting.saveDataChannelToken({
             locus: {
               self: {practiceSessionDatachannelToken: 'ps-token'},
             },
           });
 
-          assert.equal(meeting._pendingPracticeSessionDatachannelToken, 'ps-token');
+          assert.equal(meeting.webinar._pendingPracticeSessionDatachannelToken, 'ps-token');
         });
 
         it('saves both tokens when both are present', () => {
@@ -14867,28 +14867,28 @@ describe('plugin-meetings', () => {
           });
 
           assert.equal(meeting._pendingDatachannelToken, 'default-token');
-          assert.equal(meeting._pendingPracticeSessionDatachannelToken, 'ps-token');
+          assert.equal(meeting.webinar._pendingPracticeSessionDatachannelToken, 'ps-token');
         });
 
         it('does not set pending tokens when no tokens are present', () => {
           meeting.saveDataChannelToken({locus: {self: {}}});
 
           assert.isUndefined(meeting._pendingDatachannelToken);
-          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
+          assert.isUndefined(meeting.webinar._pendingPracticeSessionDatachannelToken);
         });
 
         it('handles undefined join gracefully', () => {
           meeting.saveDataChannelToken(undefined);
 
           assert.isUndefined(meeting._pendingDatachannelToken);
-          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
+          assert.isUndefined(meeting.webinar._pendingPracticeSessionDatachannelToken);
         });
 
         it('handles missing locus.self gracefully', () => {
           meeting.saveDataChannelToken({locus: {}});
 
           assert.isUndefined(meeting._pendingDatachannelToken);
-          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
+          assert.isUndefined(meeting.webinar._pendingPracticeSessionDatachannelToken);
         });
 
         it('sets token on llmChannel if it exists', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15056,6 +15056,7 @@ describe('plugin-meetings', () => {
           meeting.handleLLMOnline = sinon.stub();
           meeting.clearLLMHealthCheckTimer = sinon.stub();
           meeting.startLLMHealthCheckTimer = sinon.stub();
+          meeting.annotation.registerChannel = sinon.stub();
 
           meeting.webinar.isJoinPracticeSessionDataChannel = sinon.stub().returns(false);
         });
@@ -15324,6 +15325,35 @@ describe('plugin-meetings', () => {
 
           assert.calledOnce(meeting.startLLMHealthCheckTimer);
         });
+
+        it('registers annotation channel when not in practice session', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+          meeting.webinar.isJoinPracticeSessionDataChannel.returns(false);
+
+          await meeting.updateLLMConnection();
+
+          assert.calledOnceWithExactly(meeting.annotation.registerChannel, mockChannel);
+        });
+
+        it('does not register annotation channel when in practice session', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+          meeting.webinar.isJoinPracticeSessionDataChannel.returns(true);
+
+          await meeting.updateLLMConnection();
+
+          assert.notCalled(meeting.annotation.registerChannel);
+        });
+
         it('still need connect main session data channel when PS started', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
@@ -17230,12 +17260,129 @@ describe('plugin-meetings', () => {
         it('returns the correct structured result', async () => {
           const result = await meeting.refreshDataChannelToken();
 
-          expect(result).to.deep.equal({
+                  expect(result).to.deep.equal({
             body: {
               datachannelToken: 'mock-token',
               dataChannelTokenType: 'llm-practice-session',
             },
           });
+        });
+      });
+      describe('#isLLMConnected', () => {
+        it('returns true when main LLM channel is connected and not in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(false),
+          };
+          meeting.llmChannel = {
+            isConnected: sinon.stub().returns(true),
+          };
+
+          const result = meeting.isLLMConnected();
+
+          expect(result).to.equal(true);
+        });
+
+        it('returns false when main LLM channel is not connected and not in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(false),
+          };
+          meeting.llmChannel = {
+            isConnected: sinon.stub().returns(false),
+          };
+
+          const result = meeting.isLLMConnected();
+
+          expect(result).to.equal(false);
+        });
+
+        it('returns false when no LLM channel exists and not in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(false),
+          };
+          meeting.llmChannel = undefined;
+
+          const result = meeting.isLLMConnected();
+
+          expect(result).to.equal(false);
+        });
+
+        it('returns practice session LLM channel status when in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(true),
+            isPracticeSessionLLMChannelConnected: sinon.stub().returns(true),
+          };
+          meeting.llmChannel = {
+            isConnected: sinon.stub().returns(false),
+          };
+
+          const result = meeting.isLLMConnected();
+
+          expect(result).to.equal(true);
+          sinon.assert.calledOnce(meeting.webinar.isPracticeSessionLLMChannelConnected);
+          sinon.assert.notCalled(meeting.llmChannel.isConnected);
+        });
+
+        it('returns false when webinar is undefined', () => {
+          meeting.webinar = undefined;
+          meeting.llmChannel = {
+            isConnected: sinon.stub().returns(true),
+          };
+
+          const result = meeting.isLLMConnected();
+
+          expect(result).to.equal(true);
+        });
+      });
+      describe('#getLLMLocusUrl', () => {
+        it('returns locus URL from main LLM channel when not in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(false),
+          };
+          meeting.llmChannel = {
+            getLocusUrl: sinon.stub().returns('https://locus.example.com/main'),
+          };
+
+          const result = meeting.getLLMLocusUrl();
+
+          expect(result).to.equal('https://locus.example.com/main');
+        });
+
+        it('returns undefined when no LLM channel exists and not in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(false),
+          };
+          meeting.llmChannel = undefined;
+
+          const result = meeting.getLLMLocusUrl();
+
+          expect(result).to.be.undefined;
+        });
+
+        it('returns practice session locus URL when in practice session', () => {
+          meeting.webinar = {
+            isJoinPracticeSessionDataChannel: sinon.stub().returns(true),
+            getPracticeSessionLocusUrl: sinon.stub().returns('https://locus.example.com/practice'),
+          };
+          meeting.llmChannel = {
+            getLocusUrl: sinon.stub().returns('https://locus.example.com/main'),
+          };
+
+          const result = meeting.getLLMLocusUrl();
+
+          expect(result).to.equal('https://locus.example.com/practice');
+          sinon.assert.calledOnce(meeting.webinar.getPracticeSessionLocusUrl);
+          sinon.assert.notCalled(meeting.llmChannel.getLocusUrl);
+        });
+
+        it('returns main channel locus URL when webinar is undefined', () => {
+          meeting.webinar = undefined;
+          meeting.llmChannel = {
+            getLocusUrl: sinon.stub().returns('https://locus.example.com/main'),
+          };
+
+          const result = meeting.getLLMLocusUrl();
+
+          expect(result).to.equal('https://locus.example.com/main');
         });
       });
       describe('#getDataChannelTokenType', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -35,7 +35,6 @@ import {
   OFFLINE,
   ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT,
   LOCUS_LLM_EVENT,
-  LLM_PRACTICE_SESSION,
   RECORDING_STATE,
 } from '@webex/plugin-meetings/src/constants';
 import {
@@ -287,6 +286,20 @@ describe('plugin-meetings', () => {
       });
     webex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(false);
     webex.internal.llm.on = sinon.stub();
+    // Factory pattern: createConnection returns a mock channel
+    webex.internal.llm.createConnection = sinon.stub().callsFake(() => ({
+      registerAndConnect: sinon.stub().resolves({}),
+      disconnect: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(false),
+      getLocusUrl: sinon.stub().returns(undefined),
+      getDatachannelUrl: sinon.stub().returns(undefined),
+      getDatachannelToken: sinon.stub().returns(undefined),
+      setDatachannelToken: sinon.stub(),
+      getBinding: sinon.stub().returns(undefined),
+      setRefreshHandler: sinon.stub(),
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }));
     webex.internal.voicea.announce = sinon.stub();
     webex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
       {},
@@ -2740,67 +2753,50 @@ describe('plugin-meetings', () => {
 
         [
           {
-            title:
-              'should skip a reaction when the default relay route does not match the LLM binding',
-            isPracticeSessionConnected: false,
-            route: 'wrong-default-route',
-            defaultBinding: 'default-route',
-            practiceBinding: 'practice-route',
+            title: 'should skip a reaction when the relay route does not match the LLM binding',
+            route: 'wrong-route',
+            channelBinding: 'correct-route',
             shouldProcess: false,
-            expectedSessionLabel: 'default session',
           },
           {
-            title: 'should process a reaction when the default relay route matches the LLM binding',
-            isPracticeSessionConnected: false,
-            route: 'default-route',
-            defaultBinding: 'default-route',
-            practiceBinding: 'practice-route',
+            title: 'should process a reaction when the relay route matches the LLM binding',
+            route: 'correct-route',
+            channelBinding: 'correct-route',
             shouldProcess: true,
           },
           {
-            title:
-              'should process a reaction when the practice-session relay route matches the practice-session LLM binding',
-            isPracticeSessionConnected: true,
-            route: 'practice-route',
-            defaultBinding: 'default-route',
-            practiceBinding: 'practice-route',
+            title: 'should process a reaction when no LLM channel exists',
+            route: 'some-route',
+            channelBinding: null, // No channel
             shouldProcess: true,
           },
           {
-            title:
-              'should skip a reaction when the practice-session relay route does not match the practice-session LLM binding',
-            isPracticeSessionConnected: true,
-            route: 'default-route',
-            defaultBinding: 'default-route',
-            practiceBinding: 'practice-route',
-            shouldProcess: false,
-            expectedSessionLabel: 'practice session',
+            title: 'should process a reaction when LLM channel has no binding',
+            route: 'some-route',
+            channelBinding: undefined, // Channel exists but no binding
+            shouldProcess: true,
           },
         ].forEach(
           ({
             title,
-            isPracticeSessionConnected,
             route,
-            defaultBinding,
-            practiceBinding,
+            channelBinding,
             shouldProcess,
-            expectedSessionLabel,
           }) => {
             it(title, () => {
               meeting.isReactionsSupported = sinon.stub().returns(true);
               meeting.config.receiveReactions = true;
               const fakeSendersName = 'Fake reactors name';
               meeting.members.membersCollection.get = sinon.stub().returns({name: fakeSendersName});
-              webex.internal.llm.isConnected = sinon.stub().callsFake((llmSessionId) => {
-                return llmSessionId === LLM_PRACTICE_SESSION && isPracticeSessionConnected;
-              });
-              webex.internal.llm.getBinding = sinon.stub().callsFake((llmSessionId) => {
-                if (llmSessionId === LLM_PRACTICE_SESSION) {
-                  return practiceBinding;
-                }
-
-                return defaultBinding;
-              });
+              
+              // Mock the llmChannel on the meeting
+              if (channelBinding === null) {
+                meeting.llmChannel = undefined;
+              } else {
+                meeting.llmChannel = {
+                  getBinding: sinon.stub().returns(channelBinding),
+                };
+              }
               const fakeReactionPayload = {
                 type: 'fake_type',
                 codepoints: 'fake_codepoints',
@@ -2944,7 +2940,10 @@ describe('plugin-meetings', () => {
             assert.calledOnce(MeetingUtil.joinMeeting);
             assert.calledOnce(webex.internal.device.meetingStarted);
             assert.equal(result, joinMeetingResult);
-            assert.calledWith(webex.internal.llm.on, 'online', meeting.handleLLMOnline);
+            // With factory pattern, event is registered on the channel, not the plugin
+            if (meeting.llmChannel) {
+              assert.calledWith(meeting.llmChannel.on, 'online', meeting.handleLLMOnline);
+            }
           });
 
           [true, false].forEach((enableMultistream) => {
@@ -3170,13 +3169,24 @@ describe('plugin-meetings', () => {
               sinon.stub(meeting, 'isJoined').returns(true);
 
               let locusLLMEventListener;
-              meeting.webex.internal.llm.on = sinon.stub().callsFake((eventName, callback) => {
-                if (eventName === 'event:locus.state_message') {
-                  locusLLMEventListener = callback;
-                }
-              });
-              meeting.webex.internal.llm.off = sinon.stub();
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({});
+              const mockChannel = {
+                registerAndConnect: sinon.stub().resolves({}),
+                disconnect: sinon.stub().resolves(),
+                isConnected: sinon.stub().returns(false),
+                getLocusUrl: sinon.stub().returns(undefined),
+                getDatachannelUrl: sinon.stub().returns(undefined),
+                getDatachannelToken: sinon.stub().returns(undefined),
+                setDatachannelToken: sinon.stub(),
+                getBinding: sinon.stub().returns(undefined),
+                setRefreshHandler: sinon.stub(),
+                on: sinon.stub().callsFake((eventName, callback) => {
+                  if (eventName === 'event:locus.state_message') {
+                    locusLLMEventListener = callback;
+                  }
+                }),
+                off: sinon.stub(),
+              };
+              webex.internal.llm.createConnection = sinon.stub().returns(mockChannel);
 
               meeting.updateLLMConnection.restore();
 
@@ -3199,9 +3209,22 @@ describe('plugin-meetings', () => {
 
             it('UpdateLLMConnection sends a metric if not connected after timeout', async () => {
               sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon.stub(meeting.webex.internal.llm, 'hasEverConnected').value(true);
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({});
+
+              const mockChannel = {
+                registerAndConnect: sinon.stub().resolves({}),
+                disconnect: sinon.stub().resolves(),
+                isConnected: sinon.stub().returns(false),
+                getLocusUrl: sinon.stub().returns(undefined),
+                getDatachannelUrl: sinon.stub().returns(undefined),
+                getDatachannelToken: sinon.stub().returns(undefined),
+                setDatachannelToken: sinon.stub(),
+                getBinding: sinon.stub().returns(undefined),
+                setRefreshHandler: sinon.stub(),
+                hasEverConnected: true,
+                on: sinon.stub(),
+                off: sinon.stub(),
+              };
+              webex.internal.llm.createConnection = sinon.stub().returns(mockChannel);
 
               meeting.updateLLMConnection.restore();
 
@@ -3436,32 +3459,44 @@ describe('plugin-meetings', () => {
 
             it('clears the LLM health check timer when disconnecting LLM', async () => {
               const isJoinedStub = sinon.stub(meeting, 'isJoined');
-              sinon.stub(meeting.webex.internal.llm, 'isConnected');
-              sinon.stub(meeting.webex.internal.llm, 'disconnectLLM').resolves();
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({});
-              sinon
-                .stub(meeting.webex.internal.llm, 'getLocusUrl')
-                .returns('https://locus1.example.com');
-              sinon
-                .stub(meeting.webex.internal.llm, 'getDatachannelUrl')
-                .returns('https://datachannel1.example.com');
+
+              const mockChannel = {
+                registerAndConnect: sinon.stub().resolves({}),
+                disconnect: sinon.stub().resolves(),
+                isConnected: sinon.stub().returns(false),
+                getLocusUrl: sinon.stub().returns(undefined),
+                getDatachannelUrl: sinon.stub().returns(undefined),
+                getDatachannelToken: sinon.stub().returns(undefined),
+                setDatachannelToken: sinon.stub(),
+                getBinding: sinon.stub().returns(undefined),
+                setRefreshHandler: sinon.stub(),
+                on: sinon.stub(),
+                off: sinon.stub(),
+              };
+              webex.internal.llm.createConnection = sinon.stub().returns(mockChannel);
 
               meeting.updateLLMConnection.restore();
 
+              // First: join and connect
               isJoinedStub.returns(true);
-              meeting.webex.internal.llm.isConnected.returns(false);
               await meeting.updateLLMConnection();
 
               assert.exists(meeting.llmHealthCheckTimer);
 
+              // Simulate existing connected channel that will be cleaned up
+              mockChannel.isConnected.returns(true);
+              meeting.llmChannel = mockChannel;
+
+              // Now leave the meeting - this should trigger cleanup
               isJoinedStub.returns(false);
-              meeting.webex.internal.llm.isConnected.returns(true);
+              meeting.locusInfo.url = 'some-url';
+              meeting.locusInfo.info = {datachannelUrl: 'some-datachannel-url'};
 
               await meeting.updateLLMConnection();
 
-              assert.calledOnce(meeting.webex.internal.llm.disconnectLLM);
-
+              // After cleanup (not joined), timer should be cleared
               assert.isUndefined(meeting.llmHealthCheckTimer);
+              assert.calledOnce(mockChannel.disconnect);
 
               Metrics.sendBehavioralMetric.resetHistory();
               fakeClock.tick(3 * 60 * 1000);
@@ -8080,6 +8115,12 @@ describe('plugin-meetings', () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
 
+          // Set up llmChannel with mock off function
+          meeting.llmChannel = {
+            off: sinon.stub(),
+            disconnect: sinon.stub().resolves(),
+          };
+
           await meeting.leave();
 
           // All llm/mercury consumers (direct listeners, voicea transcription,
@@ -8087,19 +8128,19 @@ describe('plugin-meetings', () => {
           // in-flight events do not trigger unnecessary Locus syncs
           // (per Locus team recommendation).
           assert.callOrder(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             webex.internal.mercury.off,
             meeting.stopTranscription,
             meeting.annotation.deregisterEvents,
             meeting.meetingRequest.leaveMeeting
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             'event:relay.event',
             meeting.processRelayEvent
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             LOCUS_LLM_EVENT,
             meeting.processLocusLLMEvent
           );
@@ -8119,15 +8160,21 @@ describe('plugin-meetings', () => {
             .stub()
             .returns(Promise.reject(new Error('leave failed')));
 
+          // Set up llmChannel with mock off function
+          meeting.llmChannel = {
+            off: sinon.stub(),
+            disconnect: sinon.stub().resolves(),
+          };
+
           await meeting.leave().catch(() => {});
 
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             'event:relay.event',
             meeting.processRelayEvent
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             LOCUS_LLM_EVENT,
             meeting.processLocusLLMEvent
           );
@@ -10174,6 +10221,12 @@ describe('plugin-meetings', () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
 
+          // Set up llmChannel with mock off function
+          meeting.llmChannel = {
+            off: sinon.stub(),
+            disconnect: sinon.stub().resolves(),
+          };
+
           await meeting.endMeetingForAll();
 
           // All llm/mercury consumers (direct listeners, voicea transcription,
@@ -10181,19 +10234,19 @@ describe('plugin-meetings', () => {
           // in-flight events do not trigger unnecessary Locus syncs
           // (per Locus team recommendation).
           assert.callOrder(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             webex.internal.mercury.off,
             meeting.stopTranscription,
             meeting.annotation.deregisterEvents,
             meeting.meetingRequest.endMeetingForAll
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             'event:relay.event',
             meeting.processRelayEvent
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             LOCUS_LLM_EVENT,
             meeting.processLocusLLMEvent
           );
@@ -10212,15 +10265,21 @@ describe('plugin-meetings', () => {
             .stub()
             .returns(Promise.reject(new Error('end failed')));
 
+          // Set up llmChannel with mock off function
+          meeting.llmChannel = {
+            off: sinon.stub(),
+            disconnect: sinon.stub().resolves(),
+          };
+
           await meeting.endMeetingForAll().catch(() => {});
 
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             'event:relay.event',
             meeting.processRelayEvent
           );
           assert.calledWithExactly(
-            webex.internal.llm.off,
+            meeting.llmChannel.off,
             LOCUS_LLM_EVENT,
             meeting.processLocusLLMEvent
           );
@@ -14773,41 +14832,28 @@ describe('plugin-meetings', () => {
 
       describe('#saveDataChannelToken', () => {
         beforeEach(() => {
-          webex.internal.llm.setDatachannelToken = sinon.stub();
-          webex.internal.llm.resolveSessionOwnership = sinon
-            .stub()
-            .returns({currentOwner: undefined, isOwner: true});
-          webex.internal.llm.isConnected = sinon.stub().returns(false);
+          meeting._pendingDatachannelToken = undefined;
+          meeting._pendingPracticeSessionDatachannelToken = undefined;
         });
 
-        it('saves datachannelToken into LLM as Default', () => {
+        it('saves datachannelToken to _pendingDatachannelToken', () => {
           meeting.saveDataChannelToken({
             locus: {
               self: {datachannelToken: 'default-token'},
             },
           });
 
-          assert.calledWithExactly(
-            webex.internal.llm.setDatachannelToken,
-            'default-token',
-            meeting.id,
-            'llm-default-session'
-          );
+          assert.equal(meeting._pendingDatachannelToken, 'default-token');
         });
 
-        it('saves practiceSessionDatachannelToken into LLM as PracticeSession', () => {
+        it('saves practiceSessionDatachannelToken to _pendingPracticeSessionDatachannelToken', () => {
           meeting.saveDataChannelToken({
             locus: {
               self: {practiceSessionDatachannelToken: 'ps-token'},
             },
           });
 
-          assert.calledWithExactly(
-            webex.internal.llm.setDatachannelToken,
-            'ps-token',
-            meeting.id,
-            'llm-practice-session'
-          );
+          assert.equal(meeting._pendingPracticeSessionDatachannelToken, 'ps-token');
         });
 
         it('saves both tokens when both are present', () => {
@@ -14820,100 +14866,79 @@ describe('plugin-meetings', () => {
             },
           });
 
-          assert.calledTwice(webex.internal.llm.setDatachannelToken);
-          assert.calledWithExactly(
-            webex.internal.llm.setDatachannelToken,
-            'default-token',
-            meeting.id,
-            'llm-default-session'
-          );
-          assert.calledWithExactly(
-            webex.internal.llm.setDatachannelToken,
-            'ps-token',
-            meeting.id,
-            'llm-practice-session'
-          );
+          assert.equal(meeting._pendingDatachannelToken, 'default-token');
+          assert.equal(meeting._pendingPracticeSessionDatachannelToken, 'ps-token');
         });
 
-        it('does not call setDatachannelToken when no tokens are present', () => {
+        it('does not set pending tokens when no tokens are present', () => {
           meeting.saveDataChannelToken({locus: {self: {}}});
 
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
+          assert.isUndefined(meeting._pendingDatachannelToken);
+          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
         });
 
         it('handles undefined join gracefully', () => {
           meeting.saveDataChannelToken(undefined);
 
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
+          assert.isUndefined(meeting._pendingDatachannelToken);
+          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
         });
 
         it('handles missing locus.self gracefully', () => {
           meeting.saveDataChannelToken({locus: {}});
 
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
+          assert.isUndefined(meeting._pendingDatachannelToken);
+          assert.isUndefined(meeting._pendingPracticeSessionDatachannelToken);
         });
 
-        it('writes token with meeting id as owner', () => {
+        it('sets token on llmChannel if it exists', () => {
+          const mockChannel = {
+            setDatachannelToken: sinon.stub(),
+          };
+          meeting.llmChannel = mockChannel;
+
           meeting.saveDataChannelToken({
             locus: {
               self: {datachannelToken: 'default-token'},
             },
           });
 
-          assert.calledOnceWithExactly(
-            webex.internal.llm.setDatachannelToken,
-            'default-token',
-            meeting.id,
-            'llm-default-session'
-          );
-        });
-      });
-
-      describe('#clearDataChannelToken', () => {
-        beforeEach(() => {
-          webex.internal.llm.clearDatachannelToken = sinon.stub();
-        });
-
-        it('delegates default and practice token clears to llm with meeting ownership id', () => {
-          meeting.clearDataChannelToken();
-
-          assert.calledWithExactly(
-            webex.internal.llm.clearDatachannelToken,
-            'llm-default-session',
-            meeting.id
-          );
-          assert.calledWithExactly(
-            webex.internal.llm.clearDatachannelToken,
-            'llm-practice-session',
-            meeting.id
-          );
-          assert.callCount(webex.internal.llm.clearDatachannelToken, 2);
+          assert.calledOnceWithExactly(mockChannel.setDatachannelToken, 'default-token');
         });
       });
 
       describe('#updateLLMConnection', () => {
+        let mockChannel;
+
         beforeEach(() => {
-          webex.internal.llm.isConnected = sinon.stub().returns(false);
-          webex.internal.llm.getLocusUrl = sinon.stub();
-          webex.internal.llm.getDatachannelUrl = sinon.stub();
-          webex.internal.llm.registerAndConnect = sinon.stub().resolves('something');
-          webex.internal.llm.setRefreshHandler = sinon.stub();
-          webex.internal.llm.disconnectLLM = sinon.stub().resolves();
-          webex.internal.llm.on = sinon.stub();
-          webex.internal.llm.off = sinon.stub();
-          webex.internal.llm.getDatachannelToken = sinon.stub().returns(undefined);
-          webex.internal.llm.setDatachannelToken = sinon.stub();
+          // Create a mock channel that createConnection will return
+          mockChannel = {
+            registerAndConnect: sinon.stub().resolves('something'),
+            disconnect: sinon.stub().resolves(),
+            isConnected: sinon.stub().returns(false),
+            getLocusUrl: sinon.stub().returns(undefined),
+            getDatachannelUrl: sinon.stub().returns(undefined),
+            getDatachannelToken: sinon.stub().returns(undefined),
+            setDatachannelToken: sinon.stub(),
+            getBinding: sinon.stub().returns(undefined),
+            setRefreshHandler: sinon.stub(),
+            on: sinon.stub(),
+            off: sinon.stub(),
+          };
+
+          webex.internal.llm.createConnection = sinon.stub().returns(mockChannel);
 
           meeting.processRelayEvent = sinon.stub();
           meeting.processLocusLLMEvent = sinon.stub();
+          meeting.handleLLMOnline = sinon.stub();
           meeting.clearLLMHealthCheckTimer = sinon.stub();
           meeting.startLLMHealthCheckTimer = sinon.stub();
 
           meeting.webinar.isJoinPracticeSessionDataChannel = sinon.stub().returns(false);
         });
+
         it('does not connect if the call is not joined yet', async () => {
           meeting.joinedWith = {state: 'any other state'};
-          webex.internal.llm.getLocusUrl.returns('a url');
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -14923,50 +14948,11 @@ describe('plugin-meetings', () => {
 
           const result = await meeting.updateLLMConnection();
 
-          assert.notCalled(webex.internal.llm.registerAndConnect);
-          assert.notCalled(webex.internal.llm.disconnectLLM);
+          assert.notCalled(webex.internal.llm.createConnection);
           assert.equal(result, undefined);
-          assert.notCalled(meeting.webex.internal.llm.on);
         });
-        it('returns undefined if llm is already connected and the locus url is unchanged', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
 
-          const result = await meeting.updateLLMConnection();
-          assert.notCalled(webex.internal.llm.disconnectLLM);
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
-            'a url',
-            'a datachannel url',
-            undefined
-          );
-          assert.equal(result, 'something');
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-        });
-        it('connects if not already connected', async () => {
+        it('creates a channel and connects when joined', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -14976,144 +14962,152 @@ describe('plugin-meetings', () => {
 
           const result = await meeting.updateLLMConnection();
 
-          assert.notCalled(webex.internal.llm.disconnectLLM);
+          assert.calledOnce(webex.internal.llm.createConnection);
           assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
+            mockChannel.registerAndConnect,
             'a url',
             'a datachannel url',
             undefined
-          );
-          assert.calledOnceWithExactly(
-            webex.internal.llm.setRefreshHandler,
-            sinon.match.func,
-            meeting.id,
-            'llm-default-session'
           );
           assert.equal(result, 'something');
           assert.calledOnceWithExactly(meeting.locusInfo.syncAllHashTreeDatasets, {onlyLLM: true});
         });
-        it('disconnects if the locus url has changed', async () => {
+
+        it('sets up event listeners on the channel after connection', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledWithExactly(mockChannel.off, 'event:relay.event', meeting.processRelayEvent);
+          assert.calledWithExactly(mockChannel.on, 'event:relay.event', meeting.processRelayEvent);
+          assert.calledWithExactly(mockChannel.off, 'event:locus.state_message', meeting.processLocusLLMEvent);
+          assert.calledWithExactly(mockChannel.on, 'event:locus.state_message', meeting.processLocusLLMEvent);
+          assert.calledWithExactly(mockChannel.off, 'online', meeting.handleLLMOnline);
+          assert.calledWithExactly(mockChannel.on, 'online', meeting.handleLLMOnline);
+        });
+
+        it('sets refresh handler before registration', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledOnceWithExactly(mockChannel.setRefreshHandler, sinon.match.func);
+          // Verify setRefreshHandler was called before registerAndConnect
+          assert.isTrue(mockChannel.setRefreshHandler.calledBefore(mockChannel.registerAndConnect));
+        });
+
+        it('skips reconnect when already connected to same URLs', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          // Set up existing channel with matching URLs
+          const existingChannel = {
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('a url'),
+            getDatachannelUrl: sinon.stub().returns('a datachannel url'),
+          };
+          meeting.llmChannel = existingChannel;
+
+          const result = await meeting.updateLLMConnection();
+
+          assert.notCalled(webex.internal.llm.createConnection);
+          assert.equal(result, undefined);
+        });
+
+        it('disconnects and reconnects when locus URL changes', async () => {
           meeting.joinedWith = {state: 'JOINED'};
 
-          webex.internal.llm.isConnected.returns(true);
-          webex.internal.llm.getLocusUrl.returns('a url');
+          // Set up existing channel with different URL
+          const existingChannel = {
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('old url'),
+            getDatachannelUrl: sinon.stub().returns('a datachannel url'),
+            disconnect: sinon.stub().resolves(),
+            off: sinon.stub(),
+          };
+          meeting.llmChannel = existingChannel;
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a different url',
             info: {datachannelUrl: 'a datachannel url'},
-            self: {},
           };
 
           const result = await meeting.updateLLMConnection();
 
+          // Should disconnect old channel
+          assert.calledOnce(existingChannel.disconnect);
+          // Should create new channel
+          assert.calledOnce(webex.internal.llm.createConnection);
+          // Should connect with new URL
           assert.calledWithExactly(
-            webex.internal.llm.disconnectLLM,
-            {
-              code: 3050,
-              reason: 'done (permanent)',
-            },
-            'llm-default-session',
-            meeting.id
-          );
-
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
+            mockChannel.registerAndConnect,
             'a different url',
             'a datachannel url',
             undefined
           );
-
-          assert.equal(result, 'something');
-
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-          assert.callCount(meeting.webex.internal.llm.off, 4);
-
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-          assert.isFalse(
-            meeting.webex.internal.llm.off.calledWithExactly('online', meeting.handleLLMOnline)
-          );
         });
-        it('disconnects if the data channel url has changed', async () => {
+
+        it('disconnects and reconnects when datachannel URL changes', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          webex.internal.llm.isConnected.returns(true);
-          webex.internal.llm.getLocusUrl.returns('a url');
+
+          // Set up existing channel with different datachannel URL
+          const existingChannel = {
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('a url'),
+            getDatachannelUrl: sinon.stub().returns('old datachannel url'),
+            disconnect: sinon.stub().resolves(),
+            off: sinon.stub(),
+          };
+          meeting.llmChannel = existingChannel;
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a different datachannel url'},
-            self: {},
           };
 
-          const result = await meeting.updateLLMConnection();
+          await meeting.updateLLMConnection();
 
+          // Should disconnect old channel
+          assert.calledOnce(existingChannel.disconnect);
+          // Should create new channel
+          assert.calledOnce(webex.internal.llm.createConnection);
+          // Should connect with new datachannel URL
           assert.calledWithExactly(
-            webex.internal.llm.disconnectLLM,
-            {
-              code: 3050,
-              reason: 'done (permanent)',
-            },
-            'llm-default-session',
-            meeting.id
-          );
-
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
+            mockChannel.registerAndConnect,
             'a url',
             'a different datachannel url',
             undefined
           );
-
-          assert.equal(result, 'something');
-
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.on,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-          assert.isFalse(
-            meeting.webex.internal.llm.off.calledWithExactly('online', meeting.handleLLMOnline)
-          );
         });
-        it('disconnects when the state is not JOINED', async () => {
+
+        it('disconnects when state changes to not joined', async () => {
           meeting.joinedWith = {state: 'any other state'};
-          webex.internal.llm.isConnected.returns(true);
-          webex.internal.llm.getLocusUrl.returns('a url');
+
+          // Set up existing connected channel
+          const existingChannel = {
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('a url'),
+            getDatachannelUrl: sinon.stub().returns('a datachannel url'),
+            disconnect: sinon.stub().resolves(),
+            off: sinon.stub(),
+          };
+          meeting.llmChannel = existingChannel;
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -15123,58 +15117,85 @@ describe('plugin-meetings', () => {
 
           const result = await meeting.updateLLMConnection();
 
-          assert.calledWith(
-            webex.internal.llm.disconnectLLM,
-            {
-              code: 3050,
-              reason: 'done (permanent)',
-            },
-            'llm-default-session',
-            meeting.id
-          );
-          assert.notCalled(webex.internal.llm.registerAndConnect);
+          assert.calledOnce(existingChannel.disconnect);
+          assert.notCalled(webex.internal.llm.createConnection);
           assert.equal(result, undefined);
-          assert.isFalse(
-            meeting.webex.internal.llm.off.calledWithExactly('online', meeting.handleLLMOnline)
-          );
         });
-        it('rethrows disconnect errors during reconnect cleanup after removing relay listeners and timer', async () => {
-          const disconnectError = new Error('disconnect failed');
 
+        it('passes pending datachannel token to registerAndConnect', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          webex.internal.llm.isConnected.returns(true);
-          webex.internal.llm.getLocusUrl.returns('a url');
-          webex.internal.llm.disconnectLLM.rejects(disconnectError);
-
+          meeting._pendingDatachannelToken = 'pending-token';
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a different url',
+            url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
-            self: {},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledWithExactly(
+            mockChannel.registerAndConnect,
+            'a url',
+            'a datachannel url',
+            'pending-token'
+          );
+          // Pending token should be set on channel
+          assert.calledWithExactly(mockChannel.setDatachannelToken, 'pending-token');
+          // Pending token should be cleared
+          assert.isUndefined(meeting._pendingDatachannelToken);
+        });
+
+        it('uses channel token if no pending token', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          mockChannel.getDatachannelToken.returns('channel-token');
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledWithExactly(
+            mockChannel.registerAndConnect,
+            'a url',
+            'a datachannel url',
+            'channel-token'
+          );
+        });
+
+        it('clears llmChannel on registration failure', async () => {
+          const registerError = new Error('registration failed');
+          mockChannel.registerAndConnect.rejects(registerError);
+
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
           };
 
           try {
             await meeting.updateLLMConnection();
-            assert.fail('Expected updateLLMConnection to reject when disconnectLLM fails');
+            assert.fail('Expected updateLLMConnection to reject');
           } catch (error) {
-            assert.equal(error, disconnectError);
+            assert.equal(error, registerError);
           }
 
-          assert.notCalled(webex.internal.llm.registerAndConnect);
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:relay.event',
-            meeting.processRelayEvent
-          );
-          assert.calledWithExactly(
-            meeting.webex.internal.llm.off,
-            'event:locus.state_message',
-            meeting.processLocusLLMEvent
-          );
-          assert.isFalse(
-            meeting.webex.internal.llm.off.calledWithExactly('online', meeting.handleLLMOnline)
-          );
-          assert.calledOnce(meeting.clearLLMHealthCheckTimer);
+          assert.isUndefined(meeting.llmChannel);
+        });
+
+        it('starts LLM health check timer after successful connection', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledOnce(meeting.startLLMHealthCheckTimer);
         });
         it('still need connect main session data channel when PS started', async () => {
           meeting.joinedWith = {state: 'JOINED'};
@@ -15191,411 +15212,69 @@ describe('plugin-meetings', () => {
           await meeting.updateLLMConnection();
 
           assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
+            mockChannel.registerAndConnect,
             'a url',
             'a datachannel url',
             undefined
           );
-        });
-        it('passes dataChannelToken from LLM to registerAndConnect', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
-
-          webex.internal.llm.getDatachannelToken
-            .withArgs('llm-default-session', meeting.id)
-            .returns('token-123');
-
-          await meeting.updateLLMConnection();
-
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
-            'a url',
-            'a datachannel url',
-            'token-123'
-          );
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
-        });
-        it('passes undefined token when LLM has no token stored', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
-
-          webex.internal.llm.getDatachannelToken.returns(undefined);
-
-          await meeting.updateLLMConnection();
-
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
-            'a url',
-            'a datachannel url',
-            undefined
-          );
-
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
-        });
-
-        it('does not pass token when data channel with jwt token is disabled', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
-
-          webex.internal.llm.getDatachannelToken.returns(undefined);
-          webex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(false);
-
-          await meeting.updateLLMConnection();
-
-          assert.calledWithExactly(
-            webex.internal.llm.registerAndConnect,
-            'a url',
-            'a datachannel url',
-            undefined
-          );
-          assert.notCalled(webex.internal.llm.setDatachannelToken);
-        });
-
-        describe('ownership tag', () => {
-          beforeEach(() => {
-            // Make the owner stub dynamic so setOwnerMeetingId() writes
-            // propagate back to getOwnerMeetingId() reads. This mirrors the
-            // real LLM singleton behavior so the finally-block release in
-            // cleanupLLMConneciton is reflected in subsequent reads.
-            webex.internal.llm.getOwnerMeetingId = sinon.stub().returns(undefined);
-            webex.internal.llm.setOwnerMeetingId = sinon.stub().callsFake((id) => {
-              webex.internal.llm.getOwnerMeetingId.returns(id);
-            });
-          });
-
-          it('skips disconnect and reconnect when LLM is connected and owned by another meeting (regardless of URL)', async () => {
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(true);
-            webex.internal.llm.getOwnerMeetingId.returns('some-other-meeting-id');
-            // Locus/datachannel URL mismatch is the *normal* case when
-            // another meeting owns the live socket -- each meeting has its
-            // own locus URL. URL mismatch must NOT trigger a reclaim,
-            // because doing so would tear down the owning meeting's healthy
-            // LLM socket and break its data channel.
-            webex.internal.llm.getLocusUrl.returns('owner-locus-url');
-            webex.internal.llm.getDatachannelUrl.returns('owner-dc-url');
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a different url',
-              info: {datachannelUrl: 'a different datachannel url'},
-              self: {},
-            };
-
-            const result = await meeting.updateLLMConnection();
-
-            assert.equal(result, undefined);
-            assert.notCalled(webex.internal.llm.disconnectLLM);
-            assert.notCalled(webex.internal.llm.registerAndConnect);
-            assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-            assert.notCalled(meeting.startLLMHealthCheckTimer);
-          });
-
-          it('clears stale owner tag in cleanup finally block even when disconnectLLM rejects', async () => {
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(true);
-            webex.internal.llm.getOwnerMeetingId.returns(meeting.id);
-            webex.internal.llm.getLocusUrl.returns('a url');
-            webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
-            webex.internal.llm.disconnectLLM.rejects(new Error('disconnect failed'));
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a different url',
-              info: {datachannelUrl: 'a datachannel url'},
-              self: {},
-            };
-
-            try {
-              await meeting.updateLLMConnection();
-            } catch (e) {
-              /* updateLLMConnection may reject when cleanup throws */
-            }
-
-            // The owner-eligible finally branch must release the tag so a
-            // subsequent reconnect attempt from any meeting is not blocked.
-            assert.calledWith(webex.internal.llm.setOwnerMeetingId, undefined);
-          });
-
-          it('does not clear owner tag when ownership changes during cleanup disconnect await', async () => {
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(true);
-            webex.internal.llm.getOwnerMeetingId.returns(meeting.id);
-            webex.internal.llm.getLocusUrl.returns('a url');
-            webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
-            webex.internal.llm.disconnectLLM.callsFake(async () => {
-              webex.internal.llm.getOwnerMeetingId.returns('new-owner-id');
-              throw new Error('disconnect failed');
-            });
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a different url',
-              info: {datachannelUrl: 'a datachannel url'},
-              self: {},
-            };
-
-            try {
-              await meeting.updateLLMConnection();
-            } catch (e) {
-              /* updateLLMConnection may reject when cleanup throws */
-            }
-
-            assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-            assert.equal(webex.internal.llm.getOwnerMeetingId(), 'new-owner-id');
-          });
-
-          it('proceeds normally when LLM is connected and owned by this meeting with URL change', async () => {
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(true);
-            webex.internal.llm.getOwnerMeetingId.returns(meeting.id);
-            webex.internal.llm.getLocusUrl.returns('a url');
-            webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a different url',
-              info: {datachannelUrl: 'a datachannel url'},
-              self: {},
-            };
-
-            await meeting.updateLLMConnection();
-
-            assert.calledOnceWithExactly(
-              webex.internal.llm.disconnectLLM,
-              {
-                code: 3050,
-                reason: 'done (permanent)',
-              },
-              'llm-default-session',
-              meeting.id
-            );
-            assert.calledWithExactly(
-              webex.internal.llm.registerAndConnect,
-              'a different url',
-              'a datachannel url',
-              undefined
-            );
-            // setOwnerMeetingId is called twice: first with undefined in
-            // cleanupLLMConneciton's finally block (so a failed disconnect
-            // cannot leave a stale owner), then with this meeting's id
-            // after registerAndConnect resolves.
-            assert.calledTwice(webex.internal.llm.setOwnerMeetingId);
-            assert.calledWith(webex.internal.llm.setOwnerMeetingId.firstCall, undefined);
-            assert.calledWith(webex.internal.llm.setOwnerMeetingId.lastCall, meeting.id);
-          });
-
-          it('claims ownership after successful registerAndConnect on initial connect', async () => {
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(false);
-            webex.internal.llm.getOwnerMeetingId.returns(undefined);
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a url',
-              info: {datachannelUrl: 'a datachannel url'},
-            };
-
-            await meeting.updateLLMConnection();
-
-            assert.calledOnce(webex.internal.llm.registerAndConnect);
-            assert.calledOnceWithExactly(
-              webex.internal.llm.setRefreshHandler,
-              sinon.match.func,
-              meeting.id,
-              'llm-default-session'
-            );
-            assert.calledOnceWithExactly(webex.internal.llm.setOwnerMeetingId, meeting.id);
-          });
-
-          it('proceeds to connect when LLM is not connected even if another ownerId lingers', async () => {
-            // Defensive path: if the LLM reports not-connected but an old
-            // ownerId is still present (e.g. race before a successful
-            // connections.delete), this meeting can still claim a fresh
-            // connection.
-            meeting.joinedWith = {state: 'JOINED'};
-            webex.internal.llm.isConnected.returns(false);
-            webex.internal.llm.getOwnerMeetingId.returns('stale-owner-id');
-            webex.internal.llm.getDatachannelToken.onFirstCall().returns(undefined);
-            webex.internal.llm.getDatachannelToken.onSecondCall().returns('recovered-token');
-            meeting.locusInfo = {
-              syncAllHashTreeDatasets: sinon.stub().resolves(),
-              url: 'a url',
-              info: {datachannelUrl: 'a datachannel url'},
-            };
-
-            await meeting.updateLLMConnection();
-
-            assert.calledTwice(webex.internal.llm.getDatachannelToken);
-            assert.calledWithExactly(
-              webex.internal.llm.getDatachannelToken.firstCall,
-              'llm-default-session',
-              meeting.id
-            );
-            assert.calledWithExactly(
-              webex.internal.llm.getDatachannelToken.secondCall,
-              'llm-default-session'
-            );
-            assert.calledOnceWithExactly(
-              webex.internal.llm.registerAndConnect,
-              'a url',
-              'a datachannel url',
-              'recovered-token'
-            );
-            assert.calledWithExactly(
-              webex.internal.llm.setRefreshHandler.firstCall,
-              sinon.match.func,
-              undefined,
-              'llm-default-session'
-            );
-            assert.calledTwice(webex.internal.llm.setRefreshHandler);
-            assert.calledWithExactly(
-              webex.internal.llm.setRefreshHandler.secondCall,
-              sinon.match.func,
-              meeting.id,
-              'llm-default-session'
-            );
-            assert.calledOnceWithExactly(webex.internal.llm.setOwnerMeetingId, meeting.id);
-          });
         });
 
         describe('#clearMeetingData', () => {
+          let existingChannel;
+
           beforeEach(() => {
-            webex.internal.llm.isConnected = sinon.stub().returns(true);
-            webex.internal.llm.disconnectLLM = sinon.stub().resolves();
-            webex.internal.llm.off = sinon.stub();
+            existingChannel = {
+              isConnected: sinon.stub().returns(true),
+              disconnect: sinon.stub().resolves(),
+              off: sinon.stub(),
+            };
+            meeting.llmChannel = existingChannel;
+
             meeting.annotation.deregisterEvents = sinon.stub();
             meeting.clearLLMHealthCheckTimer = sinon.stub();
             meeting.stopTranscription = sinon.stub();
-            meeting.clearDataChannelToken = sinon.stub();
             meeting.shareStatus = 'no-share';
           });
 
-          it('disconnects llm and removes online and relay listeners during meeting data cleanup', async () => {
+          it('disconnects llm channel and removes listeners during meeting data cleanup', async () => {
             await meeting.clearMeetingData();
 
-            assert.calledOnceWithExactly(
-              webex.internal.llm.disconnectLLM,
-              {
-                code: 3050,
-                reason: 'done (permanent)',
-              },
-              'llm-default-session',
-              meeting.id
-            );
-            assert.calledWithExactly(webex.internal.llm.off, 'online', meeting.handleLLMOnline);
+            assert.calledOnce(existingChannel.disconnect);
+            assert.calledWithExactly(existingChannel.off, 'online', meeting.handleLLMOnline);
             assert.calledWithExactly(
-              webex.internal.llm.off,
+              existingChannel.off,
               'event:relay.event',
               meeting.processRelayEvent
             );
             assert.calledWithExactly(
-              webex.internal.llm.off,
+              existingChannel.off,
               'event:locus.state_message',
               meeting.processLocusLLMEvent
             );
-            assert.calledOnce(meeting.clearLLMHealthCheckTimer);
-            assert.calledOnce(meeting.clearDataChannelToken);
-            // stopTranscription and annotation.deregisterEvents are not
-            // called here: they run in stopListeningForMeetingEvents()
-            // before /leave to avoid double-emitting
-            // MEETING_STOPPED_RECEIVING_TRANSCRIPTION.
-            assert.notCalled(meeting.stopTranscription);
-            assert.notCalled(meeting.annotation.deregisterEvents);
+            assert.called(meeting.clearLLMHealthCheckTimer);
           });
-          it('continues cleanup when disconnectLLM fails during meeting data cleanup', async () => {
-            webex.internal.llm.disconnectLLM.rejects(new Error('disconnect failed'));
+
+          it('continues cleanup when disconnect fails', async () => {
+            existingChannel.disconnect.rejects(new Error('disconnect failed'));
 
             await meeting.clearMeetingData();
 
-            assert.calledWithExactly(webex.internal.llm.off, 'online', meeting.handleLLMOnline);
+            assert.calledWithExactly(existingChannel.off, 'online', meeting.handleLLMOnline);
             assert.calledWithExactly(
-              webex.internal.llm.off,
+              existingChannel.off,
               'event:relay.event',
               meeting.processRelayEvent
             );
-            assert.calledWithExactly(
-              webex.internal.llm.off,
-              'event:locus.state_message',
-              meeting.processLocusLLMEvent
-            );
-            assert.calledOnce(meeting.clearLLMHealthCheckTimer);
-            assert.calledOnce(meeting.clearDataChannelToken);
-            assert.notCalled(meeting.stopTranscription);
-            assert.notCalled(meeting.annotation.deregisterEvents);
+            assert.called(meeting.clearLLMHealthCheckTimer);
           });
 
-          describe('ownership tag', () => {
-            beforeEach(() => {
-              webex.internal.llm.getOwnerMeetingId = sinon.stub();
-            });
+          it('handles cleanup when no llmChannel exists', async () => {
+            meeting.llmChannel = undefined;
 
-            it('skips disconnectLLM but still removes this meeting listeners when another meeting owns the LLM', async () => {
-              webex.internal.llm.getOwnerMeetingId.returns('some-other-meeting-id');
+            // Should not throw
+            await meeting.clearMeetingData();
 
-              await meeting.clearMeetingData();
-
-              assert.notCalled(webex.internal.llm.disconnectLLM);
-              // clearDataChannelToken is always delegated; llm enforces
-              // ownership and no-ops for non-owners internally.
-              assert.calledOnce(meeting.clearDataChannelToken);
-              // Listeners owned by *this* Meeting instance must still be
-              // removed so a leaving subordinate meeting stops receiving
-              // relay/locus events from the shared singleton.
-              assert.calledWithExactly(webex.internal.llm.off, 'online', meeting.handleLLMOnline);
-              assert.calledWithExactly(
-                webex.internal.llm.off,
-                'event:relay.event',
-                meeting.processRelayEvent
-              );
-              assert.calledWithExactly(
-                webex.internal.llm.off,
-                'event:locus.state_message',
-                meeting.processLocusLLMEvent
-              );
-              assert.calledOnce(meeting.clearLLMHealthCheckTimer);
-            });
-
-            it('calls disconnectLLM and clears data channel token when this meeting is the owner', async () => {
-              webex.internal.llm.getOwnerMeetingId.returns(meeting.id);
-
-              await meeting.clearMeetingData();
-
-              assert.calledOnceWithExactly(
-                webex.internal.llm.disconnectLLM,
-                {
-                  code: 3050,
-                  reason: 'done (permanent)',
-                },
-                'llm-default-session',
-                meeting.id
-              );
-              assert.calledOnce(meeting.clearDataChannelToken);
-            });
-
-            it('calls disconnectLLM and clears data channel token when no owner is recorded (first-claim / legacy)', async () => {
-              webex.internal.llm.getOwnerMeetingId.returns(undefined);
-
-              await meeting.clearMeetingData();
-
-              assert.calledOnceWithExactly(
-                webex.internal.llm.disconnectLLM,
-                {
-                  code: 3050,
-                  reason: 'done (permanent)',
-                },
-                'llm-default-session',
-                meeting.id
-              );
-              assert.calledOnce(meeting.clearDataChannelToken);
-            });
+            assert.called(meeting.clearLLMHealthCheckTimer);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -291,6 +291,7 @@ describe('plugin-meetings', () => {
       registerAndConnect: sinon.stub().resolves({}),
       disconnect: sinon.stub().resolves(),
       isConnected: sinon.stub().returns(false),
+      isConnecting: sinon.stub().returns(false),
       getLocusUrl: sinon.stub().returns(undefined),
       getDatachannelUrl: sinon.stub().returns(undefined),
       getDatachannelToken: sinon.stub().returns(undefined),
@@ -301,6 +302,20 @@ describe('plugin-meetings', () => {
       off: sinon.stub(),
     }));
     webex.internal.voicea.announce = sinon.stub();
+    // Factory pattern: createChannel returns a mock voicea channel
+    webex.internal.voicea.createChannel = sinon.stub().callsFake(() => ({
+      on: sinon.stub(),
+      off: sinon.stub(),
+      onSpokenLanguageUpdate: sinon.stub(),
+      onCaptionServiceIdUpdate: sinon.stub(),
+      requestLanguage: sinon.stub(),
+      setSpokenLanguage: sinon.stub(),
+      turnOnCaptions: sinon.stub().resolves(),
+      listenToEvents: sinon.stub(),
+      deregisterEvents: sinon.stub(),
+      getIsCaptionBoxOn: sinon.stub().returns(false),
+      updateSubchannelSubscriptions: sinon.stub(),
+    }));
     webex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
       {},
       {parent: webex}
@@ -2193,41 +2208,53 @@ describe('plugin-meetings', () => {
       });
 
       describe('#update hesiod llm id', () => {
+        let mockVoiceaChannel;
         beforeEach(() => {
-          webex.internal.voicea.onCaptionServiceIdUpdate = sinon.stub();
+          mockVoiceaChannel = {
+            onCaptionServiceIdUpdate: sinon.stub(),
+            on: sinon.stub(),
+            off: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
         });
         afterEach(() => {
           // Restore the original methods after each test
           sinon.restore();
         });
-        it('should call voicea.onCaptionServiceIdUpdate when joined', async () => {
+        it('should call voiceaChannel.onCaptionServiceIdUpdate when joined', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           await meeting.locusInfo.emitScoped(
             {function: 'test', file: 'test'},
             LOCUSINFO.EVENTS.CONTROLS_MEETING_HESIOD_LLM_ID_UPDATED,
             {hesiodLlmId: '123a-456b-789c'}
           );
-          assert.calledWith(webex.internal.voicea.onCaptionServiceIdUpdate, '123a-456b-789c');
+          assert.calledWith(mockVoiceaChannel.onCaptionServiceIdUpdate, '123a-456b-789c');
         });
       });
 
       describe('#update spoken language', () => {
+        let mockVoiceaChannel;
         beforeEach(() => {
-          webex.internal.voicea.onSpokenLanguageUpdate = sinon.stub();
+          mockVoiceaChannel = {
+            onSpokenLanguageUpdate: sinon.stub(),
+            on: sinon.stub(),
+            off: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
           meeting.transcription = {languageOptions: {currentSpokenLanguage: 'en'}};
         });
         afterEach(() => {
           // Restore the original methods after each test
           sinon.restore();
         });
-        it('should call voicea.onSpokenLanguageUpdate when joined', async () => {
+        it('should call voiceaChannel.onSpokenLanguageUpdate when joined', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           await meeting.locusInfo.emitScoped(
             {function: 'test', file: 'test'},
             LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIPTION_SPOKEN_LANGUAGE_UPDATED,
             {spokenLanguage: 'fr'}
           );
-          assert.calledWith(webex.internal.voicea.onSpokenLanguageUpdate, 'fr', meeting.id);
+          assert.calledWith(mockVoiceaChannel.onSpokenLanguageUpdate, 'fr', meeting.id);
           assert.equal(meeting.transcription.languageOptions.currentSpokenLanguage, 'fr');
           assert.calledWith(
             TriggerProxy.trigger,
@@ -2237,24 +2264,29 @@ describe('plugin-meetings', () => {
           );
         });
 
-        it('should also call voicea.onSpokenLanguageUpdate when not joined', async () => {
+        it('should also call voiceaChannel.onSpokenLanguageUpdate when not joined', async () => {
           meeting.joinedWith = {state: 'NOT_JOINED'};
           await meeting.locusInfo.emitScoped(
             {function: 'test', file: 'test'},
             LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIPTION_SPOKEN_LANGUAGE_UPDATED,
             {spokenLanguage: 'de'}
           );
-          assert.calledWith(webex.internal.voicea.onSpokenLanguageUpdate, 'de');
+          assert.calledWith(mockVoiceaChannel.onSpokenLanguageUpdate, 'de');
           assert.equal(meeting.transcription.languageOptions.currentSpokenLanguage, 'de');
         });
       });
 
       describe('#startTranscription', () => {
+        let mockVoiceaChannel;
+
         beforeEach(() => {
-          webex.internal.voicea.on = sinon.stub();
-          webex.internal.voicea.off = sinon.stub();
-          webex.internal.voicea.listenToEvents = sinon.stub();
-          webex.internal.voicea.turnOnCaptions = sinon.stub();
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            listenToEvents: sinon.stub(),
+            turnOnCaptions: sinon.stub().resolves(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
         });
 
         it('should subscribe to events for the first time and avoid subscribing for future transcription starts', async () => {
@@ -2266,16 +2298,14 @@ describe('plugin-meetings', () => {
 
           await meeting.startTranscription();
 
-          assert.equal(webex.internal.voicea.on.callCount, 4);
+          assert.equal(mockVoiceaChannel.on.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, true);
-          assert.equal(webex.internal.voicea.listenToEvents.callCount, 1);
-          assert.called(webex.internal.voicea.turnOnCaptions);
+          assert.calledOnce(mockVoiceaChannel.turnOnCaptions);
 
           await meeting.startTranscription();
-          assert.equal(webex.internal.voicea.on.callCount, 4);
+          assert.equal(mockVoiceaChannel.on.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, true);
-          assert.equal(webex.internal.voicea.listenToEvents.callCount, 1);
-          assert.calledTwice(webex.internal.voicea.turnOnCaptions);
+          assert.calledTwice(mockVoiceaChannel.turnOnCaptions);
         });
 
         it('should listen to events and turnOnCaptions for all users', async () => {
@@ -2286,10 +2316,9 @@ describe('plugin-meetings', () => {
 
           await meeting.startTranscription();
 
-          assert.equal(webex.internal.voicea.on.callCount, 4);
+          assert.equal(mockVoiceaChannel.on.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, true);
-          assert.equal(webex.internal.voicea.listenToEvents.callCount, 1);
-          assert.calledOnce(webex.internal.voicea.turnOnCaptions);
+          assert.calledOnce(mockVoiceaChannel.turnOnCaptions);
         });
 
         it("should throw error if request doesn't work", async () => {
@@ -2304,17 +2333,22 @@ describe('plugin-meetings', () => {
       });
 
       describe('#stopTranscription', () => {
+        let mockVoiceaChannel;
+
         beforeEach(() => {
-          webex.internal.voicea.on = sinon.stub();
-          webex.internal.voicea.off = sinon.stub();
-          webex.internal.voicea.listenToEvents = sinon.stub();
-          webex.internal.voicea.turnOnCaptions = sinon.stub();
-          webex.internal.voicea.deregisterEvents = sinon.stub();
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            listenToEvents: sinon.stub(),
+            turnOnCaptions: sinon.stub(),
+            deregisterEvents: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
         });
 
         it('should stop listening to voicea events and also trigger a stop event', () => {
           meeting.stopTranscription();
-          assert.equal(webex.internal.voicea.off.callCount, 4);
+          assert.equal(mockVoiceaChannel.off.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, false);
           assert.calledWith(
             TriggerProxy.trigger,
@@ -2330,7 +2364,7 @@ describe('plugin-meetings', () => {
         it('should stop listening to voicea events even when transcription is undefined', () => {
           meeting.transcription = undefined;
           meeting.stopTranscription();
-          assert.equal(webex.internal.voicea.off.callCount, 4);
+          assert.equal(mockVoiceaChannel.off.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, false);
           assert.calledWith(
             TriggerProxy.trigger,
@@ -2345,13 +2379,18 @@ describe('plugin-meetings', () => {
       });
 
       describe('#setCaptionLanguage', () => {
+        let mockVoiceaChannel;
+
         beforeEach(() => {
           meeting.isTranscriptionSupported = sinon.stub();
           meeting.transcription = {languageOptions: {}};
-          webex.internal.voicea.on = sinon.stub();
-          webex.internal.voicea.off = sinon.stub();
-          webex.internal.voicea.setCaptionLanguage = sinon.stub();
-          webex.internal.voicea.requestLanguage = sinon.stub();
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            setCaptionLanguage: sinon.stub(),
+            requestLanguage: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
         });
 
         afterEach(() => {
@@ -2373,7 +2412,7 @@ describe('plugin-meetings', () => {
           const languageCode = 'fr';
 
           meeting.setCaptionLanguage(languageCode).then((resolvedLanguageCode) => {
-            assert.calledWith(webex.internal.voicea.requestLanguage, languageCode);
+            assert.calledWith(mockVoiceaChannel.requestLanguage, languageCode);
             assert.equal(resolvedLanguageCode, languageCode);
             assert.equal(
               meeting.transcription.languageOptions.currentCaptionLanguage,
@@ -2382,13 +2421,10 @@ describe('plugin-meetings', () => {
             done();
           });
 
-          assert.calledOnceWithMatch(
-            webex.internal.voicea.on,
-            VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE
-          );
+          assert.calledOnceWithMatch(mockVoiceaChannel.on, VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE);
 
           // Trigger the event
-          const voiceaListenerLangugeUpdate = webex.internal.voicea.on.getCall(0).args[1];
+          const voiceaListenerLangugeUpdate = mockVoiceaChannel.on.getCall(0).args[1];
           voiceaListenerLangugeUpdate({statusCode: 200, languageCode});
         });
 
@@ -2405,24 +2441,26 @@ describe('plugin-meetings', () => {
             done();
           });
 
-          assert.calledOnceWithMatch(
-            webex.internal.voicea.on,
-            VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE
-          );
+          assert.calledOnceWithMatch(mockVoiceaChannel.on, VOICEAEVENTS.CAPTION_LANGUAGE_UPDATE);
 
           // Trigger the event
-          const voiceaListenerLangugeUpdate = webex.internal.voicea.on.getCall(0).args[1];
+          const voiceaListenerLangugeUpdate = mockVoiceaChannel.on.getCall(0).args[1];
           voiceaListenerLangugeUpdate(rejectPayload);
         });
       });
 
       describe('#setSpokenLanguage', () => {
+        let mockVoiceaChannel;
+
         beforeEach(() => {
           meeting.isTranscriptionSupported = sinon.stub();
           meeting.transcription = {languageOptions: {}};
-          webex.internal.voicea.on = sinon.stub();
-          webex.internal.voicea.off = sinon.stub();
-          webex.internal.voicea.setSpokenLanguage = sinon.stub();
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            setSpokenLanguage: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
           meeting.roles = ['MODERATOR'];
         });
 
@@ -2455,16 +2493,16 @@ describe('plugin-meetings', () => {
           const languageCode = 'fr';
 
           meeting.setSpokenLanguage(languageCode).then((resolvedLanguageCode) => {
-            assert.calledWith(webex.internal.voicea.setSpokenLanguage, languageCode);
+            assert.calledWith(mockVoiceaChannel.setSpokenLanguage, languageCode);
             assert.equal(resolvedLanguageCode, languageCode);
             assert.equal(meeting.transcription.languageOptions.currentSpokenLanguage, languageCode);
             done();
           });
 
-          assert.calledOnceWithMatch(webex.internal.voicea.on, VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE);
+          assert.calledOnceWithMatch(mockVoiceaChannel.on, VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE);
 
           // Trigger the event
-          const voiceaListenerLangugeUpdate = webex.internal.voicea.on.getCall(0).args[1];
+          const voiceaListenerLangugeUpdate = mockVoiceaChannel.on.getCall(0).args[1];
           voiceaListenerLangugeUpdate({languageCode});
         });
 
@@ -2480,10 +2518,10 @@ describe('plugin-meetings', () => {
             done();
           });
 
-          assert.calledOnceWithMatch(webex.internal.voicea.on, VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE);
+          assert.calledOnceWithMatch(mockVoiceaChannel.on, VOICEAEVENTS.SPOKEN_LANGUAGE_UPDATE);
 
           // Trigger the event
-          const voiceaListenerLangugeUpdate = webex.internal.voicea.on.getCall(0).args[1];
+          const voiceaListenerLangugeUpdate = mockVoiceaChannel.on.getCall(0).args[1];
           voiceaListenerLangugeUpdate(rejectPayload);
         });
       });
@@ -2844,10 +2882,15 @@ describe('plugin-meetings', () => {
       });
 
       describe('#handleLLMOnline', () => {
+        let mockVoiceaChannel;
+
         beforeEach(() => {
           webex.internal.llm.off = sinon.stub();
-          webex.internal.voicea.getKeepTranscriptionSubscribed = sinon.stub().returns(false);
-          webex.internal.voicea.updateSubchannelSubscriptions = sinon.stub();
+          mockVoiceaChannel = {
+            getKeepTranscriptionSubscribed: sinon.stub().returns(false),
+            updateSubchannelSubscriptions: sinon.stub(),
+          };
+          meeting.voiceaChannel = mockVoiceaChannel;
         });
 
         it('emits transcription connected events', () => {
@@ -2864,21 +2907,21 @@ describe('plugin-meetings', () => {
         });
 
         it('restores transcription subscription when caption intent is enabled', () => {
-          webex.internal.voicea.getKeepTranscriptionSubscribed.returns(true);
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
 
           meeting.handleLLMOnline();
 
-          assert.calledOnceWithExactly(webex.internal.voicea.updateSubchannelSubscriptions, {
+          assert.calledOnceWithExactly(mockVoiceaChannel.updateSubchannelSubscriptions, {
             subscribe: ['transcription'],
           });
         });
 
         it('does not restore transcription subscription when caption intent is disabled', () => {
-          webex.internal.voicea.getKeepTranscriptionSubscribed.returns(false);
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(false);
 
           meeting.handleLLMOnline();
 
-          assert.notCalled(webex.internal.voicea.updateSubchannelSubscriptions);
+          assert.notCalled(mockVoiceaChannel.updateSubchannelSubscriptions);
         });
 
         it('calls syncAllHashTreeDatasets on locusInfo', () => {
@@ -3173,6 +3216,7 @@ describe('plugin-meetings', () => {
                 registerAndConnect: sinon.stub().resolves({}),
                 disconnect: sinon.stub().resolves(),
                 isConnected: sinon.stub().returns(false),
+                isConnecting: sinon.stub().returns(false),
                 getLocusUrl: sinon.stub().returns(undefined),
                 getDatachannelUrl: sinon.stub().returns(undefined),
                 getDatachannelToken: sinon.stub().returns(undefined),
@@ -3214,6 +3258,7 @@ describe('plugin-meetings', () => {
                 registerAndConnect: sinon.stub().resolves({}),
                 disconnect: sinon.stub().resolves(),
                 isConnected: sinon.stub().returns(false),
+                isConnecting: sinon.stub().returns(false),
                 getLocusUrl: sinon.stub().returns(undefined),
                 getDatachannelUrl: sinon.stub().returns(undefined),
                 getDatachannelToken: sinon.stub().returns(undefined),
@@ -3464,6 +3509,7 @@ describe('plugin-meetings', () => {
                 registerAndConnect: sinon.stub().resolves({}),
                 disconnect: sinon.stub().resolves(),
                 isConnected: sinon.stub().returns(false),
+                isConnecting: sinon.stub().returns(false),
                 getLocusUrl: sinon.stub().returns(undefined),
                 getDatachannelUrl: sinon.stub().returns(undefined),
                 getDatachannelToken: sinon.stub().returns(undefined),
@@ -14909,6 +14955,7 @@ describe('plugin-meetings', () => {
 
       describe('#updateLLMConnection', () => {
         let mockChannel;
+        let mockVoiceaChannel;
 
         beforeEach(() => {
           // Create a mock channel that createConnection will return
@@ -14926,7 +14973,23 @@ describe('plugin-meetings', () => {
             off: sinon.stub(),
           };
 
+          // Create a mock voicea channel
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            onSpokenLanguageUpdate: sinon.stub(),
+            onCaptionServiceIdUpdate: sinon.stub(),
+            requestLanguage: sinon.stub(),
+            setSpokenLanguage: sinon.stub(),
+            turnOnCaptions: sinon.stub().resolves(),
+            listenToEvents: sinon.stub(),
+            deregisterEvents: sinon.stub(),
+            getIsCaptionBoxOn: sinon.stub().returns(false),
+            updateSubchannelSubscriptions: sinon.stub(),
+          };
+
           webex.internal.llm.createConnection = sinon.stub().returns(mockChannel);
+          webex.internal.voicea.createChannel = sinon.stub().returns(mockVoiceaChannel);
 
           meeting.processRelayEvent = sinon.stub();
           meeting.processLocusLLMEvent = sinon.stub();
@@ -15017,6 +15080,7 @@ describe('plugin-meetings', () => {
           // Set up existing channel with matching URLs
           const existingChannel = {
             isConnected: sinon.stub().returns(true),
+            isConnecting: sinon.stub().returns(false),
             getLocusUrl: sinon.stub().returns('a url'),
             getDatachannelUrl: sinon.stub().returns('a datachannel url'),
           };
@@ -15034,6 +15098,7 @@ describe('plugin-meetings', () => {
           // Set up existing channel with different URL
           const existingChannel = {
             isConnected: sinon.stub().returns(true),
+            isConnecting: sinon.stub().returns(false),
             getLocusUrl: sinon.stub().returns('old url'),
             getDatachannelUrl: sinon.stub().returns('a datachannel url'),
             disconnect: sinon.stub().resolves(),
@@ -15068,6 +15133,7 @@ describe('plugin-meetings', () => {
           // Set up existing channel with different datachannel URL
           const existingChannel = {
             isConnected: sinon.stub().returns(true),
+            isConnecting: sinon.stub().returns(false),
             getLocusUrl: sinon.stub().returns('a url'),
             getDatachannelUrl: sinon.stub().returns('old datachannel url'),
             disconnect: sinon.stub().resolves(),
@@ -15102,6 +15168,7 @@ describe('plugin-meetings', () => {
           // Set up existing connected channel
           const existingChannel = {
             isConnected: sinon.stub().returns(true),
+            isConnecting: sinon.stub().returns(false),
             getLocusUrl: sinon.stub().returns('a url'),
             getDatachannelUrl: sinon.stub().returns('a datachannel url'),
             disconnect: sinon.stub().resolves(),

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -303,6 +303,28 @@ describe('plugin-meetings', () => {
         });
       });
 
+      describe('#getPracticeSessionLocusUrl', () => {
+        it('returns locus URL when practice session channel exists', () => {
+          const mockChannel = createMockLLMChannel({
+            getLocusUrl: sinon.stub().returns('https://locus.example.com/practice'),
+          });
+          webinar._practiceSessionLLMChannel = mockChannel;
+
+          const locusUrl = webinar.getPracticeSessionLocusUrl();
+
+          assert.equal(locusUrl, 'https://locus.example.com/practice');
+          assert.calledOnce(mockChannel.getLocusUrl);
+        });
+
+        it('returns undefined when no practice session channel exists', () => {
+          webinar._practiceSessionLLMChannel = undefined;
+
+          const locusUrl = webinar.getPracticeSessionLocusUrl();
+
+          assert.isUndefined(locusUrl);
+        });
+      });
+
       describe('#ensurePracticeSessionDatachannelToken', () => {
         let meeting;
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -303,76 +303,6 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe('#turnOnCaptions', () => {
-        it('turns on captions with spoken language when practice session voicea channel exists', async () => {
-          const mockVoiceaChannel = {
-            turnOnCaptions: sinon.stub().resolves(),
-          };
-          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
-
-          await webinar.turnOnCaptions('en-US');
-
-          assert.calledOnceWithExactly(mockVoiceaChannel.turnOnCaptions, 'en-US');
-        });
-
-        it('turns on captions without spoken language', async () => {
-          const mockVoiceaChannel = {
-            turnOnCaptions: sinon.stub().resolves(),
-          };
-          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
-
-          await webinar.turnOnCaptions();
-
-          assert.calledOnceWithExactly(mockVoiceaChannel.turnOnCaptions, undefined);
-        });
-
-        it('does nothing when no practice session voicea channel exists', async () => {
-          webinar.practiceSessionVoiceaChannel = undefined;
-
-          // Should not throw
-          await webinar.turnOnCaptions('en-US');
-        });
-      });
-
-      describe('#setupPracticeSessionVoiceaListeners', () => {
-        it('forwards voicea events from practice session channel to meeting callbacks', () => {
-          const callback1 = sinon.stub();
-          const callback2 = sinon.stub();
-          const mockVoiceaChannel = {on: sinon.stub()};
-          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
-
-          const meeting = {
-            voiceaListenerCallbacks: {
-              'caption:ready': callback1,
-              'transcript:interim': callback2,
-            },
-          };
-
-          webinar.setupPracticeSessionVoiceaListeners(meeting);
-
-          assert.calledWith(mockVoiceaChannel.on, 'caption:ready', callback1);
-          assert.calledWith(mockVoiceaChannel.on, 'transcript:interim', callback2);
-        });
-
-        it('does nothing when practice session voicea channel is undefined', () => {
-          webinar.practiceSessionVoiceaChannel = undefined;
-
-          const meeting = {
-            voiceaListenerCallbacks: {'caption:ready': sinon.stub()},
-          };
-
-          // Should not throw
-          webinar.setupPracticeSessionVoiceaListeners(meeting);
-        });
-
-        it('does nothing when meeting is undefined', () => {
-          webinar.practiceSessionVoiceaChannel = {on: sinon.stub()};
-
-          // Should not throw
-          webinar.setupPracticeSessionVoiceaListeners(undefined);
-        });
-      });
-
       describe('#ensurePracticeSessionDatachannelToken', () => {
         let meeting;
 
@@ -478,11 +408,15 @@ describe('plugin-meetings', () => {
       describe('#cleanupPSDataChannel', () => {
         let mockPSChannel;
         let meeting;
+        let mockVoiceaChannel;
 
         beforeEach(() => {
           webinar.meetingId = 'meeting-id';
           mockPSChannel = createMockLLMChannel();
           webinar.practiceSessionLLMChannel = mockPSChannel;
+          mockVoiceaChannel = {
+            switchLLMChannel: sinon.stub().resolves(),
+          };
           meeting = {
             id: 'meeting-id',
             locusUrl: 'locusUrl',
@@ -490,6 +424,7 @@ describe('plugin-meetings', () => {
             processLocusLLMEvent: sinon.stub(),
             handleLLMOnline: sinon.stub(),
             llmChannel: createMockLLMChannel(),
+            voiceaChannel: mockVoiceaChannel,
             annotation: {registerChannel: sinon.stub()},
             trigger: sinon.stub(),
           };
@@ -567,31 +502,19 @@ describe('plugin-meetings', () => {
           assert.notCalled(mockPSChannel.disconnect);
         });
 
-        it('cleans up voicea channel when it exists', async () => {
-          const mockVoiceaChannel = {deregisterEvents: sinon.stub()};
-          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
-
+        it('switches voicea channel back to main meeting LLM channel', async () => {
           await webinar.cleanupPSDataChannel();
 
-          assert.calledOnceWithExactly(mockVoiceaChannel.deregisterEvents);
-          assert.isUndefined(webinar.practiceSessionVoiceaChannel);
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
         });
 
-        it('triggers voicea channel cleanup event when voicea channel existed', async () => {
-          const mockVoiceaChannel = {deregisterEvents: sinon.stub()};
-          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
+        it('does not switch voicea channel when meeting has no voiceaChannel', async () => {
+          meeting.voiceaChannel = undefined;
 
           await webinar.cleanupPSDataChannel();
 
-          assert.calledOnce(meeting.trigger);
-        });
-
-        it('does not trigger voicea channel cleanup event when no voicea channel existed', async () => {
-          webinar.practiceSessionVoiceaChannel = undefined;
-
-          await webinar.cleanupPSDataChannel();
-
-          assert.notCalled(meeting.trigger);
+          // Should not throw - cleanup should continue without voicea switch
+          assert.calledOnce(mockPSChannel.disconnect);
         });
       });
 
@@ -612,13 +535,7 @@ describe('plugin-meetings', () => {
             }),
           });
           mockVoiceaChannel = {
-            on: sinon.stub(),
-            off: sinon.stub(),
-            announce: sinon.stub(),
-            turnOnCaptions: sinon.stub().resolves(),
-            deregisterEvents: sinon.stub(),
-            getIsCaptionBoxOn: sinon.stub().returns(false),
-            updateSubchannelSubscriptions: sinon.stub(),
+            switchLLMChannel: sinon.stub().resolves(),
           };
 
           // Default session channel on the meeting
@@ -634,6 +551,7 @@ describe('plugin-meetings', () => {
             processLocusLLMEvent: sinon.stub(),
             handleLLMOnline: sinon.stub(),
             llmChannel: mockDefaultChannel,
+            voiceaChannel: mockVoiceaChannel,
             annotation: {registerChannel: sinon.stub()},
             locusInfo: {
               url: 'locus-url',
@@ -651,7 +569,6 @@ describe('plugin-meetings', () => {
 
           webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
           webex.internal.llm.createConnection = sinon.stub().returns(mockPSChannel);
-          webex.internal.voicea.createChannel = sinon.stub().returns(mockVoiceaChannel);
 
           // Ensure connect path is eligible
           webinar.selfIsPanelist = true;
@@ -800,34 +717,19 @@ describe('plugin-meetings', () => {
           assert.calledOnce(mockPSChannel.registerAndConnect);
         });
 
-        it('creates voicea channel for practice session', async () => {
+        it('switches voicea channel to practice session LLM channel after connect', async () => {
           await webinar.updatePSDataChannel();
 
-          assert.calledOnceWithExactly(webex.internal.voicea.createChannel, mockPSChannel);
-          assert.strictEqual(webinar.practiceSessionVoiceaChannel, mockVoiceaChannel);
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
         });
 
-        it('announces voicea on practice session channel after connect', async () => {
-          await webinar.updatePSDataChannel();
-
-          assert.calledOnce(mockVoiceaChannel.announce);
-        });
-
-        it('turns on captions when caption box was on', async () => {
-          // Set up existing voicea on default channel with captions on
-          meeting.voiceaChannel = {getIsCaptionBoxOn: sinon.stub().returns(true)};
+        it('does not call switchLLMChannel when meeting has no voiceaChannel', async () => {
+          meeting.voiceaChannel = undefined;
 
           await webinar.updatePSDataChannel();
 
-          assert.calledOnce(mockVoiceaChannel.turnOnCaptions);
-        });
-
-        it('does not turn on captions when caption box was off', async () => {
-          meeting.voiceaChannel = {getIsCaptionBoxOn: sinon.stub().returns(false)};
-
-          await webinar.updatePSDataChannel();
-
-          assert.notCalled(mockVoiceaChannel.turnOnCaptions);
+          // Should complete without error
+          assert.calledOnce(mockPSChannel.registerAndConnect);
         });
 
         it('defers connect when default session is not yet connected', async () => {
@@ -951,27 +853,6 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockPSChannel.disconnect, {code: 3050, reason: 'replaced'});
           // Should return undefined since the channel was replaced
           assert.isUndefined(result);
-        });
-
-        it('sets up voicea listeners for meeting callbacks', async () => {
-          meeting.voiceaListenerCallbacks = {
-            'caption:ready': sinon.stub(),
-            'transcript:final': sinon.stub(),
-          };
-
-          await webinar.updatePSDataChannel();
-
-          // Voicea channel should have listeners registered for each callback
-          assert.calledWith(
-            mockVoiceaChannel.on,
-            'caption:ready',
-            meeting.voiceaListenerCallbacks['caption:ready']
-          );
-          assert.calledWith(
-            mockVoiceaChannel.on,
-            'transcript:final',
-            meeting.voiceaListenerCallbacks['transcript:final']
-          );
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -286,7 +286,7 @@ describe('plugin-meetings', () => {
           const mockChannel = createMockLLMChannel({
             getBinding: sinon.stub().returns('test-binding-123'),
           });
-          webinar.practiceSessionLLMChannel = mockChannel;
+          webinar._practiceSessionLLMChannel = mockChannel;
 
           const binding = webinar.getPracticeSessionBinding();
 
@@ -295,7 +295,7 @@ describe('plugin-meetings', () => {
         });
 
         it('returns undefined when no practice session channel exists', () => {
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
 
           const binding = webinar.getPracticeSessionBinding();
 
@@ -328,7 +328,7 @@ describe('plugin-meetings', () => {
           const mockChannel = createMockLLMChannel({
             getDatachannelToken: sinon.stub().returns('cached-channel-token'),
           });
-          webinar.practiceSessionLLMChannel = mockChannel;
+          webinar._practiceSessionLLMChannel = mockChannel;
 
           const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
 
@@ -348,7 +348,7 @@ describe('plugin-meetings', () => {
 
         it('refreshes token when no cached token exists', async () => {
           webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
           webinar._pendingPracticeSessionDatachannelToken = undefined;
 
           const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
@@ -363,7 +363,7 @@ describe('plugin-meetings', () => {
             getDatachannelToken: sinon.stub().returns(undefined),
             setDatachannelToken: sinon.stub(),
           });
-          webinar.practiceSessionLLMChannel = mockChannel;
+          webinar._practiceSessionLLMChannel = mockChannel;
 
           await webinar.ensurePracticeSessionDatachannelToken(meeting);
 
@@ -372,7 +372,7 @@ describe('plugin-meetings', () => {
 
         it('stores refreshed token as pending when no channel exists', async () => {
           webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
           webinar._pendingPracticeSessionDatachannelToken = undefined;
 
           await webinar.ensurePracticeSessionDatachannelToken(meeting);
@@ -382,7 +382,7 @@ describe('plugin-meetings', () => {
 
         it('returns undefined and logs warning when refresh fails', async () => {
           webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
           webinar._pendingPracticeSessionDatachannelToken = undefined;
           meeting.refreshDataChannelToken.rejects(new Error('refresh failed'));
           const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
@@ -395,7 +395,7 @@ describe('plugin-meetings', () => {
 
         it('returns undefined when refresh returns no token', async () => {
           webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
           webinar._pendingPracticeSessionDatachannelToken = undefined;
           meeting.refreshDataChannelToken.resolves({body: {}});
 
@@ -413,7 +413,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           webinar.meetingId = 'meeting-id';
           mockPSChannel = createMockLLMChannel();
-          webinar.practiceSessionLLMChannel = mockPSChannel;
+          webinar._practiceSessionLLMChannel = mockPSChannel;
           mockVoiceaChannel = {
             switchLLMChannel: sinon.stub().resolves(),
           };
@@ -449,7 +449,7 @@ describe('plugin-meetings', () => {
             meeting.processLocusLLMEvent
           );
           assert.calledWithExactly(mockPSChannel.off, 'online', meeting.handleLLMOnline);
-          assert.isUndefined(webinar.practiceSessionLLMChannel);
+          assert.isUndefined(webinar._practiceSessionLLMChannel);
         });
 
         it('switches annotation back to meeting default channel after cleanup', async () => {
@@ -480,7 +480,7 @@ describe('plugin-meetings', () => {
             LOCUS_LLM_EVENT,
             meeting.processLocusLLMEvent
           );
-          assert.isUndefined(webinar.practiceSessionLLMChannel);
+          assert.isUndefined(webinar._practiceSessionLLMChannel);
         });
 
         it('removes a pending online listener if one exists', async () => {
@@ -494,7 +494,7 @@ describe('plugin-meetings', () => {
         });
 
         it('no-ops when no practice session channel exists', async () => {
-          webinar.practiceSessionLLMChannel = undefined;
+          webinar._practiceSessionLLMChannel = undefined;
 
           await webinar.cleanupPSDataChannel();
 
@@ -659,7 +659,7 @@ describe('plugin-meetings', () => {
             getLocusUrl: sinon.stub().returns('locus-url'),
             getDatachannelUrl: sinon.stub().returns('dc-url'),
           });
-          webinar.practiceSessionLLMChannel = existingChannel;
+          webinar._practiceSessionLLMChannel = existingChannel;
           const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
 
           const result = await webinar.updatePSDataChannel();
@@ -708,7 +708,7 @@ describe('plugin-meetings', () => {
             getLocusUrl: sinon.stub().returns('old-locus-url'),
             getDatachannelUrl: sinon.stub().returns('old-dc-url'),
           });
-          webinar.practiceSessionLLMChannel = existingChannel;
+          webinar._practiceSessionLLMChannel = existingChannel;
           const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
 
           await webinar.updatePSDataChannel();
@@ -825,7 +825,7 @@ describe('plugin-meetings', () => {
             assert.equal(error, registerError);
           }
 
-          assert.isUndefined(webinar.practiceSessionLLMChannel);
+          assert.isUndefined(webinar._practiceSessionLLMChannel);
         });
 
         it('stores pending token on channel when one exists', async () => {
@@ -843,7 +843,7 @@ describe('plugin-meetings', () => {
           const replacementChannel = createMockLLMChannel();
           mockPSChannel.registerAndConnect = sinon.stub().callsFake(async () => {
             // Mid-connect, another call replaces the channel
-            webinar.practiceSessionLLMChannel = replacementChannel;
+            webinar._practiceSessionLLMChannel = replacementChannel;
             return 'CONNECT_RESULT';
           });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -5,113 +5,140 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import uuid from 'uuid';
 import sinon from 'sinon';
 import {DataChannelTokenType} from '@webex/internal-plugin-llm';
-import {LLM_PRACTICE_SESSION, LOCUS_LLM_EVENT, SHARE_STATUS} from '@webex/plugin-meetings/src/constants';
-
-const PRACTICE_SESSION_KEY = LLM_PRACTICE_SESSION || DataChannelTokenType.PracticeSession;
+import {LOCUS_LLM_EVENT, SHARE_STATUS} from '@webex/plugin-meetings/src/constants';
 
 describe('plugin-meetings', () => {
     describe('Webinar', () => {
+      let webex;
+      let webinar;
+      let uuidStub;
+      let getUserTokenStub;
 
-        let webex;
-        let webinar;
-        let uuidStub;
-        let getUserTokenStub;
+      /**
+       * Creates a mock LLM channel with all the expected methods
+       */
+      function createMockLLMChannel(overrides = {}) {
+        return {
+          registerAndConnect: sinon.stub().resolves('REGISTER_AND_CONNECT_RESULT'),
+          disconnect: sinon.stub().resolves(),
+          isConnected: sinon.stub().returns(false),
+          isConnecting: sinon.stub().returns(false),
+          getLocusUrl: sinon.stub().returns(undefined),
+          getDatachannelUrl: sinon.stub().returns(undefined),
+          getDatachannelToken: sinon.stub().returns(undefined),
+          setDatachannelToken: sinon.stub(),
+          getBinding: sinon.stub().returns(undefined),
+          setRefreshHandler: sinon.stub(),
+          on: sinon.stub(),
+          off: sinon.stub(),
+          ...overrides,
+        };
+      }
 
-        beforeEach(() => {
-            // @ts-ignore
-            getUserTokenStub = sinon.stub().resolves('test-token');
-            uuidStub = sinon.stub(uuid,'v4').returns('test-uuid');
-            webex = new MockWebex({});
-            webex.internal.mercury.on = sinon.stub();
-            webinar = new Webinar({}, {parent: webex});
-            webinar.locusUrl = 'locusUrl';
-            webinar.webcastInstanceUrl = 'webcastInstanceUrl';
-            webex.request = sinon.stub().returns(Promise.resolve('REQUEST_RETURN_VALUE'));
-            webex.meetings = {};
-            webex.credentials.getUserToken = getUserTokenStub;
-            webex.meetings.getMeetingByType = sinon.stub();
-            webex.internal.voicea.announce = sinon.stub();
+      beforeEach(() => {
+        // @ts-ignore
+        getUserTokenStub = sinon.stub().resolves('test-token');
+        uuidStub = sinon.stub(uuid, 'v4').returns('test-uuid');
+        webex = new MockWebex({});
+        webex.internal.mercury.on = sinon.stub();
+        webinar = new Webinar({}, {parent: webex});
+        webinar.locusUrl = 'locusUrl';
+        webinar.webcastInstanceUrl = 'webcastInstanceUrl';
+        webex.request = sinon.stub().returns(Promise.resolve('REQUEST_RETURN_VALUE'));
+        webex.meetings = {};
+        webex.credentials.getUserToken = getUserTokenStub;
+        webex.meetings.getMeetingByType = sinon.stub();
+        webex.internal.voicea.announce = sinon.stub();
 
-      webex.internal.llm = {
-        getDatachannelToken: sinon.stub().returns(undefined),
-        setDatachannelToken: sinon.stub(),
-        setRefreshHandler: sinon.stub(),
-        getOwnerMeetingId: sinon.stub().returns(undefined),
-        resolveSessionOwnership: sinon.stub().callsFake((ownerMeetingId, sessionId) => {
-          const currentOwner = webex.internal.llm.getOwnerMeetingId(sessionId);
+        // Factory pattern: createConnection returns a mock channel
+        webex.internal.llm = {
+          isDataChannelTokenEnabled: sinon.stub().resolves(false),
+          createConnection: sinon.stub().callsFake(() => createMockLLMChannel()),
+        };
 
-          return {
-            currentOwner,
-            isOwner: !currentOwner || !ownerMeetingId || currentOwner === ownerMeetingId,
-          };
-        }),
-        setOwnerMeetingId: sinon.stub(),
-        isDataChannelTokenEnabled: sinon.stub().resolves(false),
-        isConnected: sinon.stub().returns(false),
-        disconnectLLM: sinon.stub().resolves(),
-        off: sinon.stub(),
-        on: sinon.stub(),
-        getLocusUrl: sinon.stub().returns('old-locus-url'),
-        getDatachannelUrl: sinon.stub().returns('old-dc-url'),
-        registerAndConnect: sinon.stub().resolves('REGISTER_AND_CONNECT_RESULT'),
-      };
+        // Mock voicea createChannel for practice session
+        webex.internal.voicea.createChannel = sinon.stub().callsFake(() => ({
+          on: sinon.stub(),
+          off: sinon.stub(),
+          announce: sinon.stub(),
+          turnOnCaptions: sinon.stub().resolves(),
+          deregisterEvents: sinon.stub(),
+          getIsCaptionBoxOn: sinon.stub().returns(false),
+          updateSubchannelSubscriptions: sinon.stub(),
+        }));
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      describe('#locusUrlUpdate', () => {
+        it('sets the locus url', () => {
+          webinar.locusUrlUpdate('newUrl');
+
+          assert.equal(webinar.locusUrl, 'newUrl');
+        });
+      });
+
+      describe('#updateWebcastUrl', () => {
+        it('sets the webcast instance url', () => {
+          webinar.updateWebcastUrl({resources: {webcastInstance: {url: 'newUrl'}}});
+
+          assert.equal(webinar.webcastInstanceUrl, 'newUrl');
+        });
+      });
+
+      describe('#updateCanManageWebcast', () => {
+        it('sets the webcast instance url when valid', () => {
+          webinar.updateWebcastUrl({resources: {webcastInstance: {url: 'newUrl'}}});
+          assert.equal(
+            webinar.webcastInstanceUrl,
+            'newUrl',
+            'webcast instance URL should be updated'
+          );
         });
 
-        afterEach(() => {
-          sinon.restore();
+        it('handles missing resources gracefully', () => {
+          webinar.updateWebcastUrl({});
+          assert.isUndefined(
+            webinar.webcastInstanceUrl,
+            'webcast instance URL should be undefined'
+          );
         });
 
-        describe('#locusUrlUpdate', () => {
-            it('sets the locus url', () => {
-                webinar.locusUrlUpdate('newUrl');
-
-                assert.equal(webinar.locusUrl, 'newUrl');
-            });
+        it('handles missing webcastInstance gracefully', () => {
+          webinar.updateWebcastUrl({resources: {}});
+          assert.isUndefined(
+            webinar.webcastInstanceUrl,
+            'webcast instance URL should be undefined'
+          );
         });
 
-        describe('#updateWebcastUrl', () => {
-            it('sets the webcast instance url', () => {
-                webinar.updateWebcastUrl({resources: {webcastInstance: {url:'newUrl'}}});
-
-                assert.equal(webinar.webcastInstanceUrl, 'newUrl');
-            });
+        it('handles missing URL gracefully', () => {
+          webinar.updateWebcastUrl({resources: {webcastInstance: {}}});
+          assert.isUndefined(
+            webinar.webcastInstanceUrl,
+            'webcast instance URL should be undefined'
+          );
         });
-
-
-        describe('#updateCanManageWebcast', () => {
-          it('sets the webcast instance url when valid', () => {
-            webinar.updateWebcastUrl({resources: {webcastInstance: {url:'newUrl'}}});
-            assert.equal(webinar.webcastInstanceUrl, 'newUrl', 'webcast instance URL should be updated');
-          });
-
-          it('handles missing resources gracefully', () => {
-              webinar.updateWebcastUrl({});
-              assert.isUndefined(webinar.webcastInstanceUrl, 'webcast instance URL should be undefined');
-          });
-
-          it('handles missing webcastInstance gracefully', () => {
-              webinar.updateWebcastUrl({resources: {}});
-              assert.isUndefined(webinar.webcastInstanceUrl, 'webcast instance URL should be undefined');
-          });
-
-          it('handles missing URL gracefully', () => {
-              webinar.updateWebcastUrl({resources: {webcastInstance: {}}});
-              assert.isUndefined(webinar.webcastInstanceUrl, 'webcast instance URL should be undefined');
-          });
-        });
+      });
 
       describe('#updateRoleChanged', () => {
         it('updates roles when promoted from attendee to panelist', () => {
           const payload = {
             oldRoles: ['ATTENDEE'],
-            newRoles: ['PANELIST']
+            newRoles: ['PANELIST'],
           };
 
           const result = webinar.updateRoleChanged(payload);
 
           assert.equal(webinar.selfIsPanelist, true, 'self should be a panelist');
           assert.equal(webinar.selfIsAttendee, false, 'self should not be an attendee');
-          assert.equal(webinar.canManageWebcast, false, 'self should not have manage webcast capability');
+          assert.equal(
+            webinar.canManageWebcast,
+            false,
+            'self should not have manage webcast capability'
+          );
           assert.equal(result.isPromoted, true, 'should indicate promotion');
           assert.equal(result.isDemoted, false, 'should not indicate demotion');
         });
@@ -119,14 +146,18 @@ describe('plugin-meetings', () => {
         it('updates roles when demoted from panelist to attendee', () => {
           const payload = {
             oldRoles: ['PANELIST'],
-            newRoles: ['ATTENDEE']
+            newRoles: ['ATTENDEE'],
           };
 
           const result = webinar.updateRoleChanged(payload);
 
           assert.equal(webinar.selfIsPanelist, false, 'self should not be a panelist');
           assert.equal(webinar.selfIsAttendee, true, 'self should be an attendee');
-          assert.equal(webinar.canManageWebcast, false, 'self should not have manage webcast capability');
+          assert.equal(
+            webinar.canManageWebcast,
+            false,
+            'self should not have manage webcast capability'
+          );
           assert.equal(result.isPromoted, false, 'should not indicate promotion');
           assert.equal(result.isDemoted, true, 'should indicate demotion');
         });
@@ -134,14 +165,18 @@ describe('plugin-meetings', () => {
         it('updates roles when attendee just join meeting', () => {
           const payload = {
             oldRoles: [''],
-            newRoles: ['ATTENDEE']
+            newRoles: ['ATTENDEE'],
           };
 
           const result = webinar.updateRoleChanged(payload);
 
           assert.equal(webinar.selfIsPanelist, false, 'self should not be a panelist');
           assert.equal(webinar.selfIsAttendee, true, 'self should be an attendee');
-          assert.equal(webinar.canManageWebcast, false, 'self should not have manage webcast capability');
+          assert.equal(
+            webinar.canManageWebcast,
+            false,
+            'self should not have manage webcast capability'
+          );
           assert.equal(result.isPromoted, false, 'should not indicate promotion');
           assert.equal(result.isDemoted, true, 'should indicate demotion');
         });
@@ -149,14 +184,18 @@ describe('plugin-meetings', () => {
         it('updates roles when promoted to moderator', () => {
           const payload = {
             oldRoles: ['PANELIST'],
-            newRoles: ['MODERATOR']
+            newRoles: ['MODERATOR'],
           };
 
           const result = webinar.updateRoleChanged(payload);
 
           assert.equal(webinar.selfIsPanelist, false, 'self should not be a panelist');
           assert.equal(webinar.selfIsAttendee, false, 'self should not be an attendee');
-          assert.equal(webinar.canManageWebcast, true, 'self should have manage webcast capability');
+          assert.equal(
+            webinar.canManageWebcast,
+            true,
+            'self should have manage webcast capability'
+          );
           assert.equal(result.isPromoted, false, 'should not indicate promotion');
           assert.equal(result.isDemoted, false, 'should not indicate demotion');
         });
@@ -164,703 +203,794 @@ describe('plugin-meetings', () => {
         it('updates roles when unchanged (remains as panelist)', () => {
           const payload = {
             oldRoles: ['PANELIST'],
-            newRoles: ['PANELIST']
+            newRoles: ['PANELIST'],
           };
 
           const result = webinar.updateRoleChanged(payload);
 
           assert.equal(webinar.selfIsPanelist, true, 'self should remain a panelist');
           assert.equal(webinar.selfIsAttendee, false, 'self should not be an attendee');
-          assert.equal(webinar.canManageWebcast, false, 'self should not have manage webcast capability');
+          assert.equal(
+            webinar.canManageWebcast,
+            false,
+            'self should not have manage webcast capability'
+          );
           assert.equal(result.isPromoted, false, 'should not indicate promotion');
           assert.equal(result.isDemoted, false, 'should not indicate demotion');
         });
 
-      it('handles missing role payload safely', () => {
-        const updateStatusByRoleStub = sinon.stub(webinar, 'updateStatusByRole');
+        it('handles missing role payload safely', () => {
+          const updateStatusByRoleStub = sinon.stub(webinar, 'updateStatusByRole');
 
-        const result = webinar.updateRoleChanged(undefined);
+          const result = webinar.updateRoleChanged(undefined);
 
-        assert.equal(webinar.selfIsPanelist, false);
-        assert.equal(webinar.selfIsAttendee, false);
-        assert.equal(webinar.canManageWebcast, false);
-        assert.deepEqual(result, {isPromoted: false, isDemoted: false});
-        assert.calledOnceWithExactly(updateStatusByRoleStub, {isPromoted: false, isDemoted: false});
-      });
-    });
-
-    describe('#getValidatedWebinarMeeting', () => {
-      it('returns the meeting when its locusUrl matches the webinar locusUrl', () => {
-        const meeting = {locusUrl: 'locusUrl'};
-        webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
-        webinar.locusUrl = 'locusUrl';
-
-        assert.equal(webinar.getValidatedWebinarMeeting(), meeting);
+          assert.equal(webinar.selfIsPanelist, false);
+          assert.equal(webinar.selfIsAttendee, false);
+          assert.equal(webinar.canManageWebcast, false);
+          assert.deepEqual(result, {isPromoted: false, isDemoted: false});
+          assert.calledOnceWithExactly(updateStatusByRoleStub, {
+            isPromoted: false,
+            isDemoted: false,
+          });
+        });
       });
 
-      it('returns undefined and warns when the resolved meeting locusUrl does not match', () => {
-        const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
-        const meeting = {locusUrl: 'other-locus-url'};
-        webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
-        webinar.locusUrl = 'locusUrl';
+      describe('#getValidatedWebinarMeeting', () => {
+        it('returns the meeting when its locusUrl matches the webinar locusUrl', () => {
+          const meeting = {locusUrl: 'locusUrl'};
+          webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
+          webinar.locusUrl = 'locusUrl';
 
-        assert.isUndefined(webinar.getValidatedWebinarMeeting());
-        assert.calledOnce(warnStub);
+          assert.equal(webinar.getValidatedWebinarMeeting(), meeting);
+        });
+
+        it('returns undefined and warns when the resolved meeting locusUrl does not match', () => {
+          const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
+          const meeting = {locusUrl: 'other-locus-url'};
+          webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
+          webinar.locusUrl = 'locusUrl';
+
+          assert.isUndefined(webinar.getValidatedWebinarMeeting());
+          assert.calledOnce(warnStub);
+        });
+
+        it('returns undefined when no meeting is resolved', () => {
+          webex.meetings.getMeetingByType = sinon.stub().returns(undefined);
+
+          assert.isUndefined(webinar.getValidatedWebinarMeeting());
+        });
+
+        it('returns undefined and warns when webinar locusUrl is not yet initialized', () => {
+          const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
+          const meeting = {locusUrl: 'some-url'};
+          webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
+          webinar.locusUrl = undefined;
+
+          assert.isUndefined(webinar.getValidatedWebinarMeeting());
+          assert.calledOnce(warnStub);
+        });
       });
 
-      it('returns undefined when no meeting is resolved', () => {
-        webex.meetings.getMeetingByType = sinon.stub().returns(undefined);
+      describe('#cleanUp', () => {
+        it('delegates to cleanupPSDataChannel', () => {
+          const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
 
-        assert.isUndefined(webinar.getValidatedWebinarMeeting());
+          webinar.cleanUp();
+
+          assert.calledOnceWithExactly(cleanupPSDataChannelStub);
+        });
       });
 
-      it('returns undefined and warns when webinar locusUrl is not yet initialized', () => {
-        const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
-        const meeting = {locusUrl: 'some-url'};
-        webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
-        webinar.locusUrl = undefined;
+      describe('#getPracticeSessionBinding', () => {
+        it('returns binding when practice session channel exists and is connected', () => {
+          const mockChannel = createMockLLMChannel({
+            getBinding: sinon.stub().returns('test-binding-123'),
+          });
+          webinar.practiceSessionLLMChannel = mockChannel;
 
-        assert.isUndefined(webinar.getValidatedWebinarMeeting());
-        assert.calledOnce(warnStub);
-      });
-    });
+          const binding = webinar.getPracticeSessionBinding();
 
-    describe('#cleanUp', () => {
-      it('delegates to cleanupPSDataChannel', () => {
-        const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
+          assert.equal(binding, 'test-binding-123');
+          assert.calledOnce(mockChannel.getBinding);
+        });
 
-        webinar.cleanUp();
+        it('returns undefined when no practice session channel exists', () => {
+          webinar.practiceSessionLLMChannel = undefined;
 
-        assert.calledOnceWithExactly(cleanupPSDataChannelStub);
-      });
-    });
+          const binding = webinar.getPracticeSessionBinding();
 
-    describe('#cleanupPSDataChannel', () => {
-      let relayListener;
-
-      beforeEach(() => {
-        webinar.meetingId = 'meeting-id';
-        relayListener = sinon.stub();
-        webinar.llmListeners = {relay: relayListener, locusLLM: null};
+          assert.isUndefined(binding);
+        });
       });
 
-      it('disconnects the practice session channel and removes the tracked relay listener', async () => {
-        await webinar.cleanupPSDataChannel();
+      describe('#turnOnCaptions', () => {
+        it('turns on captions with spoken language when practice session voicea channel exists', async () => {
+          const mockVoiceaChannel = {
+            turnOnCaptions: sinon.stub().resolves(),
+          };
+          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
 
-        assert.calledOnceWithExactly(
-          webex.internal.llm.disconnectLLM,
-          {code: 3050, reason: 'done (permanent)'},
-          PRACTICE_SESSION_KEY,
-          webinar.meetingId
-        );
-        assert.calledWithExactly(
-          webex.internal.llm.off,
-          `event:relay.event:${PRACTICE_SESSION_KEY}`,
-          relayListener
-        );
-        assert.isNull(webinar.llmListeners.relay);
+          await webinar.turnOnCaptions('en-US');
+
+          assert.calledOnceWithExactly(mockVoiceaChannel.turnOnCaptions, 'en-US');
+        });
+
+        it('turns on captions without spoken language', async () => {
+          const mockVoiceaChannel = {
+            turnOnCaptions: sinon.stub().resolves(),
+          };
+          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
+
+          await webinar.turnOnCaptions();
+
+          assert.calledOnceWithExactly(mockVoiceaChannel.turnOnCaptions, undefined);
+        });
+
+        it('does nothing when no practice session voicea channel exists', async () => {
+          webinar.practiceSessionVoiceaChannel = undefined;
+
+          // Should not throw
+          await webinar.turnOnCaptions('en-US');
+        });
       });
 
-      it('skips disconnect when practice-session owner is another meeting', async () => {
-        webex.internal.llm.getOwnerMeetingId.returns('other-meeting-id');
-        webex.internal.llm.disconnectLLM.resolves(false);
+      describe('#setupPracticeSessionVoiceaListeners', () => {
+        it('forwards voicea events from practice session channel to meeting callbacks', () => {
+          const callback1 = sinon.stub();
+          const callback2 = sinon.stub();
+          const mockVoiceaChannel = {on: sinon.stub()};
+          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
 
-        await webinar.cleanupPSDataChannel();
+          const meeting = {
+            voiceaListenerCallbacks: {
+              'caption:ready': callback1,
+              'transcript:interim': callback2,
+            },
+          };
 
-        assert.calledOnceWithExactly(
-          webex.internal.llm.disconnectLLM,
-          {code: 3050, reason: 'done (permanent)'},
-          PRACTICE_SESSION_KEY,
-          webinar.meetingId
-        );
-        assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-        assert.calledOnceWithExactly(
-          webex.internal.llm.off,
-          `event:relay.event:${PRACTICE_SESSION_KEY}`,
-          relayListener
-        );
+          webinar.setupPracticeSessionVoiceaListeners(meeting);
+
+          assert.calledWith(mockVoiceaChannel.on, 'caption:ready', callback1);
+          assert.calledWith(mockVoiceaChannel.on, 'transcript:interim', callback2);
+        });
+
+        it('does nothing when practice session voicea channel is undefined', () => {
+          webinar.practiceSessionVoiceaChannel = undefined;
+
+          const meeting = {
+            voiceaListenerCallbacks: {'caption:ready': sinon.stub()},
+          };
+
+          // Should not throw
+          webinar.setupPracticeSessionVoiceaListeners(meeting);
+        });
+
+        it('does nothing when meeting is undefined', () => {
+          webinar.practiceSessionVoiceaChannel = {on: sinon.stub()};
+
+          // Should not throw
+          webinar.setupPracticeSessionVoiceaListeners(undefined);
+        });
       });
 
-      it('skips relay listener removal when no listener has been tracked', async () => {
-        webinar.llmListeners.relay = null;
+      describe('#ensurePracticeSessionDatachannelToken', () => {
+        let meeting;
 
-        await webinar.cleanupPSDataChannel();
+        beforeEach(() => {
+          meeting = {
+            refreshDataChannelToken: sinon.stub().resolves({
+              body: {datachannelToken: 'refreshed-token'},
+            }),
+          };
+        });
 
-        const relayOffCalls = webex.internal.llm.off.args.filter(
-          ([event]) => event === `event:relay.event:${PRACTICE_SESSION_KEY}`
-        );
-        assert.equal(relayOffCalls.length, 0);
+        it('returns undefined when data channel token is not enabled', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(false);
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.isUndefined(token);
+          assert.notCalled(meeting.refreshDataChannelToken);
+        });
+
+        it('returns cached token from channel when available', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          const mockChannel = createMockLLMChannel({
+            getDatachannelToken: sinon.stub().returns('cached-channel-token'),
+          });
+          webinar.practiceSessionLLMChannel = mockChannel;
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.equal(token, 'cached-channel-token');
+          assert.notCalled(meeting.refreshDataChannelToken);
+        });
+
+        it('returns pending token when available', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar._pendingPracticeSessionDatachannelToken = 'pending-token';
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.equal(token, 'pending-token');
+          assert.notCalled(meeting.refreshDataChannelToken);
+        });
+
+        it('refreshes token when no cached token exists', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar.practiceSessionLLMChannel = undefined;
+          webinar._pendingPracticeSessionDatachannelToken = undefined;
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.equal(token, 'refreshed-token');
+          assert.calledOnce(meeting.refreshDataChannelToken);
+        });
+
+        it('stores refreshed token on channel when channel exists', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          const mockChannel = createMockLLMChannel({
+            getDatachannelToken: sinon.stub().returns(undefined),
+            setDatachannelToken: sinon.stub(),
+          });
+          webinar.practiceSessionLLMChannel = mockChannel;
+
+          await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.calledOnceWithExactly(mockChannel.setDatachannelToken, 'refreshed-token');
+        });
+
+        it('stores refreshed token as pending when no channel exists', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar.practiceSessionLLMChannel = undefined;
+          webinar._pendingPracticeSessionDatachannelToken = undefined;
+
+          await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.equal(webinar._pendingPracticeSessionDatachannelToken, 'refreshed-token');
+        });
+
+        it('returns undefined and logs warning when refresh fails', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar.practiceSessionLLMChannel = undefined;
+          webinar._pendingPracticeSessionDatachannelToken = undefined;
+          meeting.refreshDataChannelToken.rejects(new Error('refresh failed'));
+          const warnStub = sinon.stub(LoggerProxy.logger, 'warn');
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.isUndefined(token);
+          assert.calledOnce(warnStub);
+        });
+
+        it('returns undefined when refresh returns no token', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar.practiceSessionLLMChannel = undefined;
+          webinar._pendingPracticeSessionDatachannelToken = undefined;
+          meeting.refreshDataChannelToken.resolves({body: {}});
+
+          const token = await webinar.ensurePracticeSessionDatachannelToken(meeting);
+
+          assert.isUndefined(token);
+        });
       });
 
-      it('removes tracked relay listener even when disconnect throws', async () => {
-        const disconnectError = new Error('disconnect failed');
-        webex.internal.llm.disconnectLLM.rejects(disconnectError);
+      describe('#cleanupPSDataChannel', () => {
+        let mockPSChannel;
+        let meeting;
 
-        let caughtError;
+        beforeEach(() => {
+          webinar.meetingId = 'meeting-id';
+          mockPSChannel = createMockLLMChannel();
+          webinar.practiceSessionLLMChannel = mockPSChannel;
+          meeting = {
+            id: 'meeting-id',
+            locusUrl: 'locusUrl',
+            processRelayEvent: sinon.stub(),
+            processLocusLLMEvent: sinon.stub(),
+            handleLLMOnline: sinon.stub(),
+            llmChannel: createMockLLMChannel(),
+            annotation: {registerChannel: sinon.stub()},
+            trigger: sinon.stub(),
+          };
+          webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
+        });
 
-        try {
+        it('disconnects the practice session channel and removes listeners', async () => {
           await webinar.cleanupPSDataChannel();
-        } catch (error) {
-          caughtError = error;
-        }
 
-        assert.equal(caughtError, disconnectError);
-        assert.calledOnceWithExactly(
-          webex.internal.llm.setOwnerMeetingId,
-          undefined,
-          PRACTICE_SESSION_KEY
-        );
-        assert.calledOnceWithExactly(
-          webex.internal.llm.off,
-          `event:relay.event:${PRACTICE_SESSION_KEY}`,
-          relayListener
-        );
-        assert.notOk(webinar._practiceSessionRelayListener);
-       });
-
-      it('disconnects and removes the tracked locusLLM listener', async () => {
-        const locusLLMListener = sinon.stub();
-        webinar.llmListeners.locusLLM = locusLLMListener;
-
-        await webinar.cleanupPSDataChannel();
-
-        assert.calledWithExactly(
-          webex.internal.llm.off,
-          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-          locusLLMListener
-        );
-        assert.isNull(webinar.llmListeners.locusLLM);
-      });
-
-      it('skips locusLLM listener removal when no listener has been tracked', async () => {
-        webinar.llmListeners.locusLLM = null;
-
-        await webinar.cleanupPSDataChannel();
-
-        const locusLLMOffCalls = webex.internal.llm.off.args.filter(
-          ([event]) => event === `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`
-        );
-        assert.equal(locusLLMOffCalls.length, 0);
-      });
-
-      it('does not consult the meeting collection during cleanup', async () => {
-        webex.meetings.getMeetingByType = sinon.stub();
-
-        await webinar.cleanupPSDataChannel();
-
-        assert.notCalled(webex.meetings.getMeetingByType);
-      });
-
-      it('removes a pending online listener if one exists', async () => {
-        const listener = sinon.stub();
-        webinar._pendingOnlineListener = listener;
-
-        await webinar.cleanupPSDataChannel();
-
-        assert.calledWith(webex.internal.llm.off, 'online', listener);
-        assert.isNull(webinar._pendingOnlineListener);
-      });
-
-      it('skips online listener removal when none is pending', async () => {
-        webinar._pendingOnlineListener = null;
-
-        await webinar.cleanupPSDataChannel();
-
-        // 'off' should only be called for the relay event, not for 'online'
-        const onlineOffCalls = webex.internal.llm.off.args.filter(([event]) => event === 'online');
-        assert.equal(onlineOffCalls.length, 0);
-      });
-    });
-
-    describe('#updatePSDataChannel', () => {
-      let meeting;
-      let processRelayEvent;
-      let processLocusLLMEvent;
-
-      beforeEach(() => {
-        webinar.meetingId = 'meeting-id';
-        processRelayEvent = sinon.stub();
-        processLocusLLMEvent = sinon.stub();
-        meeting = {
-          id: 'meeting-id',
-          locusUrl: 'locusUrl',
-          isJoined: sinon.stub().returns(true),
-          processRelayEvent,
-          processLocusLLMEvent,
-          locusInfo: {
-            url: 'locus-url',
-            info: {practiceSessionDatachannelUrl: 'dc-url'},
-          },
-        };
-
-        webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
-
-        // Default session is connected by default; practice session is not
-        webex.internal.llm.isConnected = sinon.stub().callsFake((sessionId) => {
-          return sessionId !== PRACTICE_SESSION_KEY;
+          assert.calledOnceWithExactly(mockPSChannel.disconnect, {
+            code: 3050,
+            reason: 'done (permanent)',
+          });
+          assert.calledWithExactly(
+            mockPSChannel.off,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
+          assert.calledWithExactly(
+            mockPSChannel.off,
+            LOCUS_LLM_EVENT,
+            meeting.processLocusLLMEvent
+          );
+          assert.calledWithExactly(mockPSChannel.off, 'online', meeting.handleLLMOnline);
+          assert.isUndefined(webinar.practiceSessionLLMChannel);
         });
 
-        // Token is pre-saved into LLM by saveDataChannelToken
-        webex.internal.llm.getDatachannelToken = sinon.stub().callsFake((tokenType) => {
-          if (tokenType === DataChannelTokenType.PracticeSession) return 'ps-token';
-          return undefined;
+        it('switches annotation back to meeting default channel after cleanup', async () => {
+          await webinar.cleanupPSDataChannel();
+
+          assert.calledOnceWithExactly(meeting.annotation.registerChannel, meeting.llmChannel);
         });
 
-        // Ensure connect path is eligible
-        webinar.selfIsPanelist = true;
-        webinar.practiceSessionEnabled = true;
-        webex.internal.voicea.getKeepTranscriptionSubscribed = sinon.stub().returns(false);
-        webex.internal.voicea.updateSubchannelSubscriptions = sinon.stub();
-      });
+        it('removes listeners even when disconnect throws', async () => {
+          const disconnectError = new Error('disconnect failed');
+          mockPSChannel.disconnect.rejects(disconnectError);
 
-      it('refreshes practice-session token before register when cached token is missing', async () => {
-        webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-        webex.internal.llm.getDatachannelToken = sinon.stub().callsFake((tokenType) => {
-          if (tokenType === DataChannelTokenType.PracticeSession) return undefined;
+          let caughtError;
+          try {
+            await webinar.cleanupPSDataChannel();
+          } catch (error) {
+            caughtError = error;
+          }
 
-          return undefined;
-        });
-        meeting.refreshDataChannelToken = sinon.stub().resolves({
-          body: {
-            datachannelToken: 'ps-token-from-refresh',
-            dataChannelTokenType: DataChannelTokenType.PracticeSession,
-          },
-        });
-
-        await webinar.updatePSDataChannel();
-
-        assert.calledOnceWithExactly(meeting.refreshDataChannelToken);
-        assert.calledWithExactly(
-          webex.internal.llm.setDatachannelToken,
-          'ps-token-from-refresh',
-          'meeting-id',
-          DataChannelTokenType.PracticeSession
-        );
-        assert.calledWith(
-          webex.internal.llm.registerAndConnect,
-          'locus-url',
-          'dc-url',
-          'ps-token-from-refresh',
-          PRACTICE_SESSION_KEY
-        );
-      });
-
-      it('does not reconnect if practice-session eligibility changes during async token refresh', async () => {
-        webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-        webex.internal.llm.getDatachannelToken = sinon.stub().returns(undefined);
-
-        let resolveRefresh;
-        meeting.refreshDataChannelToken = sinon.stub().returns(
-          new Promise((resolve) => {
-            resolveRefresh = resolve;
-          })
-        );
-
-        const updatePromise = webinar.updatePSDataChannel();
-
-        webinar.practiceSessionEnabled = false;
-
-        resolveRefresh({
-          body: {
-            datachannelToken: 'stale-ps-token',
-            dataChannelTokenType: DataChannelTokenType.PracticeSession,
-          },
+          assert.equal(caughtError, disconnectError);
+          assert.calledWithExactly(
+            mockPSChannel.off,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
+          assert.calledWithExactly(
+            mockPSChannel.off,
+            LOCUS_LLM_EVENT,
+            meeting.processLocusLLMEvent
+          );
+          assert.isUndefined(webinar.practiceSessionLLMChannel);
         });
 
-        const result = await updatePromise;
+        it('removes a pending online listener if one exists', async () => {
+          const listener = sinon.stub();
+          webinar._pendingOnlineListener = listener;
 
-        assert.isUndefined(result);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
+          await webinar.cleanupPSDataChannel();
 
-      it('no-ops when practice session join eligibility is false', async () => {
-        webinar.practiceSessionEnabled = false;
-        const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.isUndefined(result);
-        assert.calledOnceWithExactly(cleanupPSDataChannelStub);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('no-ops when meeting is not joined', async () => {
-        meeting.isJoined.returns(false);
-        const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.isUndefined(result);
-        assert.calledOnceWithExactly(cleanupPSDataChannelStub);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('no-ops when practiceSessionDatachannelUrl is missing', async () => {
-        meeting.locusInfo.info.practiceSessionDatachannelUrl = undefined;
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.isUndefined(result);
-        assert.notCalled(webex.internal.llm.setRefreshHandler);
-        assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('no-ops when already connected to the same endpoints', async () => {
-        webex.internal.llm.isConnected.returns(true);
-        webex.internal.llm.getLocusUrl.returns('locus-url');
-        webex.internal.llm.getDatachannelUrl.returns('dc-url');
-        const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.isUndefined(result);
-        assert.notCalled(cleanupPSDataChannelStub);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('connects when eligible', async () => {
-        const result = await webinar.updatePSDataChannel();
-
-        assert.calledOnce(webex.internal.llm.registerAndConnect);
-        assert.calledWithExactly(
-          webex.internal.llm.setOwnerMeetingId,
-          'meeting-id',
-          PRACTICE_SESSION_KEY
-        );
-        assert.calledWith(
-          webex.internal.llm.registerAndConnect,
-          'locus-url',
-          'dc-url',
-          'ps-token',
-          PRACTICE_SESSION_KEY
-        );
-        assert.calledOnceWithExactly(webex.internal.voicea.announce);
-        assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
-      });
-
-      it('uses token from LLM', async () => {
-        webex.internal.llm.getDatachannelToken = sinon.stub().callsFake((tokenType) => {
-          if (tokenType === DataChannelTokenType.PracticeSession) return 'cached-token';
-          return undefined;
+          assert.calledWith(meeting.llmChannel.off, 'online', listener);
+          assert.isNull(webinar._pendingOnlineListener);
         });
 
-        await webinar.updatePSDataChannel();
+        it('no-ops when no practice session channel exists', async () => {
+          webinar.practiceSessionLLMChannel = undefined;
 
-        assert.calledWithExactly(
-          webex.internal.llm.getDatachannelToken,
-          DataChannelTokenType.PracticeSession,
-          webinar.meetingId
-        );
-        assert.notCalled(webex.internal.llm.setDatachannelToken);
-        assert.calledWith(
-          webex.internal.llm.registerAndConnect,
-          'locus-url',
-          'dc-url',
-          'cached-token',
-          PRACTICE_SESSION_KEY
-        );
-      });
+          await webinar.cleanupPSDataChannel();
 
-      it('cleans up the existing practice session channel before reconnecting to new endpoints', async () => {
-        webex.internal.llm.isConnected.returns(true);
-        const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
-
-        await webinar.updatePSDataChannel();
-
-        assert.calledOnceWithExactly(cleanupPSDataChannelStub);
-        assert.calledOnce(webex.internal.llm.registerAndConnect);
-      });
-
-      it('tracks and binds the relay listener after successful connect', async () => {
-        await webinar.updatePSDataChannel();
-
-        // Stores the exact listener reference for deterministic cleanup
-        assert.equal(webinar.llmListeners.relay, processRelayEvent);
-        assert.calledWith(
-          webex.internal.llm.on,
-          `event:relay.event:${PRACTICE_SESSION_KEY}`,
-          processRelayEvent
-        );
-      });
-
-      it('removes a previously tracked relay listener before re-binding on reconnect', async () => {
-        const previousListener = sinon.stub();
-        webinar.llmListeners = {relay: previousListener, locusLLM: null};
-
-        await webinar.updatePSDataChannel();
-
-        assert.calledWith(
-          webex.internal.llm.off,
-          `event:relay.event:${PRACTICE_SESSION_KEY}`,
-          previousListener
-        );
-        assert.equal(webinar.llmListeners.relay, processRelayEvent);
-      });
-
-      it('tracks and binds the locusLLM listener after successful connect', async () => {
-        await webinar.updatePSDataChannel();
-
-        assert.equal(webinar.llmListeners.locusLLM, processLocusLLMEvent);
-        assert.calledWith(
-          webex.internal.llm.on,
-          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-          processLocusLLMEvent
-        );
-      });
-
-      it('removes a previously tracked locusLLM listener before re-binding on reconnect', async () => {
-        const previousListener = sinon.stub();
-        webinar.llmListeners = {relay: null, locusLLM: previousListener};
-
-        await webinar.updatePSDataChannel();
-
-        assert.calledWith(
-          webex.internal.llm.off,
-          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-          previousListener
-        );
-        assert.equal(webinar.llmListeners.locusLLM, processLocusLLMEvent);
-      });
-
-      it('subscribes to transcription when caption intent is enabled', async () => {
-        webex.internal.voicea.getKeepTranscriptionSubscribed = sinon.stub().returns(true);
-
-        await webinar.updatePSDataChannel();
-
-        assert.calledOnceWithExactly(webex.internal.voicea.updateSubchannelSubscriptions, { subscribe: ['transcription'] });
-      });
-
-      it('does not subscribe to transcription when caption intent is disabled', async () => {
-        webex.internal.voicea.getKeepTranscriptionSubscribed = sinon.stub().returns(false);
-
-        await webinar.updatePSDataChannel();
-
-        assert.notCalled(webex.internal.voicea.updateSubchannelSubscriptions);
-      });
-
-      it('defers connect when default session is not yet connected', async () => {
-        // Default session is not connected initially
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-
-        const result = await webinar.updatePSDataChannel();
-
-        // Should return undefined immediately (deferred)
-        assert.isUndefined(result);
-        // Should register an 'online' listener but NOT call registerAndConnect yet
-        assert.calledWith(webex.internal.llm.on, 'online', sinon.match.func);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-        assert.notCalled(webex.internal.llm.setRefreshHandler);
-        assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-        // Should store the pending listener
-        assert.isNotNull(webinar._pendingOnlineListener);
-      });
-
-      it('does not register duplicate online listeners on repeated calls', async () => {
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-
-        await webinar.updatePSDataChannel();
-        await webinar.updatePSDataChannel();
-        await webinar.updatePSDataChannel();
-
-        // Only one 'online' listener should have been registered
-        const onlineCalls = webex.internal.llm.on.args.filter(([event]) => event === 'online');
-        assert.equal(onlineCalls.length, 1, 'should register exactly one online listener');
-      });
-
-      it('re-invokes updatePSDataChannel when default session comes online', async () => {
-        // Default session is not connected initially
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-
-        const updatePSDataChannelSpy = sinon.spy(webinar, 'updatePSDataChannel');
-
-        // First call defers
-        await webinar.updatePSDataChannel();
-
-        // Capture the 'online' listener
-        const onlineCall = webex.internal.llm.on.args.find(([event]) => event === 'online');
-        assert.isDefined(onlineCall, 'should have registered an online listener');
-
-        // Now simulate default session coming online
-        webex.internal.llm.isConnected = sinon.stub().callsFake((sessionId) => {
-          return sessionId !== PRACTICE_SESSION_KEY;
+          // Should not throw and should complete successfully
+          assert.notCalled(mockPSChannel.disconnect);
         });
 
-        // Fire the captured listener
-        onlineCall[1]();
+        it('cleans up voicea channel when it exists', async () => {
+          const mockVoiceaChannel = {deregisterEvents: sinon.stub()};
+          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
 
-        // The listener should have cleared itself, removed itself, and re-called updatePSDataChannel
-        assert.isNull(webinar._pendingOnlineListener);
-        assert.calledWith(webex.internal.llm.off, 'online', sinon.match.func);
-        assert.equal(updatePSDataChannelSpy.callCount, 2);
-      });
+          await webinar.cleanupPSDataChannel();
 
-      it('does not reconnect with stale data if demoted before default session comes online', async () => {
-        // Default session is not connected initially
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-
-        await webinar.updatePSDataChannel();
-
-        // Capture the 'online' listener
-        const onlineCall = webex.internal.llm.on.args.find(([event]) => event === 'online');
-        assert.isDefined(onlineCall);
-
-        // Simulate demotion while waiting
-        webinar.selfIsPanelist = false;
-
-        // Now default session comes online
-        webex.internal.llm.isConnected = sinon.stub().callsFake((sessionId) => {
-          return sessionId !== PRACTICE_SESSION_KEY;
+          assert.calledOnceWithExactly(mockVoiceaChannel.deregisterEvents);
+          assert.isUndefined(webinar.practiceSessionVoiceaChannel);
         });
 
-        // Fire the listener — re-invokes updatePSDataChannel which will see isPracticeSession = false
-        onlineCall[1]();
+        it('triggers voicea channel cleanup event when voicea channel existed', async () => {
+          const mockVoiceaChannel = {deregisterEvents: sinon.stub()};
+          webinar.practiceSessionVoiceaChannel = mockVoiceaChannel;
 
-        // Should NOT have called registerAndConnect since the user is no longer eligible
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
+          await webinar.cleanupPSDataChannel();
 
-      it('proceeds immediately when default session is already connected', async () => {
-        // Default session already connected, practice session not
-        webex.internal.llm.isConnected = sinon.stub().callsFake((sessionId) => {
-          return sessionId !== PRACTICE_SESSION_KEY;
+          assert.calledOnce(meeting.trigger);
         });
 
-        const result = await webinar.updatePSDataChannel();
+        it('does not trigger voicea channel cleanup event when no voicea channel existed', async () => {
+          webinar.practiceSessionVoiceaChannel = undefined;
 
-        // The 'online' listener is registered then immediately removed since default session is already connected
-        assert.calledWith(webex.internal.llm.on, 'online', sinon.match.func);
-        assert.calledWith(webex.internal.llm.off, 'online', sinon.match.func);
-        assert.isNull(webinar._pendingOnlineListener);
-        assert.calledOnce(webex.internal.llm.registerAndConnect);
-        assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
+          await webinar.cleanupPSDataChannel();
+
+          assert.notCalled(meeting.trigger);
+        });
       });
 
-      it('does not override practice refresh handler or reconnect when owned by another meeting', async () => {
-        webex.internal.llm.getOwnerMeetingId.returns('other-meeting-id');
-        webex.internal.llm.isConnected = sinon.stub().callsFake((sessionId) => {
-          return sessionId !== undefined;
+      describe('#updatePSDataChannel', () => {
+        let meeting;
+        let mockPSChannel;
+        let mockVoiceaChannel;
+
+        beforeEach(() => {
+          webinar.meetingId = 'meeting-id';
+          mockPSChannel = createMockLLMChannel({
+            isConnected: sinon.stub().returns(false),
+            getLocusUrl: sinon.stub().returns('old-locus-url'),
+            getDatachannelUrl: sinon.stub().returns('old-dc-url'),
+            getDatachannelToken: sinon.stub().callsFake((tokenType) => {
+              if (tokenType === DataChannelTokenType.PracticeSession) return 'ps-token';
+              return undefined;
+            }),
+          });
+          mockVoiceaChannel = {
+            on: sinon.stub(),
+            off: sinon.stub(),
+            announce: sinon.stub(),
+            turnOnCaptions: sinon.stub().resolves(),
+            deregisterEvents: sinon.stub(),
+            getIsCaptionBoxOn: sinon.stub().returns(false),
+            updateSubchannelSubscriptions: sinon.stub(),
+          };
+
+          // Default session channel on the meeting
+          const mockDefaultChannel = createMockLLMChannel({
+            isConnected: sinon.stub().returns(true),
+          });
+
+          meeting = {
+            id: 'meeting-id',
+            locusUrl: 'locusUrl',
+            isJoined: sinon.stub().returns(true),
+            processRelayEvent: sinon.stub(),
+            processLocusLLMEvent: sinon.stub(),
+            handleLLMOnline: sinon.stub(),
+            llmChannel: mockDefaultChannel,
+            annotation: {registerChannel: sinon.stub()},
+            locusInfo: {
+              url: 'locus-url',
+              info: {practiceSessionDatachannelUrl: 'dc-url'},
+            },
+            refreshDataChannelToken: sinon.stub().resolves({
+              body: {
+                datachannelToken: 'ps-token',
+                dataChannelTokenType: DataChannelTokenType.PracticeSession,
+              },
+            }),
+            voiceaListenerCallbacks: {},
+            trigger: sinon.stub(),
+          };
+
+          webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
+          webex.internal.llm.createConnection = sinon.stub().returns(mockPSChannel);
+          webex.internal.voicea.createChannel = sinon.stub().returns(mockVoiceaChannel);
+
+          // Ensure connect path is eligible
+          webinar.selfIsPanelist = true;
+          webinar.practiceSessionEnabled = true;
+
+          // Set a pending token so the channel can connect without requiring token refresh
+          webinar._pendingPracticeSessionDatachannelToken = 'ps-token';
         });
 
-        const result = await webinar.updatePSDataChannel();
+        it('refreshes practice-session token before register when cached token is missing', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          webinar._pendingPracticeSessionDatachannelToken = undefined; // Clear the pending token
 
-        assert.isUndefined(result);
-        assert.notCalled(webex.internal.llm.setRefreshHandler);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('does not reconnect when practice session is disconnected but owned by another meeting', async () => {
-        webex.internal.llm.getOwnerMeetingId.returns('other-meeting-id');
-        webex.internal.llm.isConnected = sinon.stub().returns(false);
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.isUndefined(result);
-        assert.notCalled(webex.internal.llm.setRefreshHandler);
-        assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('does not write owner or connect if ownership changes before pre-connect owner write', async () => {
-        let ownerMeetingId = 'meeting-id';
-
-        webex.internal.llm.getOwnerMeetingId.callsFake(() => ownerMeetingId);
-        webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
-        webex.internal.llm.getDatachannelToken = sinon.stub().returns(undefined);
-
-        let resolveRefresh;
-        meeting.refreshDataChannelToken = sinon.stub().returns(
-          new Promise((resolve) => {
-            resolveRefresh = resolve;
-          })
-        );
-
-        const updatePromise = webinar.updatePSDataChannel();
-
-        ownerMeetingId = 'other-meeting-id';
-        resolveRefresh({
-          body: {
-            datachannelToken: 'ps-token-from-refresh',
-            dataChannelTokenType: DataChannelTokenType.PracticeSession,
-          },
-        });
-
-        const result = await updatePromise;
-
-        assert.isUndefined(result);
-        assert.notCalled(webex.internal.llm.setRefreshHandler);
-        assert.notCalled(webex.internal.llm.setOwnerMeetingId);
-        assert.notCalled(webex.internal.llm.registerAndConnect);
-      });
-
-      it('does not overwrite owner after connect when ownership changed during registerAndConnect', async () => {
-        let ownerMeetingId = 'meeting-id';
-
-        webex.internal.llm.getOwnerMeetingId.callsFake(() => ownerMeetingId);
-        webex.internal.llm.registerAndConnect = sinon.stub().callsFake(async () => {
-          ownerMeetingId = 'other-meeting-id';
-
-          return 'REGISTER_AND_CONNECT_RESULT';
-        });
-
-        const result = await webinar.updatePSDataChannel();
-
-        assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
-        assert.calledOnce(webex.internal.llm.setOwnerMeetingId);
-        assert.calledWithExactly(
-          webex.internal.llm.setOwnerMeetingId,
-          'meeting-id',
-          PRACTICE_SESSION_KEY
-        );
-      });
-
-      it('clears pre-claimed owner when registerAndConnect rejects', async () => {
-        const registerError = new Error('register failed');
-        let ownerMeetingId = 'meeting-id';
-
-        webex.internal.llm.getOwnerMeetingId.callsFake(() => ownerMeetingId);
-        webex.internal.llm.setOwnerMeetingId.callsFake((id) => {
-          ownerMeetingId = id;
-        });
-        webex.internal.llm.registerAndConnect = sinon.stub().rejects(registerError);
-
-        try {
           await webinar.updatePSDataChannel();
-          assert.fail('Expected updatePSDataChannel to reject when registerAndConnect fails');
-        } catch (error) {
-          assert.equal(error, registerError);
-        }
 
-        assert.calledTwice(webex.internal.llm.setOwnerMeetingId);
-        assert.calledWithExactly(
-          webex.internal.llm.setOwnerMeetingId.firstCall,
-          'meeting-id',
-          PRACTICE_SESSION_KEY
-        );
-        assert.calledWithExactly(
-          webex.internal.llm.setOwnerMeetingId.secondCall,
-          undefined,
-          PRACTICE_SESSION_KEY
-        );
-        assert.isUndefined(ownerMeetingId);
-      });
+          assert.calledOnceWithExactly(meeting.refreshDataChannelToken);
+          assert.calledWith(
+            mockPSChannel.registerAndConnect,
+            'locus-url',
+            'dc-url',
+            'ps-token' // Token from refreshDataChannelToken
+          );
+        });
+
+        it('does not reconnect if practice-session eligibility changes during async token refresh', async () => {
+          webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+          mockPSChannel.getDatachannelToken.returns(undefined);
+
+          let resolveRefresh;
+          meeting.refreshDataChannelToken = sinon.stub().returns(
+            new Promise((resolve) => {
+              resolveRefresh = resolve;
+            })
+          );
+
+          const updatePromise = webinar.updatePSDataChannel();
+
+          webinar.practiceSessionEnabled = false;
+
+          resolveRefresh({
+            body: {
+              datachannelToken: 'stale-ps-token',
+              dataChannelTokenType: DataChannelTokenType.PracticeSession,
+            },
+          });
+
+          const result = await updatePromise;
+
+          assert.isUndefined(result);
+          assert.notCalled(mockPSChannel.registerAndConnect);
+        });
+
+        it('no-ops when practice session join eligibility is false', async () => {
+          webinar.practiceSessionEnabled = false;
+          const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
+
+          const result = await webinar.updatePSDataChannel();
+
+          assert.isUndefined(result);
+          assert.calledOnceWithExactly(cleanupPSDataChannelStub);
+          assert.notCalled(mockPSChannel.registerAndConnect);
+        });
+
+        it('no-ops when meeting is not joined', async () => {
+          meeting.isJoined.returns(false);
+          const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
+
+          const result = await webinar.updatePSDataChannel();
+
+          assert.isUndefined(result);
+          assert.calledOnceWithExactly(cleanupPSDataChannelStub);
+          assert.notCalled(mockPSChannel.registerAndConnect);
+        });
+
+        it('no-ops when practiceSessionDatachannelUrl is missing', async () => {
+          meeting.locusInfo.info.practiceSessionDatachannelUrl = undefined;
+
+          const result = await webinar.updatePSDataChannel();
+
+          assert.isUndefined(result);
+          assert.notCalled(webex.internal.llm.createConnection);
+        });
+
+        it('no-ops when already connected to the same endpoints', async () => {
+          // Set up existing channel already connected to same endpoints
+          const existingChannel = createMockLLMChannel({
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('locus-url'),
+            getDatachannelUrl: sinon.stub().returns('dc-url'),
+          });
+          webinar.practiceSessionLLMChannel = existingChannel;
+          const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
+
+          const result = await webinar.updatePSDataChannel();
+
+          assert.isUndefined(result);
+          assert.notCalled(cleanupPSDataChannelStub);
+          assert.notCalled(webex.internal.llm.createConnection);
+        });
+
+        it('connects when eligible', async () => {
+          const result = await webinar.updatePSDataChannel();
+
+          assert.calledOnce(webex.internal.llm.createConnection);
+          assert.calledWith(mockPSChannel.registerAndConnect, 'locus-url', 'dc-url', 'ps-token');
+          assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
+        });
+
+        it('sets up refresh handler on the channel', async () => {
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnce(mockPSChannel.setRefreshHandler);
+          // The refresh handler should call meeting.refreshDataChannelToken
+          const refreshHandler = mockPSChannel.setRefreshHandler.firstCall.args[0];
+          refreshHandler();
+          assert.calledOnce(meeting.refreshDataChannelToken);
+        });
+
+        it('registers event listeners on the practice session channel', async () => {
+          await webinar.updatePSDataChannel();
+
+          assert.calledWith(mockPSChannel.on, 'event:relay.event', meeting.processRelayEvent);
+          assert.calledWith(mockPSChannel.on, LOCUS_LLM_EVENT, meeting.processLocusLLMEvent);
+          assert.calledWith(mockPSChannel.on, 'online', meeting.handleLLMOnline);
+        });
+
+        it('switches annotation to practice session channel after connect', async () => {
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnceWithExactly(meeting.annotation.registerChannel, mockPSChannel);
+        });
+
+        it('cleans up the existing practice session channel before reconnecting to new endpoints', async () => {
+          // Set up existing channel connected to different endpoints
+          const existingChannel = createMockLLMChannel({
+            isConnected: sinon.stub().returns(true),
+            getLocusUrl: sinon.stub().returns('old-locus-url'),
+            getDatachannelUrl: sinon.stub().returns('old-dc-url'),
+          });
+          webinar.practiceSessionLLMChannel = existingChannel;
+          const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
+
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnceWithExactly(cleanupPSDataChannelStub);
+          assert.calledOnce(mockPSChannel.registerAndConnect);
+        });
+
+        it('creates voicea channel for practice session', async () => {
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnceWithExactly(webex.internal.voicea.createChannel, mockPSChannel);
+          assert.strictEqual(webinar.practiceSessionVoiceaChannel, mockVoiceaChannel);
+        });
+
+        it('announces voicea on practice session channel after connect', async () => {
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnce(mockVoiceaChannel.announce);
+        });
+
+        it('turns on captions when caption box was on', async () => {
+          // Set up existing voicea on default channel with captions on
+          meeting.voiceaChannel = {getIsCaptionBoxOn: sinon.stub().returns(true)};
+
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnce(mockVoiceaChannel.turnOnCaptions);
+        });
+
+        it('does not turn on captions when caption box was off', async () => {
+          meeting.voiceaChannel = {getIsCaptionBoxOn: sinon.stub().returns(false)};
+
+          await webinar.updatePSDataChannel();
+
+          assert.notCalled(mockVoiceaChannel.turnOnCaptions);
+        });
+
+        it('defers connect when default session is not yet connected', async () => {
+          // Default session is not connected initially
+          meeting.llmChannel.isConnected.returns(false);
+
+          const result = await webinar.updatePSDataChannel();
+
+          // Should return undefined immediately (deferred)
+          assert.isUndefined(result);
+          // Should register an 'online' listener but NOT call registerAndConnect yet
+          assert.calledWith(meeting.llmChannel.on, 'online', sinon.match.func);
+          assert.notCalled(mockPSChannel.registerAndConnect);
+          // Should store the pending listener
+          assert.isNotNull(webinar._pendingOnlineListener);
+        });
+
+        it('does not register duplicate online listeners on repeated calls', async () => {
+          meeting.llmChannel.isConnected.returns(false);
+
+          await webinar.updatePSDataChannel();
+          await webinar.updatePSDataChannel();
+          await webinar.updatePSDataChannel();
+
+          // Only one 'online' listener should have been registered
+          const onlineCalls = meeting.llmChannel.on.args.filter(([event]) => event === 'online');
+          assert.equal(onlineCalls.length, 1, 'should register exactly one online listener');
+        });
+
+        it('re-invokes updatePSDataChannel when default session comes online', async () => {
+          meeting.llmChannel.isConnected.returns(false);
+
+          const updatePSDataChannelSpy = sinon.spy(webinar, 'updatePSDataChannel');
+
+          // First call defers
+          await webinar.updatePSDataChannel();
+
+          // Capture the 'online' listener
+          const onlineCall = meeting.llmChannel.on.args.find(([event]) => event === 'online');
+          assert.isDefined(onlineCall, 'should have registered an online listener');
+
+          // Now simulate default session coming online
+          meeting.llmChannel.isConnected.returns(true);
+
+          // Fire the captured listener
+          onlineCall[1]();
+
+          // The listener should have cleared itself, removed itself, and re-called updatePSDataChannel
+          assert.isNull(webinar._pendingOnlineListener);
+          assert.calledWith(meeting.llmChannel.off, 'online', sinon.match.func);
+          assert.equal(updatePSDataChannelSpy.callCount, 2);
+        });
+
+        it('does not reconnect with stale data if demoted before default session comes online', async () => {
+          meeting.llmChannel.isConnected.returns(false);
+
+          await webinar.updatePSDataChannel();
+
+          // Capture the 'online' listener
+          const onlineCall = meeting.llmChannel.on.args.find(([event]) => event === 'online');
+          assert.isDefined(onlineCall);
+
+          // Simulate demotion while waiting
+          webinar.selfIsPanelist = false;
+
+          // Now default session comes online
+          meeting.llmChannel.isConnected.returns(true);
+
+          // Fire the listener — re-invokes updatePSDataChannel which will see isPracticeSession = false
+          onlineCall[1]();
+
+          // Should NOT have called registerAndConnect since the user is no longer eligible
+          assert.notCalled(mockPSChannel.registerAndConnect);
+        });
+
+        it('proceeds immediately when default session is already connected', async () => {
+          meeting.llmChannel.isConnected.returns(true);
+
+          const result = await webinar.updatePSDataChannel();
+
+          assert.calledOnce(mockPSChannel.registerAndConnect);
+          assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
+        });
+
+        it('clears channel reference when registerAndConnect rejects', async () => {
+          const registerError = new Error('register failed');
+          mockPSChannel.registerAndConnect.rejects(registerError);
+
+          try {
+            await webinar.updatePSDataChannel();
+            assert.fail('Expected updatePSDataChannel to reject when registerAndConnect fails');
+          } catch (error) {
+            assert.equal(error, registerError);
+          }
+
+          assert.isUndefined(webinar.practiceSessionLLMChannel);
+        });
+
+        it('stores pending token on channel when one exists', async () => {
+          webinar._pendingPracticeSessionDatachannelToken = 'pending-token';
+
+          await webinar.updatePSDataChannel();
+
+          assert.calledOnceWithExactly(mockPSChannel.setDatachannelToken, 'pending-token');
+          assert.isUndefined(webinar._pendingPracticeSessionDatachannelToken);
+        });
+
+        it('disconnects and returns undefined when channel replaced mid-connect', async () => {
+          // Simulate a race condition where another updatePSDataChannel call replaces the channel
+          // while registerAndConnect is in progress
+          const replacementChannel = createMockLLMChannel();
+          mockPSChannel.registerAndConnect = sinon.stub().callsFake(async () => {
+            // Mid-connect, another call replaces the channel
+            webinar.practiceSessionLLMChannel = replacementChannel;
+            return 'CONNECT_RESULT';
+          });
+
+          const result = await webinar.updatePSDataChannel();
+
+          // Original channel should be disconnected (replaced scenario)
+          assert.calledOnceWithExactly(mockPSChannel.disconnect, {code: 3050, reason: 'replaced'});
+          // Should return undefined since the channel was replaced
+          assert.isUndefined(result);
+        });
+
+        it('sets up voicea listeners for meeting callbacks', async () => {
+          meeting.voiceaListenerCallbacks = {
+            'caption:ready': sinon.stub(),
+            'transcript:final': sinon.stub(),
+          };
+
+          await webinar.updatePSDataChannel();
+
+          // Voicea channel should have listeners registered for each callback
+          assert.calledWith(
+            mockVoiceaChannel.on,
+            'caption:ready',
+            meeting.voiceaListenerCallbacks['caption:ready']
+          );
+          assert.calledWith(
+            mockVoiceaChannel.on,
+            'transcript:final',
+            meeting.voiceaListenerCallbacks['transcript:final']
+          );
+        });
       });
 
       describe('#updateStatusByRole', () => {
         let updateMediaShares;
         beforeEach(() => {
-          updateMediaShares = sinon.stub()
+          updateMediaShares = sinon.stub();
           webinar.webex.meetings = {
             getMeetingByType: sinon.stub().returns({
-              id: 'meeting-id', locusUrl: 'locusUrl',
+              id: 'meeting-id',
+              locusUrl: 'locusUrl',
               isJoined: sinon.stub().returns(false),
               updateLLMConnection: sinon.stub(),
               shareStatus: SHARE_STATUS.WHITEBOARD_SHARE_ACTIVE,
               locusInfo: {
                 mediaShares: 'mediaShares',
-                updateMediaShares: updateMediaShares
-              }
-            })
+                updateMediaShares: updateMediaShares,
+              },
+            }),
           };
         });
 
@@ -869,7 +999,6 @@ describe('plugin-meetings', () => {
         });
 
         it('trigger updateMediaShares if promoted', () => {
-
           const roleChange = {isPromoted: true, isDemoted: false};
 
           webinar.updateStatusByRole(roleChange);
@@ -878,7 +1007,6 @@ describe('plugin-meetings', () => {
         });
 
         it('Not trigger updateMediaShares if no role change', () => {
-
           const roleChange = {isPromoted: false, isDemoted: false};
 
           webinar.updateStatusByRole(roleChange);
@@ -886,7 +1014,6 @@ describe('plugin-meetings', () => {
           assert.notCalled(updateMediaShares);
         });
         it('trigger updateMediaShares if is promoted', () => {
-
           const roleChange = {isPromoted: true, isDemoted: false};
 
           webinar.updateStatusByRole(roleChange);
@@ -895,7 +1022,6 @@ describe('plugin-meetings', () => {
         });
 
         it('trigger updateMediaShares if is attendee with whiteboard share', () => {
-
           const roleChange = {isPromoted: false, isDemoted: true};
 
           webinar.updateStatusByRole(roleChange);
@@ -904,18 +1030,18 @@ describe('plugin-meetings', () => {
         });
 
         it('Not trigger updateMediaShares if is attendee with screen share', () => {
-
           webinar.webex.meetings = {
             getMeetingByType: sinon.stub().returns({
-              id: 'meeting-id', locusUrl: 'locusUrl',
+              id: 'meeting-id',
+              locusUrl: 'locusUrl',
               isJoined: sinon.stub().returns(false),
               updateLLMConnection: sinon.stub(),
               shareStatus: SHARE_STATUS.REMOTE_SHARE_ACTIVE,
               locusInfo: {
                 mediaShares: 'mediaShares',
-                updateMediaShares: updateMediaShares
-              }
-            })
+                updateMediaShares: updateMediaShares,
+              },
+            }),
           };
 
           const roleChange = {isPromoted: false, isDemoted: true};
@@ -925,28 +1051,34 @@ describe('plugin-meetings', () => {
           assert.notCalled(updateMediaShares);
         });
 
-      it('updates PS data channel based on join eligibility', () => {
-        const updatePSDataChannelStub = sinon.stub(webinar, 'updatePSDataChannel').resolves();
+        it('updates PS data channel based on join eligibility', () => {
+          const updatePSDataChannelStub = sinon.stub(webinar, 'updatePSDataChannel').resolves();
 
-        webinar.updateStatusByRole({isPromoted: false, isDemoted: false});
+          webinar.updateStatusByRole({isPromoted: false, isDemoted: false});
 
-        assert.calledOnceWithExactly(updatePSDataChannelStub);
+          assert.calledOnceWithExactly(updatePSDataChannelStub);
+        });
       });
-      });
 
-      describe("#setPracticeSessionState", () => {
+      describe('#setPracticeSessionState', () => {
         [true, false].forEach((enabled) => {
-          it(`sends a PATCH request to ${enabled ? "enable" : "disable"} the practice session`, async () => {
+          it(`sends a PATCH request to ${
+            enabled ? 'enable' : 'disable'
+          } the practice session`, async () => {
             const result = await webinar.setPracticeSessionState(enabled);
             assert.calledOnce(webex.request);
             assert.calledWith(webex.request, {
-              method: "PATCH",
+              method: 'PATCH',
               uri: `${webinar.locusUrl}/controls`,
               body: {
-                practiceSession: { enabled }
-              }
+                practiceSession: {enabled},
+              },
             });
-            assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+            assert.equal(
+              result,
+              'REQUEST_RETURN_VALUE',
+              'should return the resolved value from the request'
+            );
           });
         });
 
@@ -960,7 +1092,11 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#setPracticeSessionState failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#setPracticeSessionState failed',
+              sinon.match.instanceOf(Error)
+            );
           }
 
           errorLogger.restore();
@@ -1007,37 +1143,37 @@ describe('plugin-meetings', () => {
 
           assert.equal(webinar.practiceSessionEnabled, false);
         });
-      it('triggers PS data channel update using computed eligibility', () => {
-        webinar.selfIsPanelist = true;
-        const updatePSDataChannelStub = sinon.stub(webinar, 'updatePSDataChannel').resolves();
+        it('triggers PS data channel update using computed eligibility', () => {
+          webinar.selfIsPanelist = true;
+          const updatePSDataChannelStub = sinon.stub(webinar, 'updatePSDataChannel').resolves();
 
-        webinar.updatePracticeSessionStatus({enabled: true});
+          webinar.updatePracticeSessionStatus({enabled: true});
 
-        assert.calledOnceWithExactly(updatePSDataChannelStub);
+          assert.calledOnceWithExactly(updatePSDataChannelStub);
+        });
       });
-      });
 
-      describe("#startWebcast", () => {
+      describe('#startWebcast', () => {
         const meeting = {
           locusId: 'locusId',
           correlationId: 'correlationId',
-        }
+        };
         const layout = {
           videoLayout: 'Prominent',
           contentLayout: 'Prominent',
           syncStageLayout: false,
           syncStageInMeeting: false,
-        }
+        };
         it(`sends a PUT request to start the webcast`, async () => {
           const result = await webinar.startWebcast(meeting, layout);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "PUT",
+            method: 'PUT',
             uri: `${webinar.webcastInstanceUrl}/streaming`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
             },
             body: {
               action: 'start',
@@ -1046,9 +1182,13 @@ describe('plugin-meetings', () => {
                 correlationId: meeting.correlationId,
               },
               layout,
-            }
+            },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('should handle undefined meeting parameter', async () => {
@@ -1058,9 +1198,16 @@ describe('plugin-meetings', () => {
             await webinar.startWebcast(undefined, layout);
             assert.fail('startWebcast should throw an error');
           } catch (error) {
-            assert.equal(error.message, 'Meeting parameter does not meet expectations', 'should throw the correct error');
+            assert.equal(
+              error.message,
+              'Meeting parameter does not meet expectations',
+              'should throw the correct error'
+            );
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, `Meeting:webinar#startWebcast failed --> meeting parameter : ${undefined}`);
+            assert.calledWith(
+              errorLogger,
+              `Meeting:webinar#startWebcast failed --> meeting parameter : ${undefined}`
+            );
           } finally {
             errorLogger.restore();
           }
@@ -1076,30 +1223,38 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#startWebcast failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#startWebcast failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-      describe("#stopWebcast", () => {
+      describe('#stopWebcast', () => {
         it(`sends a PUT request to stop the webcast`, async () => {
           const result = await webinar.stopWebcast();
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "PUT",
+            method: 'PUT',
             uri: `${webinar.webcastInstanceUrl}/streaming`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
             },
             body: {
               action: 'stop',
-            }
+            },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1112,27 +1267,34 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#stopWebcast failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#stopWebcast failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-
-      describe("#queryWebcastLayout", () => {
+      describe('#queryWebcastLayout', () => {
         it(`sends a GET request to query the webcast layout`, async () => {
           const result = await webinar.queryWebcastLayout();
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "GET",
+            method: 'GET',
             uri: `${webinar.webcastInstanceUrl}/layout`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1145,36 +1307,44 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#queryWebcastLayout failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#queryWebcastLayout failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-      describe("#updateWebcastLayout", () => {
+      describe('#updateWebcastLayout', () => {
         const layout = {
           videoLayout: 'Prominent',
           contentLayout: 'Prominent',
           syncStageLayout: false,
           syncStageInMeeting: false,
-        }
+        };
         it(`sends a PUT request to update the webcast layout`, async () => {
           const result = await webinar.updateWebcastLayout(layout);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "PUT",
+            method: 'PUT',
             uri: `${webinar.webcastInstanceUrl}/layout`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
             },
             body: {
-              ...layout
-            }
+              ...layout,
+            },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1187,30 +1357,40 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#updateWebcastLayout failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#updateWebcastLayout failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-      describe("#searchWebcastAttendees", () => {
+      describe('#searchWebcastAttendees', () => {
         const queryString = 'queryString';
         const specialCharsQuery = 'query@string!';
         const emptyQuery = '';
 
-        it("sends a GET request to search the webcast attendees", async () => {
+        it('sends a GET request to search the webcast attendees', async () => {
           const result = await webinar.searchWebcastAttendees(queryString);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "GET",
-            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(queryString)}`,
+            method: 'GET',
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(
+              queryString
+            )}`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1223,55 +1403,74 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#searchWebcastAttendees failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#searchWebcastAttendees failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
 
-        it("should handle empty query string", async () => {
+        it('should handle empty query string', async () => {
           const result = await webinar.searchWebcastAttendees(emptyQuery);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "GET",
-            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(emptyQuery)}`,
+            method: 'GET',
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(
+              emptyQuery
+            )}`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
-        it("should handle query string with special characters", async () => {
+        it('should handle query string with special characters', async () => {
           const result = await webinar.searchWebcastAttendees(specialCharsQuery);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "GET",
-            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(specialCharsQuery)}`,
+            method: 'GET',
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(
+              specialCharsQuery
+            )}`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
       });
 
-
-      describe("#viewAllWebcastAttendees", () => {
+      describe('#viewAllWebcastAttendees', () => {
         it(`sends a GET request to view all the webcast attendees`, async () => {
           const result = await webinar.viewAllWebcastAttendees();
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "GET",
+            method: 'GET',
             uri: `${webinar.webcastInstanceUrl}/attendees`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1284,27 +1483,35 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#viewAllWebcastAttendees failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#viewAllWebcastAttendees failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-      describe("#expelWebcastAttendee", () => {
-        const participantId = 'participantId'
+      describe('#expelWebcastAttendee', () => {
+        const participantId = 'participantId';
         it(`sends a DELETE request to expel the webcast attendee`, async () => {
           const result = await webinar.expelWebcastAttendee(participantId);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
-            method: "DELETE",
+            method: 'DELETE',
             uri: `${webinar.webcastInstanceUrl}/attendees/${participantId}`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
             },
           });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+          assert.equal(
+            result,
+            'REQUEST_RETURN_VALUE',
+            'should return the resolved value from the request'
+          );
         });
 
         it('handles API call failures gracefully', async () => {
@@ -1317,14 +1524,18 @@ describe('plugin-meetings', () => {
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#expelWebcastAttendee failed', sinon.match.instanceOf(Error));
+            assert.calledWith(
+              errorLogger,
+              'Meeting:webinar#expelWebcastAttendee failed',
+              sinon.match.instanceOf(Error)
+            );
           } finally {
             errorLogger.restore();
           }
         });
       });
 
-      describe("#searchLargeScaleWebinarAttendees", () => {
+      describe('#searchLargeScaleWebinarAttendees', () => {
         const attendeeSearchUrl = 'https://locusUrl/attendees/search';
         const params = {
           queryString: 'queryString',
@@ -1335,40 +1546,46 @@ describe('plugin-meetings', () => {
           // @ts-ignore
           webinar.webex.meetings = {
             getMeetingByType: sinon.stub().returns({
-              id: 'meeting-id', locusUrl: 'locusUrl',
+              id: 'meeting-id',
+              locusUrl: 'locusUrl',
               locusInfo: {
-                links:{
+                links: {
                   resources: {
                     attendeeSearch: {
-                      url: attendeeSearchUrl
-                    }
-                  }
-                }
-              }
-            })
+                      url: attendeeSearchUrl,
+                    },
+                  },
+                },
+              },
+            }),
           };
         });
 
         it('throws an error if attendeeSearchUrl is not available', async () => {
           webinar.webex.meetings = {
             getMeetingByType: sinon.stub().returns({
-              id: 'meeting-id', locusUrl: 'locusUrl',
+              id: 'meeting-id',
+              locusUrl: 'locusUrl',
               locusInfo: {
-                links:{
+                links: {
                   resources: {
                     attendeeSearch: {
-                      url: null
-                    }
-                  }
-                }
-              }
-            })
+                      url: null,
+                    },
+                  },
+                },
+              },
+            }),
           };
           try {
             await webinar.searchLargeScaleWebinarAttendees(params);
             assert.fail('searchLargeScaleWebinarAttendees should throw an error');
           } catch (error) {
-            assert.equal(error.message,'Meeting:webinar5k#Attendee search url is not available', 'should throw the correct error');
+            assert.equal(
+              error.message,
+              'Meeting:webinar5k#Attendee search url is not available',
+              'should throw the correct error'
+            );
           }
         });
 
@@ -1377,7 +1594,9 @@ describe('plugin-meetings', () => {
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
             method: 'GET',
-            uri: `${attendeeSearchUrl}?search_text=${encodeURIComponent(params.queryString)}&limit=50`,
+            uri: `${attendeeSearchUrl}?search_text=${encodeURIComponent(
+              params.queryString
+            )}&limit=50`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
@@ -1429,5 +1648,5 @@ describe('plugin-meetings', () => {
           }
         });
       });
-    })
+    });
 })


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >
Before refactor:
Main Session:
Uses webex.internal.llm singleton with session ID 'llm-default-session'
URL from [locusInfo.info.datachannelUrl]
Events: ['event:relay.event'] ['locus.llm'], 'online'

Practice Session:
Uses  same  webex.internal.llm singleton with session ID 'llm-practice-session'
URL from [locusInfo.info.practiceSessionDatachannelUrl]
Events: ['event:relay.event:llm-practice-session'], ['locus.llm:llm-practice-session']
Waits for main session 'online' before connecting

Voicea:
Single [webex.internal.voicea] singleton shared by both sessions
[announce()] / [turnOnCaptions()]operates on whichever session is active
Caption state isCaptionBoxOn is global

Refactor:
Main Session:

[meeting.llmChannel]= dedicated [LLMChannel] instance owned by meeting
[meeting.voiceaChannel]= dedicated [VoiceaChannel] instance bound to [llmChannel]
Events emitted directly on the channel instance (no suffix)

Practice Session:
[webinar.practiceSessionLLMChannel] = dedicated [LLMChannel] instance owned by webinar
[webinar.practiceSessionVoiceaChannel]= dedicated [VoiceaChannel] instance bound to PS channel
Still waits for main session 'online' before connecting

In both architectures, when Practice Session is active:

- Main session channel stays connected
- Practice session channel connects after main session is online
- Both receive relay events, routed by binding in event header
- Services like annotation switch to PS channel during practice session

### Channel Ownership Summary

Regular Meeting:
meeting.llmChannel
meeting.voiceaChannel → listens to meeting.llmChannel

Webinar (main session only):
meeting.llmChannel
meeting.voiceaChannel → listens to meeting.llmChannel

Webinar (practice session active):
meeting.llmChannel - main session (stays connected)
webinar.practiceSessionLLMChannel - practice session (ADDITIONAL)
meeting.voiceaChannel → SWITCHES to practiceSessionLLMChannel
                        (preserves caption state, re-announces)

On practice session exit:
meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel) → switches back
webinar.practiceSessionLLMChannel → disconnected & cleaned up

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
