### PR TITLE
fix(meetings): adding media retry fix for 403 error cases

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -278,6 +278,7 @@ export class LocusMediaRequest extends WebexPlugin {
       .catch(async (e) => {
         if (
           e?.statusCode === 409 &&
+          e?.statusCode === 403 &&
           (await this.shouldRetryOnSelfUrlChange(request, selfUrlRetryCount))
         ) {
           // In-flight race: selfUrl rotated after we left the queue but

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -277,8 +277,7 @@ export class LocusMediaRequest extends WebexPlugin {
       })
       .catch(async (e) => {
         if (
-          e?.statusCode === 409 &&
-          e?.statusCode === 403 &&
+          (e?.statusCode === 409 || e?.statusCode === 403) &&
           (await this.shouldRetryOnSelfUrlChange(request, selfUrlRetryCount))
         ) {
           // In-flight race: selfUrl rotated after we left the queue but

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -292,13 +292,117 @@ describe('LocusMediaRequest.send()', () => {
     assert.calledTwice(webexRequestStub);
     assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
     assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrl/media');
-    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
-      correlation_id: 'correlationId',
-      reason: 'selfUrlUpdatedBeforeMediaRequest',
-    });
-    // The updated selfUrl is detected twice: once while deciding to retry and
-    // again when the request is re-resolved for the actual re-send.
     assert.calledTwice(sendBehavioralMetricStub);
+    assert.calledWithExactly(
+      sendBehavioralMetricStub.getCall(0),
+      BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY,
+      {
+        correlation_id: 'correlationId',
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
+      }
+    );
+    assert.calledWithExactly(
+      sendBehavioralMetricStub.getCall(1),
+      BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY,
+      {
+        correlation_id: 'correlationId',
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
+      }
+    );
+  });
+
+  it('retries a roap message with the latest resolved selfUrl after a forbidden error', async () => {
+    let currentSelfUrl = 'oldSelfUrl';
+    const forbiddenError = {statusCode: 403, message: 'forbidden'};
+
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request');
+    webexRequestStub.onFirstCall().callsFake(() => {
+      currentSelfUrl = 'newSelfUrl';
+
+      return Promise.reject(forbiddenError);
+    });
+    webexRequestStub.onSecondCall().resolves(fakeLocusResponse);
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'oldSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    const result = await locusMediaRequest.send(request);
+
+    assert.equal(result, fakeLocusResponse);
+    assert.calledTwice(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrl/media');
+    assert.calledTwice(sendBehavioralMetricStub);
+    assert.calledWithExactly(
+      sendBehavioralMetricStub.getCall(0),
+      BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY,
+      {
+        correlation_id: 'correlationId',
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
+      }
+    );
+    assert.calledWithExactly(
+      sendBehavioralMetricStub.getCall(1),
+      BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY,
+      {
+        correlation_id: 'correlationId',
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
+      }
+    );
+  });
+
+  it('does not retry when error is neither 409 nor 403', async () => {
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => 'sameSelfUrl',
+        waitForSelfUrlChange,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request').rejects({
+      statusCode: 500,
+      message: 'server error',
+    });
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'sameSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    await assert.isRejected(locusMediaRequest.send(request));
+
+    assert.calledOnce(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'sameSelfUrl/media');
+    assert.notCalled(sendBehavioralMetricStub);
   });
 
   it('does not retry a roap conflict when the resolved selfUrl has not changed', async () => {


### PR DESCRIPTION
# COMPLETES #AD-HOC fix for existing BEMS

## This pull request addresses
Adding handling for media request retry for 403 error case as well.

## by making the following changes
Updated the condition to handle 403 as well

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
