### PR TITLE
fix(meetings): always emit inbound audio issue metric and bump media-core

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.26.2",
+    "@webex/internal-media-core": "2.28.0",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.33.5"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@webex/common": "workspace:*",
     "@webex/event-dictionary-ts": "^1.0.2215",
-    "@webex/internal-media-core": "2.26.2",
+    "@webex/internal-media-core": "2.28.0",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8482,6 +8482,7 @@ export default class Meeting extends StatelessWebexPlugin {
             data.issueSubType,
             this.correlationId
           );
+
           Trigger.trigger(
             this,
             {file: 'meeting/index', function: 'createStatsAnalyzer'},

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8476,13 +8476,12 @@ export default class Meeting extends StatelessWebexPlugin {
           return !member.isSelf && !member.isPairedWithSelf && !member.isAudioMuted;
         });
 
-        this.mediaProperties.sendMediaIssueMetric(
-          'inbound_audio',
-          data.issueSubType,
-          this.correlationId
-        );
-
         if (atLeastOneUnmutedOtherMember) {
+          this.mediaProperties.sendMediaIssueMetric(
+            'inbound_audio',
+            data.issueSubType,
+            this.correlationId
+          );
           Trigger.trigger(
             this,
             {file: 'meeting/index', function: 'createStatsAnalyzer'},

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8476,13 +8476,13 @@ export default class Meeting extends StatelessWebexPlugin {
           return !member.isSelf && !member.isPairedWithSelf && !member.isAudioMuted;
         });
 
-        if (atLeastOneUnmutedOtherMember) {
-          this.mediaProperties.sendMediaIssueMetric(
-            'inbound_audio',
-            data.issueSubType,
-            this.correlationId
-          );
+        this.mediaProperties.sendMediaIssueMetric(
+          'inbound_audio',
+          data.issueSubType,
+          this.correlationId
+        );
 
+        if (atLeastOneUnmutedOtherMember) {
           Trigger.trigger(
             this,
             {file: 'meeting/index', function: 'createStatsAnalyzer'},

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -94,7 +94,6 @@ import {
   MeetingNotActiveError,
   UserInLobbyError,
   AddMediaFailed,
-  MediaConnectionTimedOutError,
 } from '../../../../src/common/errors/webex-errors';
 import WebExMeetingsErrors from '../../../../src/common/errors/webex-meetings-error';
 import ParameterError from '../../../../src/common/errors/parameter';
@@ -265,7 +264,6 @@ describe('plugin-meetings', () => {
     webex.meetings.uploadLogs = sinon.stub().returns(Promise.resolve());
     webex.meetings.reachability = {
       isAnyPublicClusterReachable: sinon.stub().resolves(true),
-      isAnyClusterReachableViaProtocol: sinon.stub().resolves(false),
       getReachabilityResults: sinon.stub().resolves(undefined),
       getReachabilityMetrics: sinon.stub().resolves({}),
       stopReachability: sinon.stub(),
@@ -515,7 +513,6 @@ describe('plugin-meetings', () => {
           localWebex.meetings.uploadLogs = sinon.stub().returns(Promise.resolve());
           localWebex.meetings.reachability = {
             isAnyPublicClusterReachable: sinon.stub().resolves(true),
-            isAnyClusterReachableViaProtocol: sinon.stub().resolves(false),
             getReachabilityResults: sinon.stub().resolves(undefined),
             getReachabilityMetrics: sinon.stub().resolves({}),
             stopReachability: sinon.stub(),
@@ -886,67 +883,6 @@ describe('plugin-meetings', () => {
           assert.deepEqual(args, [[uuid1], locusUrls]);
         });
       });
-      describe('#transfer', () => {
-        it('should have #transfer', () => {
-          assert.exists(meeting.transfer);
-        });
-
-        it('should transfer host using the current locus when the target member is in the current session', async () => {
-          sinon.stub(meeting.members.membersCollection, 'get').withArgs(uuid2).returns({isInMeeting: true});
-          meeting.members.transferHostToMember = sinon.stub().resolves(test1);
-
-          await meeting.transfer(uuid2, false);
-
-          assert.calledOnceWithExactly(meeting.members.transferHostToMember, uuid2, false);
-        });
-
-        it('should transfer host using breakout locus when the target member is joined in a breakout session', async () => {
-          sinon.stub(meeting.members.membersCollection, 'get').withArgs(uuid2).returns({isInMeeting: false});
-          meeting.members.transferHostToMember = sinon.stub().resolves(test1);
-          meeting.breakouts.breakouts = {
-            models: [
-              {
-                members: {
-                  membersCollection: {
-                    get: sinon.stub().withArgs(uuid2).returns({isInMeeting: true}),
-                  },
-                },
-                breakoutRosterLocus: {url: 'https://example.com/breakout-locus'},
-              },
-            ],
-          };
-
-          await meeting.transfer(uuid2, false);
-
-          assert.calledOnceWithExactly(
-            meeting.members.transferHostToMember,
-            uuid2,
-            false,
-            'https://example.com/breakout-locus'
-          );
-        });
-
-        it('should not use breakout locus when the breakout member is not in meeting', async () => {
-          sinon.stub(meeting.members.membersCollection, 'get').withArgs(uuid2).returns({isInMeeting: false});
-          meeting.members.transferHostToMember = sinon.stub().resolves(test1);
-          meeting.breakouts.breakouts = {
-            models: [
-              {
-                members: {
-                  membersCollection: {
-                    get: sinon.stub().withArgs(uuid2).returns({isInMeeting: false}),
-                  },
-                },
-                breakoutRosterLocus: {url: 'https://example.com/breakout-locus'},
-              },
-            ],
-          };
-
-          await meeting.transfer(uuid2, false);
-
-          assert.calledOnceWithExactly(meeting.members.transferHostToMember, uuid2, false, undefined);
-        });
-      });
       describe('#getMembers', () => {
         it('should have #getMembers', () => {
           assert.exists(meeting.getMembers);
@@ -976,8 +912,6 @@ describe('plugin-meetings', () => {
         let addMediaInternalStub;
         let supportsRTCPeerConnectionStub;
 
-        let suspendDestroyMeetingStub;
-
         beforeEach(() => {
           supportsRTCPeerConnectionStub = sinon
             .stub(WebCapabilities, 'supportsRTCPeerConnection')
@@ -998,7 +932,6 @@ describe('plugin-meetings', () => {
             .stub(meeting.roap, 'handleTurnDiscoveryHttpResponse')
             .resolves({turnServerInfo: fakeTurnServerInfo, turnDiscoverySkippedReason: undefined});
           abortTurnDiscoveryStub = sinon.stub(meeting.roap, 'abortTurnDiscovery');
-          suspendDestroyMeetingStub = sinon.stub(meeting.locusInfo, 'suspendDestroyMeeting');
         });
 
         it('should work as expected', async () => {
@@ -1021,9 +954,8 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(
             meeting.addMediaInternal,
             sinon.match.any,
-            false,
             fakeTurnServerInfo,
-            undefined,
+            false,
             mediaOptions
           );
 
@@ -1031,14 +963,9 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            retryCount: 0,
+            isRetry: false,
             prevJoinResponse: undefined,
           });
-
-          // suspendDestroyMeeting should be called with true at start and false on success
-          assert.calledTwice(suspendDestroyMeetingStub);
-          assert.calledWith(suspendDestroyMeetingStub.firstCall, true);
-          assert.calledWith(suspendDestroyMeetingStub.secondCall, false);
         });
 
         it("should not call handleTurnDiscoveryHttpResponse if we don't send a TURN discovery request with join", async () => {
@@ -1060,9 +987,8 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(
             meeting.addMediaInternal,
             sinon.match.any,
+            undefined,
             false,
-            undefined,
-            undefined,
             mediaOptions
           );
 
@@ -1096,9 +1022,8 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(
             meeting.addMediaInternal,
             sinon.match.any,
+            undefined,
             false,
-            undefined,
-            undefined,
             mediaOptions
           );
 
@@ -1110,12 +1035,7 @@ describe('plugin-meetings', () => {
           meeting.join = sinon.stub().returns(Promise.reject(error));
           meeting.locusUrl = null; // when join fails, we end up with null locusUrl
 
-          const thrownError = await assert.isRejected(
-            meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}})
-          );
-
-          // should throw the first attempt's error
-          assert.equal(thrownError, error);
+          await assert.isRejected(meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}}));
 
           assert.calledTwice(abortTurnDiscoveryStub);
 
@@ -1153,84 +1073,9 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            retryCount: 0,
+            isRetry: false,
             prevJoinResponse: undefined,
-            firstError: undefined,
-            prevError: undefined,
           });
-
-          // suspendDestroyMeeting(true) called at start of each attempt, (false) only on final failure
-          // 1st attempt: suspendDestroyMeeting(true), 2nd attempt (retry): suspendDestroyMeeting(true), final failure: suspendDestroyMeeting(false)
-          assert.calledThrice(suspendDestroyMeetingStub);
-          assert.calledWith(suspendDestroyMeetingStub.firstCall, true);
-          assert.calledWith(suspendDestroyMeetingStub.secondCall, true);
-          assert.calledWith(suspendDestroyMeetingStub.thirdCall, false);
-        });
-
-        it('should re-join on retry when join() fails on first attempt, and throw the first error if join fails again', async () => {
-          const firstJoinError = new Error('first join error');
-          const secondJoinError = new Error('second join error');
-
-          meeting.join = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(firstJoinError)
-            .onSecondCall()
-            .rejects(secondJoinError);
-          meeting.locusUrl = null; // join never succeeds
-
-          const thrownError = await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions})
-          );
-
-          // join() should be called twice — once for the first attempt, once for the re-join
-          assert.calledTwice(meeting.join);
-          // TURN discovery should be attempted twice (once per join)
-          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
-
-          // should throw the first attempt's error, not the second
-          assert.equal(thrownError, firstJoinError);
-
-          assert.calledTwice(Metrics.sendBehavioralMetric);
-          assert.calledWith(
-            Metrics.sendBehavioralMetric.firstCall,
-            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
-            sinon.match({reason: firstJoinError.message, isRetry: false}),
-            sinon.match.any
-          );
-          assert.calledWith(
-            Metrics.sendBehavioralMetric.secondCall,
-            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
-            sinon.match({reason: secondJoinError.message, isRetry: true}),
-            sinon.match.any
-          );
-
-          assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            retryCount: 0,
-            prevJoinResponse: undefined,
-            firstError: undefined,
-            prevError: undefined,
-          });
-        });
-
-        it('should NOT call join() again on retry when join() succeeded but addMediaInternal() failed', async () => {
-          const addMediaError = new Error('addMedia error');
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(addMediaError)
-            .onSecondCall()
-            .resolves(test4);
-
-          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-          // join() should only be called once — the successful join result is reused on retry
-          assert.calledOnce(meeting.join);
-          // TURN discovery request is only generated once (on the first attempt alongside join)
-          assert.calledOnce(generateTurnDiscoveryRequestMessageStub);
         });
 
         it('should resolve if join() fails the first time but succeeds the second time', async () => {
@@ -1274,7 +1119,7 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            retryCount: 0,
+            isRetry: false,
             prevJoinResponse: undefined,
           });
         });
@@ -1341,127 +1186,6 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
-        });
-
-        it('should throw the first attempt error when retry also fails with a different error', async () => {
-          const firstError = new Error('first attempt error');
-          const secondError = new Error('second attempt error');
-
-          const addMediaInternalResults = [];
-          meeting.addMediaInternal = sinon.stub().callsFake(() => {
-            const defer = new Defer();
-            addMediaInternalResults.push(defer);
-            return defer.promise;
-          });
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          await testUtils.flushPromises();
-
-          // 1st attempt fails
-          addMediaInternalResults[0].reject(firstError);
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 1st attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 2nd (final) attempt fails
-          addMediaInternalResults[1].reject(secondError);
-          const thrownError = await assert.isRejected(result);
-
-          // should throw the first error, not the second
-          assert.equal(thrownError, firstError);
-
-          // leave() should only be called after the last (2nd) attempt
-          assert.calledOnce(leaveStub);
-
-          assert.calledTwice(Metrics.sendBehavioralMetric);
-        });
-
-        it('should throw the UserNotJoinedError as firstError when it occurs on the 1st attempt and 2nd attempt fails differently', async () => {
-          const userNotJoinedError = new UserNotJoinedError();
-          const secondError = new Error('second attempt error');
-
-          const addMediaInternalResults = [];
-          meeting.addMediaInternal = sinon.stub().callsFake(() => {
-            const defer = new Defer();
-            addMediaInternalResults.push(defer);
-            return defer.promise;
-          });
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          await testUtils.flushPromises();
-
-          // 1st attempt fails with UserNotJoinedError — triggers a re-join
-          addMediaInternalResults[0].reject(userNotJoinedError);
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 1st attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 2nd (final) attempt fails
-          addMediaInternalResults[1].reject(secondError);
-          const thrownError = await assert.isRejected(result);
-
-          // should throw the first (UserNotJoinedError), not the second
-          assert.equal(thrownError, userNotJoinedError);
-
-          // join() called twice: original + re-join triggered by UserNotJoinedError in prevError
-          assert.calledTwice(meeting.join);
-          // leave() should only be called after the last (2nd) attempt
-          assert.calledOnce(leaveStub);
-          assert.calledTwice(Metrics.sendBehavioralMetric);
-        });
-
-        it('should throw the first UserNotJoinedError when it occurs on both 1st and 2nd attempts and a 3rd attempt also fails', async () => {
-          const firstUserNotJoinedError = new UserNotJoinedError('first');
-          const secondUserNotJoinedError = new UserNotJoinedError('second');
-          const thirdError = new Error('third attempt error');
-
-          const addMediaInternalResults = [];
-          meeting.addMediaInternal = sinon.stub().callsFake(() => {
-            const defer = new Defer();
-            addMediaInternalResults.push(defer);
-            return defer.promise;
-          });
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          await testUtils.flushPromises();
-
-          // 1st attempt fails with UserNotJoinedError — triggers a re-join
-          addMediaInternalResults[0].reject(firstUserNotJoinedError);
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 1st attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 2nd attempt fails with UserNotJoinedError again — triggers another re-join
-          addMediaInternalResults[1].reject(secondUserNotJoinedError);
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 2nd attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 3rd (final) attempt fails
-          addMediaInternalResults[2].reject(thirdError);
-          const thrownError = await assert.isRejected(result);
-
-          // should throw the very first error across all 3 attempts
-          assert.equal(thrownError, firstUserNotJoinedError);
-
-          // join() called 3 times: original + 2 re-joins triggered by prevError being UserNotJoinedError
-          assert.calledThrice(meeting.join);
-          // leave() should only be called after the last (3rd) attempt
-          assert.calledOnce(leaveStub);
-          assert.calledThrice(Metrics.sendBehavioralMetric);
         });
 
         it('should call leave() if addMediaInternal() fails with a browser media error (TypeError)', async () => {
@@ -1659,9 +1383,8 @@ describe('plugin-meetings', () => {
           assert.calledWith(
             meeting.addMediaInternal.firstCall,
             sinon.match.any,
-            false,
             fakeTurnServerInfo,
-            undefined,
+            false,
             mediaOptions
           );
 
@@ -1669,9 +1392,8 @@ describe('plugin-meetings', () => {
           assert.calledWith(
             meeting.addMediaInternal.secondCall,
             sinon.match.any,
+            undefined,
             true,
-            undefined,
-            undefined,
             mediaOptions
           );
 
@@ -1689,7 +1411,7 @@ describe('plugin-meetings', () => {
 
           meeting.addMediaInternal = sinon
             .stub()
-            .callsFake((icePhaseCallback, _forceTurnDiscovery, _turnServerInfo) => {
+            .callsFake((icePhaseCallback, _turnServerInfo, _forceTurnDiscovery) => {
               const defer = new Defer();
 
               icePhaseCallbacks.push(icePhaseCallback);
@@ -1713,8 +1435,7 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          // check the callback works correctly on the 2nd attempt:
-          // retryCount=1 with a non-UserNotJoinedError is terminal, so icePhase must be JOIN_MEETING_FINAL
+          // check the callback works correctly on the 2nd attempt
           assert.equal(icePhaseCallbacks.length, 2);
           assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_FINAL');
 
@@ -1722,118 +1443,6 @@ describe('plugin-meetings', () => {
           addMediaInternalResults[1].reject(addMediaError);
 
           await assert.isRejected(result);
-        });
-
-        it('should allow an additional retry when UserNotJoinedError occurs and return JOIN_MEETING_FINAL on the 3rd attempt', async () => {
-          const genericError = new Error('generic error');
-          const userNotJoinedError = new UserNotJoinedError();
-          const thirdError = new Error('third error');
-
-          const icePhaseCallbacks = [];
-          const addMediaInternalResults = [];
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .callsFake((icePhaseCallback) => {
-              const defer = new Defer();
-
-              icePhaseCallbacks.push(icePhaseCallback);
-              addMediaInternalResults.push(defer);
-              return defer.promise;
-            });
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          const result = meeting.joinWithMedia({
-            joinOptions,
-            mediaOptions,
-          });
-
-          await testUtils.flushPromises();
-
-          // 1st attempt: retryCount=0 → JOIN_MEETING_RETRY
-          assert.equal(icePhaseCallbacks.length, 1);
-          assert.equal(icePhaseCallbacks[0](), 'JOIN_MEETING_RETRY');
-          addMediaInternalResults[0].reject(genericError);
-
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 1st attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 2nd attempt: retryCount=1 → JOIN_MEETING_FINAL
-          // (In real usage this callback is never invoked when UserNotJoinedError is thrown,
-          // because UserNotJoinedError is thrown before waitForMediaConnectionConnected() is reached.)
-          assert.equal(icePhaseCallbacks.length, 2);
-          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_FINAL');
-          addMediaInternalResults[1].reject(userNotJoinedError);
-
-          await testUtils.flushPromises();
-
-          // leave() should NOT be called after the 2nd attempt (intermediate retry)
-          assert.notCalled(leaveStub);
-
-          // 3rd attempt: retryCount=2 → JOIN_MEETING_FINAL
-          assert.equal(icePhaseCallbacks.length, 3);
-          assert.equal(icePhaseCallbacks[2](), 'JOIN_MEETING_FINAL');
-          addMediaInternalResults[2].reject(thirdError);
-
-          const thrownError = await assert.isRejected(result);
-
-          // should throw the first error
-          assert.equal(thrownError, genericError);
-
-          // leave() should only be called once, after the last (3rd) attempt
-          assert.calledOnce(leaveStub);
-        });
-
-        it('should re-join when retrying after a UserNotJoinedError', async () => {
-          const userNotJoinedError = new UserNotJoinedError();
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(userNotJoinedError)
-            .onSecondCall()
-            .resolves(test4);
-
-          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-          // join() should be called twice — once for the first attempt, once for the re-join after UserNotJoinedError
-          assert.calledTwice(meeting.join);
-          // TURN discovery should be attempted twice (once per join)
-          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
-          // leave() should never be called when retrying after UserNotJoinedError
-          assert.notCalled(leaveStub);
-        });
-
-        it('should re-join when isUserInLeftState returns true on retry', async () => {
-          const addMediaError = new Error('addMedia error');
-
-          sinon.stub(MeetingUtil, 'isUserInLeftState').returns(true);
-
-          const leaveStub = sinon.stub(meeting, 'leave').resolves();
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(addMediaError)
-            .onSecondCall()
-            .resolves(test4);
-
-          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-          // join() should be called twice — once for the first attempt, once because the user is in left state
-          assert.calledTwice(meeting.join);
-          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
-          // leave() should never be called when retrying after isUserInLeftState returns true
-          assert.notCalled(leaveStub);
         });
 
         [
@@ -1903,7 +1512,6 @@ describe('plugin-meetings', () => {
             sinon.match.any,
             sinon.match.any,
             sinon.match.any,
-            sinon.match.any,
             sinon.match.has('videoEnabled', false).and(sinon.match.has('allowMediaInLobby', true))
           );
         });
@@ -1921,7 +1529,6 @@ describe('plugin-meetings', () => {
 
           assert.calledWithMatch(
             meeting.addMediaInternal,
-            sinon.match.any,
             sinon.match.any,
             sinon.match.any,
             sinon.match.any,
@@ -1946,7 +1553,6 @@ describe('plugin-meetings', () => {
             sinon.match.any,
             sinon.match.any,
             sinon.match.any,
-            sinon.match.any,
             sinon.match({
               sendVideo: true,
               receiveVideo: false,
@@ -1954,97 +1560,6 @@ describe('plugin-meetings', () => {
               receiveAudio: true,
             })
           );
-        });
-
-        describe('shouldRetryMediaWithOnlyTurnTLS', () => {
-          it('should pass iceTransportPolicy=relay for multistream when previous error is DTLS failure over UDP and TLS is reachable', async () => {
-            meeting.isMultistream = true;
-            const dtlsError = new AddMediaFailed({iceConnected: true, connectionType: 'UDP'});
-
-            webex.meetings.reachability.isAnyClusterReachableViaProtocol = sinon.stub().resolves(true);
-
-            addMediaInternalStub.onFirstCall().rejects(dtlsError);
-            addMediaInternalStub.onSecondCall().resolves(test4);
-
-            await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-            assert.calledWith(
-              meeting.addMediaInternal.secondCall,
-              sinon.match.any,
-              sinon.match.any,
-              sinon.match.any,
-              'relay',
-              mediaOptions
-            );
-          });
-
-          [
-            {
-              title: 'TLS is not reachable',
-              prevError: new AddMediaFailed({iceConnected: true, connectionType: 'UDP'}),
-              tlsReachable: false,
-              isMultistream: true,
-            },
-            {
-              title: 'error is not AddMediaFailed',
-              prevError: new Error('generic error'),
-              tlsReachable: true,
-              isMultistream: true,
-            },
-            {
-              title: 'error is AddMediaFailed but not DTLS failure',
-              prevError: new AddMediaFailed({iceConnected: false, connectionType: 'UDP'}),
-              tlsReachable: true,
-              isMultistream: true,
-            },
-            {
-              title: 'error is DTLS failure but connectionType is not UDP',
-              prevError: new AddMediaFailed({iceConnected: true, connectionType: 'TURN-TLS'}),
-              tlsReachable: true,
-              isMultistream: true,
-            },
-            {
-              title: 'isMultistream is false',
-              prevError: new AddMediaFailed({iceConnected: true, connectionType: 'UDP'}),
-              tlsReachable: true,
-              isMultistream: false,
-            },
-          ].forEach(({title, prevError, tlsReachable, isMultistream}) => {
-            it(`should pass iceTransportPolicy=undefined when ${title}`, async () => {
-              meeting.join = sinon.stub().callsFake(() => {
-                meeting.isMultistream = isMultistream;
-                return Promise.resolve(fakeJoinResult);
-              });
-              webex.meetings.reachability.isAnyClusterReachableViaProtocol = sinon.stub().resolves(tlsReachable);
-
-              addMediaInternalStub.onFirstCall().rejects(prevError);
-              addMediaInternalStub.onSecondCall().resolves(test4);
-
-              await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-              assert.calledWith(
-                meeting.addMediaInternal.secondCall,
-                sinon.match.any,
-                sinon.match.any,
-                sinon.match.any,
-                undefined,
-                mediaOptions
-              );
-            });
-          });
-
-          it('should pass iceTransportPolicy=undefined on first attempt (no prevError)', async () => {
-            await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-            assert.calledWith(
-              meeting.addMediaInternal.firstCall,
-              sinon.match.any,
-              sinon.match.any,
-              sinon.match.any,
-              undefined,
-              mediaOptions
-            );
-          });
         });
 
         it('should throw immediately if RTCPeerConnection is not available', async () => {
@@ -2058,86 +1573,8 @@ describe('plugin-meetings', () => {
             Errors.WebrtcApiNotAvailableError
           );
 
-          assert.notCalled(suspendDestroyMeetingStub);
           assert.notCalled(meeting.join);
           assert.notCalled(meeting.addMediaInternal);
-        });
-
-        [
-          {description: '409 error from join()', statusCode: 409, useCause: false},
-          {description: '403 error from join()', statusCode: 403, useCause: false},
-          {description: '409 error in cause (e.g. AddMediaFailed)', statusCode: 409, useCause: true},
-          {description: '403 error in cause (e.g. AddMediaFailed)', statusCode: 403, useCause: true},
-        ].forEach(({description, statusCode, useCause}) => {
-          it(`should re-join on retry when ${description}`, async () => {
-            const error = useCause
-              ? Object.assign(new Error('wrapped error'), {cause: {statusCode}})
-              : Object.assign(new Error('locus error'), {statusCode});
-
-            meeting.addMediaInternal = sinon
-              .stub()
-              .onFirstCall()
-              .rejects(error)
-              .onSecondCall()
-              .resolves(test4);
-
-            const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
-
-            assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-            // join() should be called twice — once for the first attempt, once for the re-join
-            assert.calledTwice(meeting.join);
-            assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
-          });
-        });
-
-        it('should allow up to JOIN_WITH_MEDIA_RETRY_MAX_COUNT retries for 409 errors', async () => {
-          const error409 = Object.assign(new Error('locus dropped us'), {statusCode: 409});
-
-          meeting.addMediaInternal = sinon.stub().rejects(error409);
-          meeting.join = sinon.stub().callsFake(() => Promise.resolve(fakeJoinResult));
-          sinon.stub(meeting, 'leave').resolves();
-
-          await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions})
-          );
-
-          // JOIN_WITH_MEDIA_RETRY_MAX_COUNT is 2, so we expect 3 attempts total (initial + 2 retries)
-          assert.callCount(meeting.join, 3);
-          assert.callCount(meeting.addMediaInternal, 3);
-        });
-
-        it('should not retry on 1-1 calls', async () => {
-          const addMediaError = new Error('addMedia error');
-
-          sinon.stub(MeetingsUtil, 'isOneOnOneCall').returns(true);
-
-          meeting.addMediaInternal = sinon.stub().rejects(addMediaError);
-          sinon.stub(meeting, 'leave').resolves();
-
-          await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions}),
-            addMediaError
-          );
-
-          // should not retry - only 1 attempt
-          assert.calledOnce(meeting.join);
-          assert.calledOnce(meeting.addMediaInternal);
-          assert.calledOnceWithExactly(
-            Metrics.sendBehavioralMetric,
-            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
-            {
-              correlation_id: meeting.correlationId,
-              locus_id: meeting.locusUrl.split('/').pop(),
-              reason: addMediaError.message,
-              stack: addMediaError.stack,
-              leaveErrorReason: undefined,
-              isRetry: false,
-            },
-            {
-              type: addMediaError.name,
-            }
-          );
         });
       });
       describe('#isTranscriptionSupported', () => {
@@ -2945,8 +2382,6 @@ describe('plugin-meetings', () => {
                     regionCode: 'EU',
                   },
                   preferTranscoding: !enableMultistream,
-                  getCurrentSelfUrl: sinon.match.func,
-                  waitForSelfUrlChange: sinon.match.func,
                 },
                 {
                   parent: meeting.webex,
@@ -3189,221 +2624,6 @@ describe('plugin-meetings', () => {
                   hasEverConnected: true,
                 }
               );
-            });
-
-            it('emits breakout join response metric only once per breakoutMoveId', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-              meeting.breakouts.set('sessionType', 'BREAKOUT');
-              meeting.breakouts.set('status', 'OPEN');
-              meeting.breakouts.set('currentBreakoutSession', {
-                sessionId: 'session-id-1',
-                groupId: 'group-id-1',
-              });
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              await meeting.updateLLMConnection();
-              await meeting.updateLLMConnection();
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 1);
-              assert.equal(joinResponseCalls[0].args[0].options.meetingId, meeting.id);
-            });
-
-            it('does not emit breakout join response metric when breakout session is missing', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              await meeting.updateLLMConnection();
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 0);
-            });
-
-            it('does not emit failed breakout join response metric when breakout session is missing', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon
-                .stub(meeting.webex.internal.llm, 'registerAndConnect')
-                .rejects(new Error('failed to connect LLM'));
-
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              try {
-                await meeting.updateLLMConnection();
-                assert.fail('Expected updateLLMConnection to reject');
-              } catch (error) {
-                assert.equal(error.message, 'failed to connect LLM');
-              }
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 0);
-            });
-
-            it('emits llm breakout join response metric after suppressing join response without llmLatency', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-
-              meeting.config.enableAutomaticLLM = true;
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-              meeting.breakouts.set('sessionType', 'BREAKOUT');
-              meeting.breakouts.set('status', 'OPEN');
-              meeting.breakouts.set('currentBreakoutSession', {
-                sessionId: 'session-id-1',
-                groupId: 'group-id-1',
-              });
-
-              assert.isFalse(meeting.shouldEmitBreakoutJoinResponseMetric('move-id-1'));
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              await meeting.updateLLMConnection();
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 1);
-              assert.deepEqual(joinResponseCalls[0].args[0].payload.llmLatency, {
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-            });
-
-            it('emits breakout join response metric with llmLatency when returning to main session', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-              meeting.breakouts.set('sessionType', 'MAIN');
-              meeting.breakouts.set('status', 'OPEN');
-              meeting.breakouts.set('currentBreakoutSession', {
-                sessionId: 'session-id-1',
-                groupId: 'group-id-1',
-              });
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              await meeting.updateLLMConnection();
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 1);
-              assert.deepEqual(joinResponseCalls[0].args[0].payload.llmLatency, {
-                clientLLMDatachannelResponseTime: 10,
-                clientLLMWebSocketConnectTime: 20,
-              });
-            });
-
-            it('uses the partial datachannel timing from the error when the websocket connect fails', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              const connectError = new Error('failed to connect LLM');
-              connectError.timing = {clientLLMDatachannelResponseTime: 42};
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').rejects(connectError);
-
-              meeting.meetingInfo.enableConvergedArchitecture = true;
-              meeting.breakouts.set('breakoutMoveId', 'move-id-1');
-              meeting.breakouts.set('sessionType', 'BREAKOUT');
-              meeting.breakouts.set('status', 'OPEN');
-              meeting.breakouts.set('currentBreakoutSession', {
-                sessionId: 'session-id-1',
-                groupId: 'group-id-1',
-              });
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              try {
-                await meeting.updateLLMConnection();
-                assert.fail('Expected updateLLMConnection to reject');
-              } catch (error) {
-                assert.equal(error, connectError);
-              }
-
-              const joinResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.breakout-session.join.response');
-
-              assert.lengthOf(joinResponseCalls, 1);
-              assert.deepEqual(joinResponseCalls[0].args[0].payload.llmLatency, {
-                clientLLMDatachannelResponseTime: 42,
-                clientLLMWebSocketConnectTime: 0,
-              });
-            });
-
-            it('reports the partial datachannel timing on client.llm.connect.response when the websocket connect fails during initial join', async () => {
-              sinon.stub(meeting, 'isJoined').returns(true);
-              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(false);
-              const connectError = new Error('failed to connect LLM');
-              connectError.timing = {clientLLMDatachannelResponseTime: 42};
-              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').rejects(connectError);
-
-              webex.internal.newMetrics.submitClientEvent.resetHistory();
-              meeting.updateLLMConnection.restore();
-
-              try {
-                await meeting.updateLLMConnection({isInitialJoinPhase: true});
-                assert.fail('Expected updateLLMConnection to reject');
-              } catch (error) {
-                assert.equal(error, connectError);
-              }
-
-              const connectResponseCalls = webex.internal.newMetrics.submitClientEvent
-                .getCalls()
-                .filter((call) => call.args[0]?.name === 'client.llm.connect.response');
-
-              assert.lengthOf(connectResponseCalls, 1);
-              assert.deepEqual(connectResponseCalls[0].args[0].payload.llmLatency, {
-                clientLLMDatachannelResponseTime: 42,
-                clientLLMWebSocketConnectTime: 0,
-              });
             });
 
             it('clears the LLM health check timer when disconnecting LLM', async () => {
@@ -3680,11 +2900,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: false,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
               selectedCandidatePairChanges: 2,
@@ -3810,11 +3028,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: false,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
               selectedCandidatePairChanges: 2,
@@ -4582,11 +3798,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: true,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               selectedCandidatePairChanges: 2,
               numTransports: 1,
               iceCandidatesCount: 0,
@@ -4609,169 +3823,6 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.mediaProperties.webrtcMediaConnection);
 
           assert.isOk(errorThrown);
-        });
-
-        [
-          {iceConnected: true, title: 'iceConnected=true'},
-          {iceConnected: false, title: 'iceConnected=false'},
-        ].forEach(({iceConnected, title}) => {
-          it(`should propagate ${title} from waitForMediaConnectionConnected rejection to AddMediaFailed`, async () => {
-            webex.meetings.reachability = {
-              isWebexMediaBackendUnreachable: sinon.stub().resolves(false),
-              getReachabilityMetrics: sinon.stub().resolves({}),
-              stopReachability: sinon.stub(),
-              isSubnetReachable: sinon.stub().returns(true),
-            };
-            webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
-              sinon.stub().returns({fatal: true});
-            sinon.stub(CallDiagnosticUtils, 'generateClientErrorCodeForIceFailure').returns(2004);
-
-            meeting.meetingState = 'ACTIVE';
-            const rejectedResult = {iceConnected};
-            meeting.mediaProperties.waitForMediaConnectionConnected = sinon
-              .stub()
-              .rejects(rejectedResult);
-
-            meeting.roap.doTurnDiscovery = sinon.stub().returns({
-              turnServerInfo: {urls: ['turns:fake:443'], username: 'u', password: 'p'},
-              turnDiscoverySkippedReason: undefined,
-            });
-
-            const forceRtcMetricsSend = sinon.stub().resolves();
-            Media.createMediaConnection = sinon.stub().returns({
-              close: sinon.stub(),
-              forceRtcMetricsSend,
-              getConnectionState: sinon.stub().returns(ConnectionState.Connected),
-              initiateOffer: sinon.stub().resolves({}),
-              on: sinon.stub(),
-            });
-
-            let thrownError;
-            await meeting.addMedia({mediaSettings: {}}).catch((err) => {
-              thrownError = err;
-            });
-
-            assert.instanceOf(thrownError, AddMediaFailed);
-            assert.equal(thrownError.iceConnected, iceConnected);
-            // the AddMediaFailed cause should be the MediaConnectionTimedOutError, which in turn should
-            // preserve the original rejected result as its cause, so that the web client
-            // can find the CA-reported error in the eventErrorCache via the cause chain
-            assert.instanceOf(thrownError.cause, MediaConnectionTimedOutError);
-            assert.equal(thrownError.cause.cause, rejectedResult);
-          });
-        });
-
-        describe('iceTransportPolicy=relay handling', () => {
-          let createMediaConnectionStub;
-
-          beforeEach(() => {
-            webex.meetings.reachability = {
-              isWebexMediaBackendUnreachable: sinon.stub().resolves(false),
-              isAnyClusterReachableViaProtocol: sinon.stub().resolves(true),
-              getReachabilityMetrics: sinon.stub().resolves({}),
-              stopReachability: sinon.stub(),
-              isSubnetReachable: sinon.stub().returns(true),
-            };
-            webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
-              sinon.stub().returns({fatal: true});
-            sinon.stub(CallDiagnosticUtils, 'generateClientErrorCodeForIceFailure').returns(2004);
-
-            meeting.meetingState = 'ACTIVE';
-            meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
-
-            createMediaConnectionStub = sinon.stub().returns({
-              close: sinon.stub(),
-              forceRtcMetricsSend: sinon.stub().resolves(),
-              getConnectionState: sinon.stub().returns(ConnectionState.Connected),
-              initiateOffer: sinon.stub().resolves({}),
-              on: sinon.stub(),
-            });
-            Media.createMediaConnection = createMediaConnectionStub;
-          });
-
-          [
-            {
-              title: 'should drop iceTransportPolicy=relay when TURN discovery returns no turn server info',
-              turnServerInfo: undefined,
-              turnDiscoverySkippedReason: 'reachability',
-            },
-            {
-              title: 'should drop iceTransportPolicy=relay when TURN discovery returns turnServerInfo with empty urls',
-              turnServerInfo: {urls: [], username: 'u', password: 'p'},
-              turnDiscoverySkippedReason: undefined,
-            },
-          ].forEach(({title, turnServerInfo, turnDiscoverySkippedReason}) => {
-            it(title, async () => {
-              meeting.roap.doTurnDiscovery = sinon.stub().returns({
-                turnServerInfo,
-                turnDiscoverySkippedReason,
-              });
-
-              await meeting.addMediaInternal(
-                () => 'JOIN_MEETING_FINAL',
-                false,
-                undefined,
-                'relay',
-                {mediaSettings: {}}
-              );
-
-              assert.calledOnce(createMediaConnectionStub);
-              const config = createMediaConnectionStub.firstCall.args[3];
-              assert.isUndefined(config.iceTransportPolicy);
-
-              const successCall = Metrics.sendBehavioralMetric.getCalls().find(
-                (call) => call.args[0] === BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS
-              );
-              assert.isDefined(successCall);
-              assert.equal(successCall.args[1].iceTransportPolicy, 'all');
-            });
-          });
-
-          it('should send ADD_MEDIA_SUCCESS metric with iceTransportPolicy=relay when relay is used', async () => {
-            meeting.roap.doTurnDiscovery = sinon.stub().returns({
-              turnServerInfo: {urls: ['turns:turn-server:443?transport=tcp'], username: 'u', password: 'p'},
-              turnDiscoverySkippedReason: undefined,
-            });
-
-            await meeting.addMediaInternal(
-              () => 'JOIN_MEETING_FINAL',
-              false,
-              undefined,
-              'relay',
-              {mediaSettings: {}}
-            );
-
-            const successCall = Metrics.sendBehavioralMetric.getCalls().find(
-              (call) => call.args[0] === BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS
-            );
-            assert.isDefined(successCall);
-            assert.equal(successCall.args[1].iceTransportPolicy, 'relay');
-          });
-
-          it('should send ADD_MEDIA_FAILURE metric with iceTransportPolicy=relay when relay attempt fails', async () => {
-            meeting.roap.doTurnDiscovery = sinon.stub().returns({
-              turnServerInfo: {urls: ['turns:turn-server:443?transport=tcp'], username: 'u', password: 'p'},
-              turnDiscoverySkippedReason: undefined,
-            });
-
-            meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().rejects(
-              new MediaConnectionTimedOutError('timed out', true)
-            );
-
-            await assert.isRejected(meeting.addMediaInternal(
-              () => 'JOIN_MEETING_FINAL',
-              false,
-              undefined,
-              'relay',
-              {mediaSettings: {}}
-            ));
-
-            const failureCall = Metrics.sendBehavioralMetric.getCalls().find(
-              (call) => call.args[0] === BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE
-            );
-            assert.isDefined(failureCall);
-            assert.equal(failureCall.args[1].iceTransportPolicy, 'relay');
-          });
         });
 
         it('should resolve if waitForMediaConnectionConnected() rejects the first time but resolves the second time', async () => {
@@ -4963,7 +4014,6 @@ describe('plugin-meetings', () => {
               isMultistream: false,
               retriedWithTurnServer: true,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               iceCandidatesCount: 0,
               subnet_reachable: null,
               selected_cluster: null,
@@ -5127,7 +4177,6 @@ describe('plugin-meetings', () => {
               isMultistream: false,
               retriedWithTurnServer: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
               iceCandidatesCount: 3,
@@ -5193,11 +4242,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: false,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               selectedCandidatePairChanges: 2,
               numTransports: 1,
               subnet_reachable: null,
@@ -5258,11 +4305,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: false,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               selectedCandidatePairChanges: 2,
               numTransports: 1,
               '701_error': 2,
@@ -5324,7 +4369,6 @@ describe('plugin-meetings', () => {
             isMultistream: false,
             retriedWithTurnServer: false,
             isJoinWithMediaRetry: false,
-            iceTransportPolicy: 'all',
             iceCandidatesCount: 0,
             reachability_public_udp_success: 5,
             subnet_reachable: false,
@@ -5390,11 +4434,9 @@ describe('plugin-meetings', () => {
               retriedWithTurnServer: false,
               isMultistream: false,
               isJoinWithMediaRetry: false,
-              iceTransportPolicy: 'all',
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
-              connectionType: 'udp',
               selectedCandidatePairChanges: 2,
               numTransports: 1,
               reachability_public_udp_success: 5,
@@ -7727,14 +6769,13 @@ describe('plugin-meetings', () => {
                 sinon.stub(meeting.locusMediaRequest, 'downgradeFromMultistreamToTranscoded');
               });
 
-              const runCheck = async (turnServerInfo, forceTurnDiscovery, iceTransportPolicy) => {
+              const runCheck = async (turnServerInfo, forceTurnDiscovery) => {
                 // we're calling addMediaInternal() with mic stream,
                 // so that we also verify that audioMute, videoMute info is correctly sent to backend
                 const addMediaPromise = meeting.addMediaInternal(
                   () => '',
-                  forceTurnDiscovery,
                   turnServerInfo,
-                  iceTransportPolicy,
+                  forceTurnDiscovery,
                   {
                     localStreams: {microphone: fakeMicrophoneStream},
                   }
@@ -7787,10 +6828,6 @@ describe('plugin-meetings', () => {
 
                 // at this point the meeting should have been downgraded to transcoded
                 assert.equal(meeting.isMultistream, false);
-
-                // iceTransportPolicy must be reset to undefined on downgrade to transcoded,
-                // otherwise the transcoded retry could gather direct candidates while metrics report relay
-                assert.isUndefined(meeting.addMediaData.iceTransportPolicy);
 
                 // old stats analyzer stopped and new one created
                 assert.calledOnce(initialStatsAnalyzer.stopAnalyzer);
@@ -7881,11 +6918,6 @@ describe('plugin-meetings', () => {
                   },
                   true
                 );
-              });
-
-              it('resets iceTransportPolicy to undefined when falling back from multistream (relay) to transcoded', async () => {
-                // simulate a relay-only retry falling back to transcoded and verify iceTransportPolicy is reset
-                await runCheck(undefined, false, 'relay');
               });
             });
           }
@@ -15425,180 +14457,6 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe('#processLocusLLMEvent', () => {
-        it('routes the LLM event through locusInfo.parse and records the LLM message with the top-level tracking id', () => {
-          const event = {
-            data: {
-              eventType: 'locus.state_message',
-              dataSets: [],
-            },
-            trackingId: 'envelope-tracking-id',
-          };
-
-          meeting.locusInfo.parse = sinon.stub();
-          meeting.onLocusSyncLlmMessage = sinon.stub();
-
-          meeting.processLocusLLMEvent(event);
-
-          // The LLM message is parsed without the tracking id - completion is driven from the
-          // meeting's LLM handler, not threaded through locusInfo.
-          assert.calledOnceWithExactly(meeting.locusInfo.parse, meeting, event.data);
-          // Only the client whose /sync request tracking id matches the tracking id echoed back on
-          // the top-level LLM event envelope records the LLM arrival; onLocusSyncLlmMessage is a
-          // no-op otherwise.
-          assert.calledOnceWithExactly(
-            meeting.onLocusSyncLlmMessage,
-            meeting.id,
-            event.trackingId
-          );
-        });
-
-        it('does not attempt sync completion when the tracking id is missing', () => {
-          const event = {
-            data: {
-              eventType: 'locus.state_message',
-              dataSets: [],
-            },
-          };
-
-          meeting.locusInfo.parse = sinon.stub();
-          meeting.onLocusSyncLlmMessage = sinon.stub();
-
-          meeting.processLocusLLMEvent(event);
-
-          assert.calledOnceWithExactly(meeting.locusInfo.parse, meeting, event.data);
-          assert.notCalled(meeting.onLocusSyncLlmMessage);
-        });
-
-      });
-
-      describe('#onLocusSyncLlmMessage', () => {
-        it('records the LLM arrival time and then tries to complete the metric', () => {
-          webex.internal.newMetrics.callDiagnosticLatencies.recordLocusSyncMessageReceived =
-            sinon.stub();
-          meeting.tryCompleteLocusSyncLatency = sinon.stub();
-
-          meeting.onLocusSyncLlmMessage('meeting-1', 'sync-tracking-id');
-
-          assert.calledOnceWithExactly(
-            webex.internal.newMetrics.callDiagnosticLatencies.recordLocusSyncMessageReceived,
-            'meeting-1',
-            'sync-tracking-id'
-          );
-          assert.calledOnceWithExactly(
-            meeting.tryCompleteLocusSyncLatency,
-            'meeting-1',
-            'sync-tracking-id'
-          );
-          // the arrival time must be recorded before completion is attempted
-          assert.callOrder(
-            webex.internal.newMetrics.callDiagnosticLatencies.recordLocusSyncMessageReceived,
-            meeting.tryCompleteLocusSyncLatency
-          );
-        });
-      });
-
-      describe('#tryCompleteLocusSyncLatency', () => {
-        beforeEach(() => {
-          meeting.emitLocusSyncCompleteMetric = sinon.stub();
-        });
-
-        it('emits the metric when both milestones are in (completion succeeds)', () => {
-          const completed = {dataSet: 'main', syncLatency: {totalTime: 50}};
-          webex.internal.newMetrics.callDiagnosticLatencies.completeLocusSyncLatency = sinon
-            .stub()
-            .returns(completed);
-
-          meeting.tryCompleteLocusSyncLatency('meeting-1', 'sync-tracking-id');
-
-          assert.calledOnceWithExactly(
-            webex.internal.newMetrics.callDiagnosticLatencies.completeLocusSyncLatency,
-            'meeting-1',
-            'sync-tracking-id'
-          );
-          assert.calledOnceWithExactly(
-            meeting.emitLocusSyncCompleteMetric,
-            'meeting-1',
-            completed
-          );
-        });
-
-        it('does not emit when completion returns undefined (only one milestone is in)', () => {
-          webex.internal.newMetrics.callDiagnosticLatencies.completeLocusSyncLatency = sinon
-            .stub()
-            .returns(undefined);
-
-          meeting.tryCompleteLocusSyncLatency('meeting-1', 'sync-tracking-id');
-
-          assert.calledOnceWithExactly(
-            webex.internal.newMetrics.callDiagnosticLatencies.completeLocusSyncLatency,
-            'meeting-1',
-            'sync-tracking-id'
-          );
-          assert.notCalled(meeting.emitLocusSyncCompleteMetric);
-        });
-      });
-
-      describe('#emitLocusSyncCompleteMetric', () => {
-        it('submits client.locus.sync.complete with the llm websocket url and sync latency', () => {
-          webex.internal.newMetrics.submitClientEvent.resetHistory();
-          webex.internal.llm.getWebSocketUrl = sinon.stub().returns('wss://llm-websocket-url');
-
-          meeting.emitLocusSyncCompleteMetric(
-            'meeting-1',
-            {
-              dataSet: 'main',
-              syncLatency: {totalTime: 50},
-            }
-          );
-
-          assert.calledOnceWithExactly(webex.internal.newMetrics.submitClientEvent, {
-            name: 'client.locus.sync.complete',
-            payload: {
-              identifiers: {
-                llmWebsocketUrl: 'wss://llm-websocket-url',
-              },
-              llmInfo: {
-                dataSet: 'main',
-              },
-              syncLatency: {totalTime: 50},
-            },
-            options: {
-              meetingId: 'meeting-1',
-            },
-          });
-        });
-
-        it('submits with an undefined llm websocket url when it is unavailable', () => {
-          webex.internal.newMetrics.submitClientEvent.resetHistory();
-          webex.internal.llm.getWebSocketUrl = sinon.stub().returns(undefined);
-
-          meeting.emitLocusSyncCompleteMetric(
-            'meeting-1',
-            {
-              dataSet: 'main',
-              syncLatency: {totalTime: 50},
-            }
-          );
-
-          assert.calledOnceWithExactly(webex.internal.newMetrics.submitClientEvent, {
-            name: 'client.locus.sync.complete',
-            payload: {
-              identifiers: {
-                llmWebsocketUrl: undefined,
-              },
-              llmInfo: {
-                dataSet: 'main',
-              },
-              syncLatency: {totalTime: 50},
-            },
-            options: {
-              meetingId: 'meeting-1',
-            },
-          });
-        });
-      });
-
       describe('#setLocus', () => {
         beforeEach(() => {
           meeting.locusInfo.initialSetup = sinon.stub().returns(true);
@@ -15631,71 +14489,6 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.selfId, uuid2);
           assert.equal(meeting.mediaId, uuid3);
           assert.equal(meeting.hostId, uuid4);
-        });
-      });
-
-      describe('#waitForSelfUrlChange', () => {
-        let waitForSelfUrlChange;
-        let locusMediaRequestStub;
-
-        beforeEach(async () => {
-          locusMediaRequestStub = sinon
-            .stub(LocusMediaRequestModule, 'LocusMediaRequest')
-            .returns({id: 'fake LocusMediaRequest instance'});
-
-          meeting.setLocus = sinon.stub().returns(true);
-          webex.meetings.registered = true;
-          sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve('JOIN_RESULT'));
-          sinon.stub(meeting, 'updateLLMConnection').returns(Promise.resolve());
-
-          await meeting.join();
-
-          waitForSelfUrlChange = locusMediaRequestStub.firstCall.args[0].waitForSelfUrlChange;
-        });
-
-        it('should resolve immediately when joinWithMediaRetryInfo.retryCount > 0', async () => {
-          meeting.joinWithMediaRetryInfo = {retryCount: 1, prevJoinResponse: undefined};
-
-          const result = waitForSelfUrlChange();
-
-          assert.instanceOf(result, Promise);
-          await result;
-        });
-
-        it('should not resolve before the timeout when retryCount is 0', async () => {
-          meeting.joinWithMediaRetryInfo = {retryCount: 0, prevJoinResponse: undefined};
-
-          let resolved = false;
-          waitForSelfUrlChange().then(() => {
-            resolved = true;
-          });
-
-          await testUtils.flushPromises();
-          assert.isFalse(resolved);
-        });
-
-        it('should resolve after the 5s timeout when retryCount is 0', async () => {
-          meeting.joinWithMediaRetryInfo = {retryCount: 0, prevJoinResponse: undefined};
-
-          let resolved = false;
-          const promise = waitForSelfUrlChange();
-          promise.then(() => {
-            resolved = true;
-          });
-
-          fakeClock.tick(5000);
-          await promise;
-
-          assert.isTrue(resolved);
-        });
-
-        it('should return the same promise when called multiple times', () => {
-          meeting.joinWithMediaRetryInfo = {retryCount: 0, prevJoinResponse: undefined};
-
-          const firstPromise = waitForSelfUrlChange();
-          const secondPromise = waitForSelfUrlChange();
-
-          assert.equal(firstPromise, secondPromise);
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6145,7 +6145,13 @@ describe('plugin-meetings', () => {
                 EVENT_TRIGGERS.MEDIA_INBOUND_AUDIO_ISSUE_DETECTED,
                 fakeEventData
               );
-              assert.notCalled(meeting.mediaProperties.sendMediaIssueMetric);
+              // metric is always sent regardless of unmuted member presence
+              assert.calledOnceWithExactly(
+                meeting.mediaProperties.sendMediaIssueMetric,
+                'inbound_audio',
+                fakeEventData.issueSubType,
+                meeting.correlationId
+              );
             });
 
             it('should trigger event and metric when there are multiple members and at least one is unmuted', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6145,13 +6145,7 @@ describe('plugin-meetings', () => {
                 EVENT_TRIGGERS.MEDIA_INBOUND_AUDIO_ISSUE_DETECTED,
                 fakeEventData
               );
-              // metric is always sent regardless of unmuted member presence
-              assert.calledOnceWithExactly(
-                meeting.mediaProperties.sendMediaIssueMetric,
-                'inbound_audio',
-                fakeEventData.issueSubType,
-                meeting.correlationId
-              );
+              assert.notCalled(meeting.mediaProperties.sendMediaIssueMetric);
             });
 
             it('should trigger event and metric when there are multiple members and at least one is unmuted', () => {

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -44,7 +44,7 @@
     "@types/platform": "1.3.4",
     "@webex/common": "workspace:*",
     "@webex/common-timers": "workspace:*",
-    "@webex/internal-media-core": "2.26.2",
+    "@webex/internal-media-core": "2.28.0",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-feature": "workspace:*",
     "@webex/internal-plugin-metrics": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7434,7 +7434,7 @@ __metadata:
     "@web/dev-server": 0.4.5
     "@webex/common": "workspace:*"
     "@webex/common-timers": "workspace:*"
-    "@webex/internal-media-core": 2.26.2
+    "@webex/internal-media-core": 2.28.0
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-feature": "workspace:*"
     "@webex/internal-plugin-metrics": "workspace:*"
@@ -7774,23 +7774,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.26.2":
-  version: 2.26.2
-  resolution: "@webex/internal-media-core@npm:2.26.2"
+"@webex/internal-media-core@npm:2.28.0":
+  version: 2.28.0
+  resolution: "@webex/internal-media-core@npm:2.28.0"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@babel/runtime-corejs2": ^7.25.0
     "@webex/rtcstats": ^1.5.5
     "@webex/ts-sdp": 1.8.2
     "@webex/web-capabilities": ^1.10.0
-    "@webex/web-client-media-engine": 3.40.2
+    "@webex/web-client-media-engine": 3.41.1
     events: ^3.3.0
     ip-anonymize: ^0.1.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: 62113f3b8e7a89bc76abdb36fbf400153fd84a8635578faf7941c6896ddc51f64924dbc3b9553dba448ea2cf130d270d0e822078de49399a56a09a7b5e3e3ce5
+  checksum: e99bb903a8186576144dc3c252fd302b108d9aa6a610fef5008dd81f83aecdb9d24f2e2c46b1315af03049888bb36fbcd1a492c82302fee8bb2411541aedbcdc
   languageName: node
   linkType: hard
 
@@ -8621,7 +8621,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.26.2
+    "@webex/internal-media-core": 2.28.0
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8889,7 +8889,7 @@ __metadata:
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/event-dictionary-ts": ^1.0.2215
-    "@webex/internal-media-core": 2.26.2
+    "@webex/internal-media-core": 2.28.0
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -9623,9 +9623,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.40.2":
-  version: 3.40.2
-  resolution: "@webex/web-client-media-engine@npm:3.40.2"
+"@webex/web-client-media-engine@npm:3.41.1":
+  version: 3.41.1
+  resolution: "@webex/web-client-media-engine@npm:3.41.1"
   dependencies:
     "@webex/json-multistream": ^2.4.3
     "@webex/rtcstats": ^1.5.5
@@ -9638,7 +9638,7 @@ __metadata:
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: e9b4a14a9bd54a1bf2e2a79b6553b45878bdc17d5e9fc7fa81ecf3937766ca3230f302e9021b1ac7050f3f94f7745c8008f4359048ca089d4d6853fb045cfe0e
+  checksum: 5dd4c30f72a8c6c2b987bf5340a9066376a23ca762e2c6fedc457aa9c7563a11a720966766da0bb0e1c6eb74e40d51affbfa84f67ce5c2f9ab93d30ded7620cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## This pull request addresses

Inbound audio issue telemetry could be skipped in multi-member meetings when no other member was currently unmuted, which caused under-reporting of inbound audio problems.

The branch also updates internal media dependency alignment to pick up the latest internal media-core/runtime fixes used by meetings-related packages.

## by making the following changes

- Updated inbound audio issue handling in meeting stats processing so the inbound audio issue metric is emitted consistently whenever the inbound audio issue event is detected.
- Preserved existing event-trigger behavior for the specific case where at least one non-self, non-paired member is unmuted.
- Updated unit tests to reflect and validate the new metric-emission behavior.
- Bumped @webex/internal-media-core from 2.26.2 to 2.28.0 in:
  - @webex/plugin-meetings
  - @webex/media-helpers
  - calling
- Refreshed lockfile entries accordingly, including transitive web client media engine update from 3.40.2 to 3.41.1.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Ran targeted unit tests for meetings:
  - yarn workspace @webex/plugin-meetings test:unit --targets meeting/index.js
- Result:
  - 758 passing
  - Exit code: 0

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly