### PR TITLE
fix: some media JMFs mis-classified as join failures

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
@@ -206,10 +206,13 @@ WebExMeetingsErrors[AddMediaFailed.CODE] = AddMediaFailed;
 class MediaConnectionTimedOutError extends Error {
   iceConnected: boolean;
 
-  constructor(message: string, iceConnected: boolean) {
+  cause?: any;
+
+  constructor(message: string, iceConnected: boolean, cause?: any) {
     super(message);
     this.name = 'MediaConnectionTimedOutError';
     this.iceConnected = iceConnected;
+    this.cause = cause;
   }
 }
 export {MediaConnectionTimedOutError};

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8153,7 +8153,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
       throw new MediaConnectionTimedOutError(
         `Timed out waiting for media connection to be connected, correlationId=${this.correlationId}`,
-        iceConnected
+        iceConnected,
+        // keep reference to the original rejected result (which is the object the SDK reports to CA as rawError above)
+        error
       );
     }
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/common/errors/webex-errors.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/common/errors/webex-errors.ts
@@ -1,5 +1,8 @@
 import {assert} from '@webex/test-helper-chai';
-import {AddMediaFailed, MediaConnectionTimedOutError} from '@webex/plugin-meetings/src/common/errors/webex-errors';
+import {
+  AddMediaFailed,
+  MediaConnectionTimedOutError,
+} from '@webex/plugin-meetings/src/common/errors/webex-errors';
 
 describe('MediaConnectionTimedOutError', () => {
   [
@@ -14,6 +17,19 @@ describe('MediaConnectionTimedOutError', () => {
       assert.equal(error.name, 'MediaConnectionTimedOutError');
       assert.instanceOf(error, Error);
     });
+  });
+
+  it('stores the cause when provided', () => {
+    const cause = {iceConnected: true};
+    const error = new MediaConnectionTimedOutError('timeout', true, cause);
+
+    assert.equal(error.cause, cause);
+  });
+
+  it('leaves cause undefined when not provided', () => {
+    const error = new MediaConnectionTimedOutError('timeout', true);
+
+    assert.isUndefined(error.cause);
   });
 });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4319,7 +4319,10 @@ describe('plugin-meetings', () => {
             sinon.stub(CallDiagnosticUtils, 'generateClientErrorCodeForIceFailure').returns(2004);
 
             meeting.meetingState = 'ACTIVE';
-            meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().rejects({iceConnected});
+            const rejectedResult = {iceConnected};
+            meeting.mediaProperties.waitForMediaConnectionConnected = sinon
+              .stub()
+              .rejects(rejectedResult);
 
             meeting.roap.doTurnDiscovery = sinon.stub().returns({
               turnServerInfo: {urls: ['turns:fake:443'], username: 'u', password: 'p'},
@@ -4342,6 +4345,11 @@ describe('plugin-meetings', () => {
 
             assert.instanceOf(thrownError, AddMediaFailed);
             assert.equal(thrownError.iceConnected, iceConnected);
+            // the AddMediaFailed cause should be the MediaConnectionTimedOutError, which in turn should
+            // preserve the original rejected result as its cause, so that the web client
+            // can find the CA-reported error in the eventErrorCache via the cause chain
+            assert.instanceOf(thrownError.cause, MediaConnectionTimedOutError);
+            assert.equal(thrownError.cause.cause, rejectedResult);
           });
         });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-834193](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-834193)

## This pull request addresses
As a result of changes in this PR:

https://github.com/webex/webex-js-sdk/pull/5080

the error thrown by joinWithMedia() doesn't have a reference to the error sent with "client.ice.end", so web app's errorIsHandledBySdk() returns false when it should return true and as a result web app sends its own error with "client.call.initiated" - that makes it being classified as join failure instead of media failure by CA

## by making the following changes
Made sure that error thrown has a reference to the error sent with "client.ice.end"

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

I've verified it by running sdk with the web app and faking dtls failure and checking that the error caught by the web app has a reference to the object that has "iceConnected: true":
<img width="675" height="468" alt="image" src="https://github.com/user-attachments/assets/661dcd9c-a92c-4ad3-b02e-3a2e0620d890" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
