### PR TITLE
feat(logger): add configurable structured log pipelines

### DIFF
--- a/packages/@webex/plugin-logger/package.json
+++ b/packages/@webex/plugin-logger/package.json
@@ -38,7 +38,8 @@
     "@webex/test-helper-mocha": "workspace:*",
     "@webex/test-helper-mock-webex": "workspace:*",
     "@webex/webex-core": "workspace:*",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "^3.3.2"
   },
   "scripts": {
     "build": "yarn build:src",

--- a/packages/@webex/plugin-logger/src/config.js
+++ b/packages/@webex/plugin-logger/src/config.js
@@ -8,8 +8,10 @@
  * should be printed to the console. One of
  * silent|error|warn|log|info|debug|trace
  * @property {number} [historyLength=1000] - Maximum number of entries to store in the log buffer.
- * @property {{write: function(Object): void}} [transport] - Optional internal transport for
- * records admitted to the existing log buffer.
+ * @property {function(Object): Object} [formatter] - Optional formatter applied once before
+ * records are delivered to configured transports.
+ * @property {Array<{write: function(Object): void}>} [transports] - Optional exact set of
+ * transports. When omitted, the existing console and buffer behavior is used.
  * @example
  * {
  *   level: process.env.WEBEX_LOG_LEVEL,

--- a/packages/@webex/plugin-logger/src/config.js
+++ b/packages/@webex/plugin-logger/src/config.js
@@ -8,6 +8,8 @@
  * should be printed to the console. One of
  * silent|error|warn|log|info|debug|trace
  * @property {number} [historyLength=1000] - Maximum number of entries to store in the log buffer.
+ * @property {{write: function(Object): void}} [transport] - Optional internal transport for
+ * records admitted to the existing log buffer.
  * @example
  * {
  *   level: process.env.WEBEX_LOG_LEVEL,

--- a/packages/@webex/plugin-logger/src/formatters.js
+++ b/packages/@webex/plugin-logger/src/formatters.js
@@ -2,6 +2,8 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 
+import {LOG_ATTRIBUTE_KEYS} from './log-record-schema';
+
 const severityByLevel = {
   error: 17,
   warn: 13,
@@ -30,15 +32,18 @@ export function openTelemetryLogFormatter(logRecord) {
     severityText: (logRecord.level || 'info').toUpperCase(),
     body: logRecord.message,
     attributes: {
-      'webex.logger.schema_version': logRecord.schemaVersion,
-      'webex.logger.type': logRecord.type,
-      'webex.logger.name': logRecord.name,
       ...logRecord.attributes,
+      [LOG_ATTRIBUTE_KEYS.SCHEMA_VERSION]: logRecord.schemaVersion,
+      [LOG_ATTRIBUTE_KEYS.LOGGER_TYPE]: logRecord.type,
+      [LOG_ATTRIBUTE_KEYS.LOGGER_NAME]: logRecord.name,
     },
   };
 
   if (logRecord.eventName) {
     record.eventName = logRecord.eventName;
+    if (logRecord.eventId) {
+      record.attributes[LOG_ATTRIBUTE_KEYS.EVENT_ID] = logRecord.eventId;
+    }
   }
 
   return record;

--- a/packages/@webex/plugin-logger/src/formatters.js
+++ b/packages/@webex/plugin-logger/src/formatters.js
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
+ */
+
+const severityByLevel = {
+  error: 17,
+  warn: 13,
+  log: 9,
+  info: 9,
+  debug: 5,
+  trace: 1,
+  group: 9,
+  groupEnd: 9,
+};
+
+/**
+ * Formats an SDK log record for the OpenTelemetry JavaScript Logs API.
+ *
+ * This intentionally does not import OpenTelemetry. The application owns the
+ * OpenTelemetry provider, context, processors, and exporter.
+ *
+ * @param {Object} logRecord SDK structured log record
+ * @returns {Object} OpenTelemetry-compatible log record
+ */
+export function openTelemetryLogFormatter(logRecord) {
+  const record = {
+    timestamp: new Date(logRecord.timestamp),
+    observedTimestamp: new Date(),
+    severityNumber: severityByLevel[logRecord.level] || severityByLevel.info,
+    severityText: (logRecord.level || 'info').toUpperCase(),
+    body: logRecord.message,
+    attributes: {
+      'webex.logger.schema_version': logRecord.schemaVersion,
+      'webex.logger.type': logRecord.type,
+      'webex.logger.name': logRecord.name,
+      ...logRecord.attributes,
+    },
+  };
+
+  if (logRecord.eventName) {
+    record.eventName = logRecord.eventName;
+  }
+
+  return record;
+}

--- a/packages/@webex/plugin-logger/src/index.js
+++ b/packages/@webex/plugin-logger/src/index.js
@@ -14,3 +14,25 @@ registerPlugin('logger', Logger, {
 
 export {default, levels} from './logger';
 export {openTelemetryLogFormatter} from './formatters';
+export {
+  createEventId,
+  EVENT_ID_PATTERN,
+  EVENT_ID_PREFIX_PATTERN,
+  EVENT_INITIATOR_TYPES,
+  EVENT_NAME_PATTERN,
+  EVENT_TRIGGER_TYPES,
+  getEventIdPrefix,
+  isValidEventId,
+  isValidEventIdPrefix,
+  isValidEventName,
+  isValidOpenTelemetrySpanId,
+  isValidOpenTelemetryTraceId,
+  LOG_ATTRIBUTE_KEYS,
+  LOG_RECORD_ATTRIBUTE_COUNT_LIMIT,
+  LOG_RECORD_SCHEMA_VERSION,
+  LOG_TYPES,
+  logRecordSchema,
+  OTEL_SPAN_ID_PATTERN,
+  OTEL_TRACE_ID_PATTERN,
+  RESERVED_LOG_ATTRIBUTE_KEYS,
+} from './log-record-schema';

--- a/packages/@webex/plugin-logger/src/index.js
+++ b/packages/@webex/plugin-logger/src/index.js
@@ -13,3 +13,4 @@ registerPlugin('logger', Logger, {
 });
 
 export {default, levels} from './logger';
+export {openTelemetryLogFormatter} from './formatters';

--- a/packages/@webex/plugin-logger/src/log-record-schema.js
+++ b/packages/@webex/plugin-logger/src/log-record-schema.js
@@ -1,0 +1,162 @@
+/*!
+ * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import uuid from 'uuid';
+
+export const LOG_RECORD_SCHEMA_VERSION = 1;
+export const LOG_RECORD_ATTRIBUTE_COUNT_LIMIT = 128;
+
+export const LOG_TYPES = Object.freeze({
+  SDK: 'sdk',
+  CLIENT: 'client',
+});
+
+export const EVENT_INITIATOR_TYPES = Object.freeze({
+  USER: 'user',
+  REMOTE_USER: 'remote_user',
+  SYSTEM: 'system',
+  REMOTE_SYSTEM: 'remote_system',
+  UNKNOWN: 'unknown',
+});
+
+export const EVENT_TRIGGER_TYPES = Object.freeze({
+  UI: 'ui',
+  HTTP: 'http',
+  WEBSOCKET: 'websocket',
+  TIMER: 'timer',
+  LIFECYCLE: 'lifecycle',
+  WORKER: 'worker',
+  INTERNAL: 'internal',
+});
+
+export const LOG_ATTRIBUTE_KEYS = Object.freeze({
+  SCHEMA_VERSION: 'webex.logger.schema_version',
+  LOGGER_TYPE: 'webex.logger.type',
+  LOGGER_NAME: 'webex.logger.name',
+  EVENT_ID: 'webex.event.id',
+  EVENT_INITIATOR_TYPE: 'webex.event.initiator.type',
+  EVENT_TRIGGER_TYPE: 'webex.event.trigger.type',
+  OPERATION_ID: 'webex.operation.id',
+  MODULE: 'webex.module',
+  USER_ID: 'enduser.id',
+  ORG_ID: 'webex.org.id',
+  SESSION_ID: 'webex.session.id',
+  TRACKING_ID: 'webex.request.tracking_id',
+  CORRELATION_ID: 'webex.correlation.id',
+  SESSION_CORRELATION_ID: 'webex.session.correlation_id',
+  FEEDBACK_ID: 'webex.feedback.id',
+  CLIENT_CLOCK_TIMESTAMP: 'webex.client.clock.timestamp_unix_ms',
+  SERVER_CLOCK_TIMESTAMP: 'webex.server.clock.estimated_timestamp_unix_ms',
+  SERVER_CLOCK_OFFSET: 'webex.server.clock.offset_ms',
+  SERVER_CLOCK_UNCERTAINTY: 'webex.server.clock.uncertainty_ms',
+  SERVER_CLOCK_SYNC_AGE: 'webex.server.clock.sync_age_ms',
+  ACTION_NAME: 'webex.action.name',
+  NETWORK_ACTION: 'webex.network.action',
+});
+
+export const RESERVED_LOG_ATTRIBUTE_KEYS = Object.freeze([
+  LOG_ATTRIBUTE_KEYS.SCHEMA_VERSION,
+  LOG_ATTRIBUTE_KEYS.LOGGER_TYPE,
+  LOG_ATTRIBUTE_KEYS.LOGGER_NAME,
+  LOG_ATTRIBUTE_KEYS.EVENT_ID,
+]);
+
+export const EVENT_NAME_PATTERN = '^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$';
+export const EVENT_ID_PREFIX_PATTERN = '^[a-z][A-Za-z0-9]{0,63}$';
+export const EVENT_ID_PATTERN =
+  '^[a-z][A-Za-z0-9]{0,63}_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$';
+export const OTEL_TRACE_ID_PATTERN = '^[0-9a-f]{32}$';
+export const OTEL_SPAN_ID_PATTERN = '^[0-9a-f]{16}$';
+
+const eventNameRegExp = new RegExp(EVENT_NAME_PATTERN);
+const eventIdPrefixRegExp = new RegExp(EVENT_ID_PREFIX_PATTERN);
+const eventIdRegExp = new RegExp(EVENT_ID_PATTERN);
+const traceIdRegExp = new RegExp(OTEL_TRACE_ID_PATTERN);
+const spanIdRegExp = new RegExp(OTEL_SPAN_ID_PATTERN);
+
+export const isValidEventName = (eventName) =>
+  typeof eventName === 'string' && eventNameRegExp.test(eventName);
+
+export const isValidEventIdPrefix = (prefix) =>
+  typeof prefix === 'string' && eventIdPrefixRegExp.test(prefix);
+
+export const isValidEventId = (eventId) =>
+  typeof eventId === 'string' && eventIdRegExp.test(eventId);
+
+export const isValidOpenTelemetryTraceId = (traceId) =>
+  typeof traceId === 'string' && traceIdRegExp.test(traceId) && !/^0+$/.test(traceId);
+
+export const isValidOpenTelemetrySpanId = (spanId) =>
+  typeof spanId === 'string' && spanIdRegExp.test(spanId) && !/^0+$/.test(spanId);
+
+export const getEventIdPrefix = (eventName) => {
+  if (!isValidEventName(eventName)) {
+    throw new TypeError(`Invalid event name: ${eventName}`);
+  }
+
+  const segments = eventName.split('.');
+  const relevantSegments = segments[0] === 'webex' ? segments.slice(1) : segments;
+
+  return relevantSegments
+    .map((segment, index) => {
+      const camelSegment = segment.replace(/_([a-z0-9])/g, (_match, character) =>
+        character.toUpperCase()
+      );
+
+      return index === 0
+        ? camelSegment
+        : `${camelSegment.charAt(0).toUpperCase()}${camelSegment.slice(1)}`;
+    })
+    .join('');
+};
+
+export const createEventId = (prefix) => {
+  if (!isValidEventIdPrefix(prefix)) {
+    throw new TypeError(`Invalid event ID prefix: ${prefix}`);
+  }
+
+  return `${prefix}_${uuid.v4()}`;
+};
+
+export const logRecordSchema = Object.freeze({
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://webex.com/schemas/logger/log-record-v1.json',
+  title: 'Webex structured log record',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'timestamp', 'level', 'type', 'name', 'message'],
+  properties: {
+    schemaVersion: {const: LOG_RECORD_SCHEMA_VERSION},
+    timestamp: {type: 'integer', minimum: 0},
+    level: {
+      enum: ['error', 'warn', 'log', 'info', 'debug', 'trace', 'group', 'groupEnd'],
+    },
+    type: {enum: Object.values(LOG_TYPES)},
+    name: {type: 'string', minLength: 1, maxLength: 128},
+    message: {type: 'string'},
+    eventName: {type: 'string', pattern: EVENT_NAME_PATTERN},
+    eventId: {type: 'string', pattern: EVENT_ID_PATTERN},
+    attributes: {
+      type: 'object',
+      maxProperties: LOG_RECORD_ATTRIBUTE_COUNT_LIMIT,
+      propertyNames: {type: 'string', minLength: 1},
+      properties: {
+        [LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE]: {
+          enum: Object.values(EVENT_INITIATOR_TYPES),
+        },
+        [LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE]: {
+          enum: Object.values(EVENT_TRIGGER_TYPES),
+        },
+        [LOG_ATTRIBUTE_KEYS.OPERATION_ID]: {
+          type: 'string',
+          pattern: EVENT_ID_PATTERN,
+        },
+      },
+      additionalProperties: {type: ['string', 'number', 'boolean']},
+    },
+  },
+  dependentRequired: {
+    eventId: ['eventName'],
+  },
+});

--- a/packages/@webex/plugin-logger/src/logger.js
+++ b/packages/@webex/plugin-logger/src/logger.js
@@ -124,10 +124,10 @@ function sanitizeAttributes(logger, attributes) {
 }
 
 /**
- * Builds the SDK-owned transport record.
+ * Builds the SDK-owned structured log record.
  * @param {Logger} logger logger instance
  * @param {Object} options record inputs
- * @returns {Object} structured transport record
+ * @returns {Object} structured log record
  */
 function createLogRecord(logger, {level, type, name, timestamp, stringified, structuredRecord}) {
   const record = {
@@ -155,23 +155,73 @@ function createLogRecord(logger, {level, type, name, timestamp, stringified, str
 }
 
 /**
- * Delivers a record to the optional configured transport.
+ * Returns whether the configured transport array replaces the SDK defaults.
+ * @param {Logger} logger logger instance
+ * @returns {boolean} whether custom transports were explicitly configured
+ */
+function hasConfiguredTransports(logger) {
+  return isArray(logger.config.transports);
+}
+
+/**
+ * Delivers a formatted record to each configured transport.
  * @param {Logger} logger logger instance
  * @param {Object} record structured transport record
  * @returns {void}
  */
-function writeToTransport(logger, record) {
-  const {transport} = logger.config;
+function writeToTransports(logger, record) {
+  let formattedRecord = record;
 
-  if (!transport || typeof transport.write !== 'function') {
+  if (typeof logger.config.formatter === 'function') {
+    try {
+      formattedRecord = logger.config.formatter(record);
+    } catch {
+      return;
+    }
+  }
+
+  if (!formattedRecord) {
     return;
   }
 
-  try {
-    transport.write(record);
-  } catch {
-    // Transport failures must not affect console logging or the existing buffer.
-  }
+  logger.config.transports.forEach((transport) => {
+    if (!transport || typeof transport.write !== 'function') {
+      return;
+    }
+
+    try {
+      transport.write(formattedRecord);
+    } catch {
+      // One transport must not prevent delivery to the remaining transports.
+    }
+  });
+}
+
+/**
+ * Builds the structured buffer entry used by legacy log uploads.
+ * @param {Object} record structured log record
+ * @param {Array<string>} stringified filtered and stringified log values
+ * @param {number} groupLevel current console group depth
+ * @returns {Object} structured buffer entry
+ */
+function createBufferEntry(record, stringified, groupLevel) {
+  return {
+    record,
+    legacyLine: [
+      '|  '.repeat(groupLevel),
+      new Date(record.timestamp).toISOString(),
+      ...stringified,
+    ],
+  };
+}
+
+/**
+ * Serializes one structured buffer entry to the existing upload format.
+ * @param {Object} entry structured buffer entry
+ * @returns {string} legacy upload line
+ */
+function formatBufferEntry(entry) {
+  return entry.legacyLine.join(',');
 }
 
 /**
@@ -374,7 +424,7 @@ const Logger = WebexPlugin.extend({
    */
   formatLogs(options = {}) {
     function getDate(log) {
-      return log[1];
+      return log.record.timestamp;
     }
     const {diff = false} = options;
     let buffer = [];
@@ -418,7 +468,7 @@ const Logger = WebexPlugin.extend({
       buffer = this.buffer.buffer;
     }
 
-    return buffer.join('\n');
+    return buffer.map(formatBufferEntry).join('\n');
   },
 
   /**
@@ -500,10 +550,17 @@ function makeLoggerMethod(
     }
 
     try {
-      const shouldPrint = !neverPrint && this.shouldPrint(level, logType);
-      const shouldBuffer = alwaysBuffer || this.shouldBuffer(level);
+      const customTransportsConfigured = hasConfiguredTransports(this);
+      const shouldPrint =
+        !customTransportsConfigured && !neverPrint && this.shouldPrint(level, logType);
+      const shouldBuffer =
+        !customTransportsConfigured && (alwaysBuffer || this.shouldBuffer(level));
+      const shouldTransport =
+        customTransportsConfigured &&
+        this.config.transports.length > 0 &&
+        (alwaysBuffer || this.shouldBuffer(level));
 
-      if (!shouldBuffer && !shouldPrint) {
+      if (!shouldBuffer && !shouldPrint && !shouldTransport) {
         return;
       }
 
@@ -554,7 +611,7 @@ function makeLoggerMethod(
         console[impl](...toPrint);
       }
 
-      if (shouldBuffer) {
+      if (shouldBuffer || shouldTransport) {
         const logDate = new Date();
         const transportRecord = createLogRecord(this, {
           level,
@@ -565,30 +622,32 @@ function makeLoggerMethod(
           structuredRecord,
         });
 
-        stringified.unshift(logDate.toISOString());
-        stringified.unshift('|  '.repeat(this.groupLevel));
-        bufferRef.buffer.push(stringified);
-        if (bufferRef.buffer.length > historyLength) {
-          // we've gone over the buffer limit, trim it down
-          const deleteCount = bufferRef.buffer.length - historyLength;
+        if (shouldBuffer) {
+          bufferRef.buffer.push(createBufferEntry(transportRecord, stringified, this.groupLevel));
+          if (bufferRef.buffer.length > historyLength) {
+            // we've gone over the buffer limit, trim it down
+            const deleteCount = bufferRef.buffer.length - historyLength;
 
-          bufferRef.buffer.splice(0, deleteCount);
+            bufferRef.buffer.splice(0, deleteCount);
 
-          // and adjust the corresponding buffer index used for log diff uploads
-          bufferRef.nextIndex -= deleteCount;
-          if (bufferRef.nextIndex < 0) {
-            bufferRef.nextIndex = 0;
-          }
+            // and adjust the corresponding buffer index used for log diff uploads
+            bufferRef.nextIndex -= deleteCount;
+            if (bufferRef.nextIndex < 0) {
+              bufferRef.nextIndex = 0;
+            }
 
-          bufferRef.lastSubmitted -= deleteCount;
-          if (bufferRef.lastSubmitted < 0) {
-            bufferRef.lastSubmitted = 0;
+            bufferRef.lastSubmitted -= deleteCount;
+            if (bufferRef.lastSubmitted < 0) {
+              bufferRef.lastSubmitted = 0;
+            }
           }
         }
         if (level === 'group') this.groupLevel += 1;
         if (level === 'groupEnd' && this.groupLevel > 0) this.groupLevel -= 1;
 
-        writeToTransport(this, transportRecord);
+        if (shouldTransport) {
+          writeToTransports(this, transportRecord);
+        }
       }
     } catch (reason) {
       if (!neverPrint) {

--- a/packages/@webex/plugin-logger/src/logger.js
+++ b/packages/@webex/plugin-logger/src/logger.js
@@ -34,6 +34,7 @@ const LOG_TYPES = {
 };
 
 const SDK_LOG_TYPE_NAME = 'wx-js-sdk';
+const LOG_RECORD_SCHEMA_VERSION = 1;
 
 const authTokenKeyPattern = /[Aa]uthorization/;
 
@@ -77,6 +78,100 @@ function walkAndFilter(object, visited = []) {
   }
 
   return object;
+}
+
+/**
+ * Resolves the available console implementation for a log level.
+ * @param {string} level log level
+ * @returns {string} console method name
+ */
+function getConsoleImpl(level) {
+  let impls = fallbacks[level];
+  let impl = level;
+
+  if (impls) {
+    impls = impls.slice();
+    // eslint-disable-next-line no-console
+    while (!console[impl]) {
+      impl = impls.pop();
+    }
+  }
+
+  return impl;
+}
+
+/**
+ * Filters structured attributes down to supported scalar values.
+ * @param {Logger} logger logger instance
+ * @param {Object} attributes candidate attributes
+ * @returns {Object|undefined} sanitized attributes
+ */
+function sanitizeAttributes(logger, attributes) {
+  if (!isObject(attributes) || isArray(attributes)) {
+    return undefined;
+  }
+
+  const [filteredAttributes] = logger.filter(attributes);
+  const sanitizedAttributes = Object.entries(filteredAttributes).reduce((result, [key, value]) => {
+    if (['boolean', 'number', 'string'].includes(typeof value)) {
+      result[key] = value;
+    }
+
+    return result;
+  }, {});
+
+  return Object.keys(sanitizedAttributes).length ? sanitizedAttributes : undefined;
+}
+
+/**
+ * Builds the SDK-owned transport record.
+ * @param {Logger} logger logger instance
+ * @param {Object} options record inputs
+ * @returns {Object} structured transport record
+ */
+function createLogRecord(logger, {level, type, name, timestamp, stringified, structuredRecord}) {
+  const record = {
+    schemaVersion: LOG_RECORD_SCHEMA_VERSION,
+    timestamp: timestamp.getTime(),
+    level,
+    type,
+    name,
+    message: stringified.slice(1).join(' '),
+  };
+
+  if (structuredRecord) {
+    const attributes = sanitizeAttributes(logger, structuredRecord.attributes);
+
+    if (attributes) {
+      record.attributes = attributes;
+    }
+
+    if (isString(structuredRecord.eventName)) {
+      [record.eventName] = logger.filter(structuredRecord.eventName);
+    }
+  }
+
+  return record;
+}
+
+/**
+ * Delivers a record to the optional configured transport.
+ * @param {Logger} logger logger instance
+ * @param {Object} record structured transport record
+ * @returns {void}
+ */
+function writeToTransport(logger, record) {
+  const {transport} = logger.config;
+
+  if (!transport || typeof transport.write !== 'function') {
+    return;
+  }
+
+  try {
+    transport.write(record);
+  } catch {
+    // Transport failures must not affect console logging or the existing buffer.
+  }
 }
 
 /**
@@ -364,16 +459,26 @@ const Logger = WebexPlugin.extend({
  * @param {string} type type of log, SDK or client
  * @param {bool} neverPrint function never prints to console
  * @param {bool} alwaysBuffer function always logs to log buffer
- * @instance
- * @memberof Logger
- * @private
- * @memberof Logger
+ * @param {bool} structured whether the method accepts a structured record
  * @returns {function} logger method with specified params
  */
-function makeLoggerMethod(level, impl, type, neverPrint = false, alwaysBuffer = false) {
+function makeLoggerMethod(
+  level,
+  impl,
+  type,
+  neverPrint = false,
+  alwaysBuffer = false,
+  structured = false
+) {
   // Much of the complexity in the following function is due to a test-mode-only
   // helper
   return function wrappedConsoleMethod(...args) {
+    const structuredRecord = structured ? args[0] : undefined;
+
+    if (structured) {
+      args = [structuredRecord.message];
+    }
+
     // it would be easier to just pass in the name and buffer here, but the config isn't completely initialized
     // in Ampersand, even if the initialize method is used to set this up.  so we keep the type to achieve
     // a sort of late binding to allow retrieving a name from config.
@@ -451,6 +556,14 @@ function makeLoggerMethod(level, impl, type, neverPrint = false, alwaysBuffer = 
 
       if (shouldBuffer) {
         const logDate = new Date();
+        const transportRecord = createLogRecord(this, {
+          level,
+          type: logType,
+          name: clientName,
+          timestamp: logDate,
+          stringified,
+          structuredRecord,
+        });
 
         stringified.unshift(logDate.toISOString());
         stringified.unshift('|  '.repeat(this.groupLevel));
@@ -474,6 +587,8 @@ function makeLoggerMethod(level, impl, type, neverPrint = false, alwaysBuffer = 
         }
         if (level === 'group') this.groupLevel += 1;
         if (level === 'groupEnd' && this.groupLevel > 0) this.groupLevel -= 1;
+
+        writeToTransport(this, transportRecord);
       }
     } catch (reason) {
       if (!neverPrint) {
@@ -485,36 +600,58 @@ function makeLoggerMethod(level, impl, type, neverPrint = false, alwaysBuffer = 
   };
 }
 
-levels.forEach((level) => {
-  let impls = fallbacks[level];
-  let impl = level;
+const structuredClientMethods = {};
 
-  if (impls) {
-    impls = impls.slice();
-    // eslint-disable-next-line no-console
-    while (!console[impl]) {
-      impl = impls.pop();
-    }
-  }
+levels.forEach((level) => {
+  const impl = getConsoleImpl(level);
 
   // eslint-disable-next-line complexity
   Logger.prototype[`client_${level}`] = makeLoggerMethod(level, impl, LOG_TYPES.CLIENT);
   Logger.prototype[level] = makeLoggerMethod(level, impl, LOG_TYPES.SDK);
+  structuredClientMethods[level] = makeLoggerMethod(
+    level,
+    impl,
+    LOG_TYPES.CLIENT,
+    false,
+    false,
+    true
+  );
 });
 
+/**
+ * Writes a structured client record through the normal console, buffer, and optional transport path.
+ *
+ * @param {Object} record structured client record
+ * @param {string} record.level log level
+ * @param {string} record.message log message
+ * @param {string} [record.eventName] event name
+ * @param {Object} [record.attributes] scalar attributes
+ * @private
+ * @returns {void}
+ */
+Logger.prototype.client_logRecord = function clientLogRecord({
+  level,
+  message,
+  eventName,
+  attributes,
+}) {
+  if (!levels.includes(level)) {
+    throw new TypeError(`Unsupported log level: ${level}`);
+  }
+  if (!isString(message)) {
+    throw new TypeError('Structured log message must be a string');
+  }
+
+  structuredClientMethods[level].call(this, {message, eventName, attributes});
+};
+
 Logger.prototype.client_logToBuffer = makeLoggerMethod(
-  levels.info,
-  levels.info,
+  'info',
+  'info',
   LOG_TYPES.CLIENT,
   true,
   true
 );
-Logger.prototype.logToBuffer = makeLoggerMethod(
-  levels.info,
-  levels.info,
-  LOG_TYPES.SDK,
-  true,
-  true
-);
+Logger.prototype.logToBuffer = makeLoggerMethod('info', 'info', LOG_TYPES.SDK, true, true);
 
 export default Logger;

--- a/packages/@webex/plugin-logger/src/logger.js
+++ b/packages/@webex/plugin-logger/src/logger.js
@@ -6,6 +6,21 @@ import {inBrowser, patterns} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
 import {cloneDeep, has, isArray, isObject, isString} from 'lodash';
 
+import {
+  createEventId,
+  EVENT_INITIATOR_TYPES,
+  EVENT_TRIGGER_TYPES,
+  getEventIdPrefix,
+  isValidEventId,
+  isValidEventIdPrefix,
+  isValidEventName,
+  LOG_ATTRIBUTE_KEYS,
+  LOG_RECORD_ATTRIBUTE_COUNT_LIMIT,
+  LOG_RECORD_SCHEMA_VERSION,
+  LOG_TYPES,
+  RESERVED_LOG_ATTRIBUTE_KEYS,
+} from './log-record-schema';
+
 const precedence = {
   silent: 0,
   group: 1,
@@ -28,15 +43,13 @@ const fallbacks = {
   trace: ['debug', 'info', 'log'],
 };
 
-const LOG_TYPES = {
-  SDK: 'sdk',
-  CLIENT: 'client',
-};
-
 const SDK_LOG_TYPE_NAME = 'wx-js-sdk';
-const LOG_RECORD_SCHEMA_VERSION = 1;
 
 const authTokenKeyPattern = /[Aa]uthorization/;
+const authTokenValuePattern = /\b(Basic|Bearer)\s+[A-Za-z0-9._~+/-]+=*/gi;
+const reservedAttributeKeys = new Set(RESERVED_LOG_ATTRIBUTE_KEYS);
+const eventInitiatorTypes = new Set(Object.values(EVENT_INITIATOR_TYPES));
+const eventTriggerTypes = new Set(Object.values(EVENT_TRIGGER_TYPES));
 
 /**
  * Recursively strips "authorization" fields from the specified object
@@ -58,11 +71,12 @@ function walkAndFilter(object, visited = []) {
   }
   if (!isObject(object)) {
     if (isString(object)) {
+      object = object.replace(authTokenValuePattern, '$1 [REDACTED]');
       if (patterns.containsEmails.test(object)) {
-        return object.replace(patterns.containsEmails, '[REDACTED]');
+        object = object.replace(patterns.containsEmails, '[REDACTED]');
       }
       if (patterns.containsMTID.test(object)) {
-        return object.replace(patterns.containsMTID, '$1[REDACTED]');
+        object = object.replace(patterns.containsMTID, '$1[REDACTED]');
       }
     }
 
@@ -113,7 +127,24 @@ function sanitizeAttributes(logger, attributes) {
 
   const [filteredAttributes] = logger.filter(attributes);
   const sanitizedAttributes = Object.entries(filteredAttributes).reduce((result, [key, value]) => {
-    if (['boolean', 'number', 'string'].includes(typeof value)) {
+    if (Object.keys(result).length >= LOG_RECORD_ATTRIBUTE_COUNT_LIMIT) {
+      return result;
+    }
+
+    const isInvalidTaxonomy =
+      (key === LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE && !eventInitiatorTypes.has(value)) ||
+      (key === LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE && !eventTriggerTypes.has(value));
+    const isInvalidOperationId = key === LOG_ATTRIBUTE_KEYS.OPERATION_ID && !isValidEventId(value);
+
+    if (
+      key &&
+      !reservedAttributeKeys.has(key) &&
+      !isInvalidTaxonomy &&
+      !isInvalidOperationId &&
+      (typeof value === 'boolean' ||
+        typeof value === 'string' ||
+        (typeof value === 'number' && Number.isFinite(value)))
+    ) {
       result[key] = value;
     }
 
@@ -147,7 +178,24 @@ function createLogRecord(logger, {level, type, name, timestamp, stringified, str
     }
 
     if (isString(structuredRecord.eventName)) {
-      [record.eventName] = logger.filter(structuredRecord.eventName);
+      const [eventName] = logger.filter(structuredRecord.eventName);
+
+      if (!isValidEventName(eventName)) {
+        throw new TypeError(`Invalid event name: ${eventName}`);
+      }
+
+      const eventIdPrefix = structuredRecord.eventIdPrefix || getEventIdPrefix(eventName);
+
+      if (!isValidEventIdPrefix(eventIdPrefix)) {
+        throw new TypeError(`Invalid event ID prefix: ${eventIdPrefix}`);
+      }
+
+      if (structuredRecord.eventId && !isValidEventId(structuredRecord.eventId)) {
+        throw new TypeError(`Invalid event ID: ${structuredRecord.eventId}`);
+      }
+
+      record.eventName = eventName;
+      record.eventId = structuredRecord.eventId || createEventId(eventIdPrefix);
     }
   }
 
@@ -567,7 +615,7 @@ function makeLoggerMethod(
       const filtered = [clientName, ...this.filter(...args)];
       const stringified = filtered.map((item) => {
         if (item instanceof Error) {
-          return item.toString();
+          return walkAndFilter(item.toString());
         }
         if (typeof item === 'object') {
           let cache = [];
@@ -684,6 +732,8 @@ levels.forEach((level) => {
  * @param {string} record.level log level
  * @param {string} record.message log message
  * @param {string} [record.eventName] event name
+ * @param {string} [record.eventId] event instance identifier
+ * @param {string} [record.eventIdPrefix] event identifier prefix
  * @param {Object} [record.attributes] scalar attributes
  * @private
  * @returns {void}
@@ -692,6 +742,8 @@ Logger.prototype.client_logRecord = function clientLogRecord({
   level,
   message,
   eventName,
+  eventId,
+  eventIdPrefix,
   attributes,
 }) {
   if (!levels.includes(level)) {
@@ -701,7 +753,26 @@ Logger.prototype.client_logRecord = function clientLogRecord({
     throw new TypeError('Structured log message must be a string');
   }
 
-  structuredClientMethods[level].call(this, {message, eventName, attributes});
+  if (eventName !== undefined && !isValidEventName(eventName)) {
+    throw new TypeError(`Invalid event name: ${eventName}`);
+  }
+  if (eventId !== undefined && !isValidEventId(eventId)) {
+    throw new TypeError(`Invalid event ID: ${eventId}`);
+  }
+  if (eventIdPrefix !== undefined && !isValidEventIdPrefix(eventIdPrefix)) {
+    throw new TypeError(`Invalid event ID prefix: ${eventIdPrefix}`);
+  }
+  if ((eventId || eventIdPrefix) && !eventName) {
+    throw new TypeError('Structured event identifier requires an event name');
+  }
+
+  structuredClientMethods[level].call(this, {
+    message,
+    eventName,
+    eventId,
+    eventIdPrefix,
+    attributes,
+  });
 };
 
 Logger.prototype.client_logToBuffer = makeLoggerMethod(

--- a/packages/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/@webex/plugin-logger/test/unit/spec/logger.js
@@ -7,7 +7,19 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import {browserOnly, nodeOnly, inBrowser} from '@webex/test-helper-mocha';
-import Logger, {levels, openTelemetryLogFormatter} from '@webex/plugin-logger';
+import Logger, {
+  createEventId,
+  EVENT_INITIATOR_TYPES,
+  EVENT_TRIGGER_TYPES,
+  getEventIdPrefix,
+  isValidEventId,
+  isValidOpenTelemetrySpanId,
+  isValidOpenTelemetryTraceId,
+  levels,
+  LOG_ATTRIBUTE_KEYS,
+  logRecordSchema,
+  openTelemetryLogFormatter,
+} from '@webex/plugin-logger';
 import {WebexHttpError} from '@webex/webex-core';
 
 describe('plugin-logger', () => {
@@ -756,17 +768,27 @@ describe('plugin-logger', () => {
         level: 'info',
         message: 'meeting joined',
         eventName: 'meeting.join',
+        eventIdPrefix: 'joinMeeting',
         attributes: {
           'webex.module': 'meeting',
           'code.line.number': 42,
           successful: true,
+          [LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE]: EVENT_INITIATOR_TYPES.USER,
+          [LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE]: EVENT_TRIGGER_TYPES.UI,
+          [LOG_ATTRIBUTE_KEYS.OPERATION_ID]: 'joinMeeting_00000000-0000-4000-8000-000000000001',
           email: 'person@example.com',
           Authorization: 'Basic secret',
           nested: {ignored: true},
+          invalidNumber: Number.NaN,
+          'webex.logger.type': 'overridden',
+          'webex.event.id': 'overridden',
         },
       });
 
-      assert.calledOnceWithExactly(write, {
+      assert.calledOnce(write);
+      const record = write.firstCall.args[0];
+
+      assert.deepInclude(record, {
         schemaVersion: 1,
         timestamp: 0,
         level: 'info',
@@ -778,10 +800,33 @@ describe('plugin-logger', () => {
           'webex.module': 'meeting',
           'code.line.number': 42,
           successful: true,
+          [LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE]: 'user',
+          [LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE]: 'ui',
+          [LOG_ATTRIBUTE_KEYS.OPERATION_ID]: 'joinMeeting_00000000-0000-4000-8000-000000000001',
           email: '[REDACTED]',
         },
       });
+      assert.match(record.eventId, /^joinMeeting_/);
+      assert.isTrue(isValidEventId(record.eventId));
+      assert.notProperty(record.attributes, 'invalidNumber');
+      assert.notProperty(record.attributes, 'webex.logger.type');
+      assert.notProperty(record.attributes, 'webex.event.id');
       assert.lengthOf(webex.logger.buffer.buffer, 0);
+    });
+
+    it('drops invalid taxonomy and readable operation identifiers', () => {
+      webex.logger.client_logRecord({
+        level: 'info',
+        message: 'invalid metadata',
+        attributes: {
+          [LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE]: 'browser',
+          [LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE]: 'fetch',
+          [LOG_ATTRIBUTE_KEYS.OPERATION_ID]: 'joinMeeting_trace',
+          retained: true,
+        },
+      });
+
+      assert.deepEqual(write.firstCall.args[0].attributes, {retained: true});
     });
 
     it('validates structured client records', () => {
@@ -790,7 +835,37 @@ describe('plugin-logger', () => {
         TypeError
       );
       assert.throws(() => webex.logger.client_logRecord({level: 'info', message: {}}), TypeError);
+      assert.throws(
+        () =>
+          webex.logger.client_logRecord({
+            level: 'info',
+            message: 'invalid event',
+            eventName: 'joinMeeting_123',
+          }),
+        TypeError
+      );
+      assert.throws(
+        () =>
+          webex.logger.client_logRecord({
+            level: 'info',
+            message: 'invalid identifier',
+            eventIdPrefix: 'joinMeeting',
+          }),
+        TypeError
+      );
       assert.notCalled(write);
+    });
+
+    it('redacts sensitive values embedded in Error messages before transport', () => {
+      webex.logger.error(
+        new Error('request failed for person@example.com with Bearer secret-token')
+      );
+
+      assert.calledOnce(write);
+      assert.equal(
+        write.firstCall.args[0].message,
+        'Error: request failed for [REDACTED] with Bearer [REDACTED]'
+      );
     });
   });
 
@@ -814,9 +889,11 @@ describe('plugin-logger', () => {
         name: 'web-client',
         message: 'meeting joined',
         eventName: 'meeting.join',
+        eventId: 'joinMeeting_00000000-0000-4000-8000-000000000001',
         attributes: {
           'webex.module': 'meeting',
           'code.line.number': 42,
+          'webex.logger.type': 'overridden',
         },
       });
 
@@ -831,6 +908,7 @@ describe('plugin-logger', () => {
           'webex.logger.schema_version': 1,
           'webex.logger.type': 'client',
           'webex.logger.name': 'web-client',
+          'webex.event.id': 'joinMeeting_00000000-0000-4000-8000-000000000001',
           'webex.module': 'meeting',
           'code.line.number': 42,
         },
@@ -849,6 +927,49 @@ describe('plugin-logger', () => {
 
       assert.equal(record.severityNumber, 9);
       assert.equal(record.severityText, 'UNKNOWN');
+    });
+  });
+
+  describe('structured log schema', () => {
+    it('publishes a closed versioned canonical record schema', () => {
+      assert.equal(logRecordSchema.$id, 'https://webex.com/schemas/logger/log-record-v1.json');
+      assert.isFalse(logRecordSchema.additionalProperties);
+      assert.includeMembers(logRecordSchema.required, [
+        'schemaVersion',
+        'timestamp',
+        'level',
+        'type',
+        'name',
+        'message',
+      ]);
+      assert.equal(logRecordSchema.properties.attributes.maxProperties, 128);
+      assert.deepEqual(
+        logRecordSchema.properties.attributes.properties[LOG_ATTRIBUTE_KEYS.EVENT_INITIATOR_TYPE]
+          .enum,
+        Object.values(EVENT_INITIATOR_TYPES)
+      );
+      assert.deepEqual(
+        logRecordSchema.properties.attributes.properties[LOG_ATTRIBUTE_KEYS.EVENT_TRIGGER_TYPE]
+          .enum,
+        Object.values(EVENT_TRIGGER_TYPES)
+      );
+    });
+
+    it('creates readable event instance IDs from stable event names or explicit prefixes', () => {
+      assert.equal(getEventIdPrefix('webex.meeting.join'), 'meetingJoin');
+      assert.equal(getEventIdPrefix('webex.meeting.media_connected'), 'meetingMediaConnected');
+
+      const eventId = createEventId('joinMeeting');
+
+      assert.match(eventId, /^joinMeeting_/);
+      assert.isTrue(isValidEventId(eventId));
+    });
+
+    it('validates OpenTelemetry trace and span identifiers without changing their format', () => {
+      assert.isTrue(isValidOpenTelemetryTraceId('4bf92f3577b34da6a3ce929d0e0e4736'));
+      assert.isTrue(isValidOpenTelemetrySpanId('00f067aa0ba902b7'));
+      assert.isFalse(isValidOpenTelemetryTraceId('joinMeeting_trace'));
+      assert.isFalse(isValidOpenTelemetrySpanId('0000000000000000'));
     });
   });
 

--- a/packages/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/@webex/plugin-logger/test/unit/spec/logger.js
@@ -7,7 +7,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import {browserOnly, nodeOnly, inBrowser} from '@webex/test-helper-mocha';
-import Logger, {levels} from '@webex/plugin-logger';
+import Logger, {levels, openTelemetryLogFormatter} from '@webex/plugin-logger';
 import {WebexHttpError} from '@webex/webex-core';
 
 describe('plugin-logger', () => {
@@ -83,20 +83,20 @@ describe('plugin-logger', () => {
     it('stores the specified message in the log buffer', () => {
       webex.logger.log('test');
       assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.match(webex.logger.buffer.buffer[0][3], /test/);
+      assert.match(webex.logger.buffer.buffer[0].record.message, /test/);
     });
 
     it('adds the date to the beggining of the buffer entry', () => {
       webex.logger.log('test date');
 
       // Convert string back to date object
-      const logDate = new Date(webex.logger.buffer.buffer[0][1]);
+      const logDate = new Date(webex.logger.buffer.buffer[0].record.timestamp);
 
-      // eslint-disable-next-line no-restricted-globals
-      assert.isTrue(logDate instanceof Date && isNaN(webex.logger.buffer.buffer[0][1]));
-      assert.isString(webex.logger.buffer.buffer[0][0]);
-      assert.isString(webex.logger.buffer.buffer[0][1]);
-      assert.match(webex.logger.buffer.buffer[0][3], /test date/);
+      assert.isTrue(logDate instanceof Date && !Number.isNaN(logDate.getTime()));
+      assert.isNumber(webex.logger.buffer.buffer[0].record.timestamp);
+      assert.isString(webex.logger.buffer.buffer[0].legacyLine[0]);
+      assert.isString(webex.logger.buffer.buffer[0].legacyLine[1]);
+      assert.match(webex.logger.buffer.buffer[0].record.message, /test date/);
     });
 
     it('stores the specified message in the client and sdk log buffer', () => {
@@ -105,15 +105,15 @@ describe('plugin-logger', () => {
       webex.logger.log('testsdk');
       webex.logger.client_log('testclient');
       assert.lengthOf(webex.logger.sdkBuffer.buffer, 1);
-      assert.isString(webex.logger.sdkBuffer.buffer[0][0]);
-      assert.isString(webex.logger.sdkBuffer.buffer[0][1]);
-      assert.match(webex.logger.sdkBuffer.buffer[0][2], /wx-js-sdk/);
-      assert.match(webex.logger.sdkBuffer.buffer[0][3], /testsdk/);
+      assert.isString(webex.logger.sdkBuffer.buffer[0].legacyLine[0]);
+      assert.isString(webex.logger.sdkBuffer.buffer[0].legacyLine[1]);
+      assert.match(webex.logger.sdkBuffer.buffer[0].record.name, /wx-js-sdk/);
+      assert.match(webex.logger.sdkBuffer.buffer[0].record.message, /testsdk/);
       assert.lengthOf(webex.logger.clientBuffer.buffer, 1);
-      assert.isString(webex.logger.clientBuffer.buffer[0][0]);
-      assert.isString(webex.logger.clientBuffer.buffer[0][1]);
-      assert.match(webex.logger.clientBuffer.buffer[0][2], /someclient/);
-      assert.match(webex.logger.clientBuffer.buffer[0][3], /testclient/);
+      assert.isString(webex.logger.clientBuffer.buffer[0].legacyLine[0]);
+      assert.isString(webex.logger.clientBuffer.buffer[0].legacyLine[1]);
+      assert.match(webex.logger.clientBuffer.buffer[0].record.name, /someclient/);
+      assert.match(webex.logger.clientBuffer.buffer[0].record.message, /testclient/);
     });
 
     it('prevents the buffer from overflowing', () => {
@@ -124,8 +124,8 @@ describe('plugin-logger', () => {
       assert.lengthOf(webex.logger.buffer.buffer, 2);
       webex.logger.log(3);
       assert.lengthOf(webex.logger.buffer.buffer, 2);
-      assert.equal(webex.logger.buffer.buffer[0][3], 2);
-      assert.equal(webex.logger.buffer.buffer[1][3], 3);
+      assert.equal(webex.logger.buffer.buffer[0].record.message, '2');
+      assert.equal(webex.logger.buffer.buffer[1].record.message, '3');
     });
 
     it('adjusts lastSubmitted when buffer overflows in single buffer mode', () => {
@@ -206,10 +206,10 @@ describe('plugin-logger', () => {
       webex.logger.client_log(1);
       assert.lengthOf(webex.logger.sdkBuffer.buffer, 2);
       assert.lengthOf(webex.logger.clientBuffer.buffer, 2);
-      assert.equal(webex.logger.sdkBuffer.buffer[0][3], 2);
-      assert.equal(webex.logger.sdkBuffer.buffer[1][3], 3);
-      assert.equal(webex.logger.sdkBuffer.buffer[0][3], 2);
-      assert.equal(webex.logger.clientBuffer.buffer[1][3], 1);
+      assert.equal(webex.logger.sdkBuffer.buffer[0].record.message, '2');
+      assert.equal(webex.logger.sdkBuffer.buffer[1].record.message, '3');
+      assert.equal(webex.logger.clientBuffer.buffer[0].record.message, '2');
+      assert.equal(webex.logger.clientBuffer.buffer[1].record.message, '1');
     });
 
     // Node handles custom errors correctly, so this test is browser specific
@@ -246,7 +246,7 @@ describe('plugin-logger', () => {
 
       webex.logger.log(error);
       assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.match(webex.logger.buffer.buffer[0][3], /WebexHttpError/g);
+      assert.match(webex.logger.buffer.buffer[0].record.message, /WebexHttpError/g);
     });
 
     it('formats objects as strings passed to the logger for readability not [Object object]', async () => {
@@ -264,12 +264,12 @@ describe('plugin-logger', () => {
 
       webex.logger.log('foo', 'bar', obj);
       assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.lengthOf(webex.logger.buffer.buffer[0], 6);
-      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'foo');
-      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'bar');
+      assert.lengthOf(webex.logger.buffer.buffer[0].legacyLine, 6);
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[3], 'foo');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[4], 'bar');
       assert.deepEqual(
-        webex.logger.buffer.buffer[0][5],
+        webex.logger.buffer.buffer[0].legacyLine[5],
         '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}'
       );
     });
@@ -291,12 +291,12 @@ describe('plugin-logger', () => {
 
       webex.logger.log('foo', 'bar', obj);
       assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.lengthOf(webex.logger.buffer.buffer[0], 6);
-      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'foo');
-      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'bar');
+      assert.lengthOf(webex.logger.buffer.buffer[0].legacyLine, 6);
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[3], 'foo');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[4], 'bar');
       assert.deepEqual(
-        webex.logger.buffer.buffer[0][5],
+        webex.logger.buffer.buffer[0].legacyLine[5],
         '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}'
       );
     });
@@ -307,9 +307,12 @@ describe('plugin-logger', () => {
 
       webex.logger.log('I got this error:', err);
       assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'I got this error:');
-      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'Error: fake error for testing');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0].legacyLine[3], 'I got this error:');
+      assert.deepEqual(
+        webex.logger.buffer.buffer[0].legacyLine[4],
+        'Error: fake error for testing'
+      );
     });
   });
 
@@ -631,21 +634,21 @@ describe('plugin-logger', () => {
     });
   });
 
-  describe('configured transport', () => {
+  describe('configured transports', () => {
     let clock;
     let write;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();
       write = sinon.spy();
-      webex.logger.config.transport = {write};
+      webex.logger.config.transports = [{write}];
     });
 
     afterEach(() => {
       clock.restore();
     });
 
-    it('receives SDK and client records admitted to the existing buffer', () => {
+    it('replaces console and buffer output with the configured transports', () => {
       webex.logger.info('sdk message', {attempt: 1});
       clock.tick(1000);
       webex.logger.client_warn('client message');
@@ -667,36 +670,86 @@ describe('plugin-logger', () => {
         name: 'client',
         message: 'client message',
       });
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+      assert.notCalled(console.info);
+      assert.notCalled(console.warn);
     });
 
-    it('does not receive records rejected by the existing buffer level', () => {
+    it('does not receive records rejected by the non-console log level', () => {
       webex.logger.config.level = 'trace';
       webex.logger.config.bufferLogLevel = 'info';
 
-      webex.logger.debug('print only');
+      webex.logger.debug('filtered');
 
-      assert.calledOnce(console.debug);
+      assert.notCalled(console.debug);
       assert.notCalled(write);
       assert.lengthOf(webex.logger.buffer.buffer, 0);
     });
 
-    it('does not affect the existing buffer when the transport throws', () => {
-      webex.logger.config.transport.write = sinon.stub().throws(new Error('transport failed'));
+    it('continues to later transports when one throws', () => {
+      const secondWrite = sinon.spy();
 
-      assert.doesNotThrow(() => webex.logger.info('still buffered'));
-      assert.lengthOf(webex.logger.buffer.buffer, 1);
-      assert.equal(webex.logger.buffer.buffer[0][3], 'still buffered');
-      assert.equal(webex.logger.buffer.nextIndex, 0);
+      webex.logger.config.transports = [
+        {write: sinon.stub().throws(new Error('transport failed'))},
+        {write: secondWrite},
+      ];
+
+      assert.doesNotThrow(() => webex.logger.info('still delivered'));
+      assert.calledOnce(secondWrite);
+      assert.equal(secondWrite.firstCall.args[0].message, 'still delivered');
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
     });
 
-    it('ignores missing or invalid transports', () => {
-      webex.logger.config.transport = {};
+    it('ignores invalid entries in the configured transport array', () => {
+      webex.logger.config.transports = [{}];
 
-      assert.doesNotThrow(() => webex.logger.info('still buffered'));
-      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.doesNotThrow(() => webex.logger.info('discarded'));
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+      assert.notCalled(console.info);
     });
 
-    it('preserves structured client metadata without changing the legacy buffer message', () => {
+    it('uses an empty transport array to discard logs', () => {
+      webex.logger.config.transports = [];
+
+      webex.logger.info('discarded');
+
+      assert.notCalled(write);
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+      assert.notCalled(console.info);
+    });
+
+    it('routes logToBuffer calls to the configured transports without buffering', () => {
+      webex.logger.logToBuffer('forced');
+
+      assert.calledOnce(write);
+      assert.equal(write.firstCall.args[0].message, 'forced');
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+      assert.notCalled(console.info);
+    });
+
+    it('applies the formatter once before delivering to every transport', () => {
+      const secondWrite = sinon.spy();
+      const formatter = sinon.spy((record) => ({body: record.message}));
+
+      webex.logger.config.formatter = formatter;
+      webex.logger.config.transports = [{write}, {write: secondWrite}];
+
+      webex.logger.info('formatted');
+
+      assert.calledOnce(formatter);
+      assert.calledOnceWithExactly(write, {body: 'formatted'});
+      assert.calledOnceWithExactly(secondWrite, {body: 'formatted'});
+    });
+
+    it('does not deliver when the formatter throws', () => {
+      webex.logger.config.formatter = sinon.stub().throws(new Error('formatter failed'));
+
+      assert.doesNotThrow(() => webex.logger.info('discarded'));
+      assert.notCalled(write);
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+    });
+
+    it('preserves structured client metadata for the configured transport', () => {
       webex.logger.config.clientName = 'web-client';
 
       webex.logger.client_logRecord({
@@ -728,7 +781,7 @@ describe('plugin-logger', () => {
           email: '[REDACTED]',
         },
       });
-      assert.equal(webex.logger.buffer.buffer[0][3], 'meeting joined');
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
     });
 
     it('validates structured client records', () => {
@@ -738,6 +791,64 @@ describe('plugin-logger', () => {
       );
       assert.throws(() => webex.logger.client_logRecord({level: 'info', message: {}}), TypeError);
       assert.notCalled(write);
+    });
+  });
+
+  describe('OpenTelemetry formatter', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('maps the SDK structure to an OpenTelemetry-compatible record', () => {
+      const record = openTelemetryLogFormatter({
+        schemaVersion: 1,
+        timestamp: 0,
+        level: 'warn',
+        type: 'client',
+        name: 'web-client',
+        message: 'meeting joined',
+        eventName: 'meeting.join',
+        attributes: {
+          'webex.module': 'meeting',
+          'code.line.number': 42,
+        },
+      });
+
+      assert.deepEqual(record, {
+        timestamp: new Date(0),
+        observedTimestamp: new Date(0),
+        severityNumber: 13,
+        severityText: 'WARN',
+        body: 'meeting joined',
+        eventName: 'meeting.join',
+        attributes: {
+          'webex.logger.schema_version': 1,
+          'webex.logger.type': 'client',
+          'webex.logger.name': 'web-client',
+          'webex.module': 'meeting',
+          'code.line.number': 42,
+        },
+      });
+    });
+
+    it('uses the OpenTelemetry info severity for unknown levels', () => {
+      const record = openTelemetryLogFormatter({
+        schemaVersion: 1,
+        timestamp: 0,
+        level: 'unknown',
+        type: 'sdk',
+        name: 'wx-js-sdk',
+        message: 'fallback',
+      });
+
+      assert.equal(record.severityNumber, 9);
+      assert.equal(record.severityText, 'UNKNOWN');
     });
   });
 
@@ -1426,7 +1537,7 @@ describe('plugin-logger', () => {
   });
   describe('limit', () => {
     function logMessages() {
-      return webex.logger.buffer.buffer.map((item) => item[3]);
+      return webex.logger.buffer.buffer.map((item) => Number(item.record.message));
     }
 
     it('can be increased in runtime', () => {

--- a/packages/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/@webex/plugin-logger/test/unit/spec/logger.js
@@ -631,6 +631,116 @@ describe('plugin-logger', () => {
     });
   });
 
+  describe('configured transport', () => {
+    let clock;
+    let write;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      write = sinon.spy();
+      webex.logger.config.transport = {write};
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('receives SDK and client records admitted to the existing buffer', () => {
+      webex.logger.info('sdk message', {attempt: 1});
+      clock.tick(1000);
+      webex.logger.client_warn('client message');
+
+      assert.calledTwice(write);
+      assert.deepEqual(write.firstCall.args[0], {
+        schemaVersion: 1,
+        timestamp: 0,
+        level: 'info',
+        type: 'sdk',
+        name: 'wx-js-sdk',
+        message: 'sdk message {"attempt":1}',
+      });
+      assert.deepEqual(write.secondCall.args[0], {
+        schemaVersion: 1,
+        timestamp: 1000,
+        level: 'warn',
+        type: 'client',
+        name: 'client',
+        message: 'client message',
+      });
+    });
+
+    it('does not receive records rejected by the existing buffer level', () => {
+      webex.logger.config.level = 'trace';
+      webex.logger.config.bufferLogLevel = 'info';
+
+      webex.logger.debug('print only');
+
+      assert.calledOnce(console.debug);
+      assert.notCalled(write);
+      assert.lengthOf(webex.logger.buffer.buffer, 0);
+    });
+
+    it('does not affect the existing buffer when the transport throws', () => {
+      webex.logger.config.transport.write = sinon.stub().throws(new Error('transport failed'));
+
+      assert.doesNotThrow(() => webex.logger.info('still buffered'));
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.equal(webex.logger.buffer.buffer[0][3], 'still buffered');
+      assert.equal(webex.logger.buffer.nextIndex, 0);
+    });
+
+    it('ignores missing or invalid transports', () => {
+      webex.logger.config.transport = {};
+
+      assert.doesNotThrow(() => webex.logger.info('still buffered'));
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+    });
+
+    it('preserves structured client metadata without changing the legacy buffer message', () => {
+      webex.logger.config.clientName = 'web-client';
+
+      webex.logger.client_logRecord({
+        level: 'info',
+        message: 'meeting joined',
+        eventName: 'meeting.join',
+        attributes: {
+          'webex.module': 'meeting',
+          'code.line.number': 42,
+          successful: true,
+          email: 'person@example.com',
+          Authorization: 'Basic secret',
+          nested: {ignored: true},
+        },
+      });
+
+      assert.calledOnceWithExactly(write, {
+        schemaVersion: 1,
+        timestamp: 0,
+        level: 'info',
+        type: 'client',
+        name: 'web-client',
+        message: 'meeting joined',
+        eventName: 'meeting.join',
+        attributes: {
+          'webex.module': 'meeting',
+          'code.line.number': 42,
+          successful: true,
+          email: '[REDACTED]',
+        },
+      });
+      assert.equal(webex.logger.buffer.buffer[0][3], 'meeting joined');
+    });
+
+    it('validates structured client records', () => {
+      assert.throws(
+        () => webex.logger.client_logRecord({level: 'verbose', message: 'invalid'}),
+        TypeError
+      );
+      assert.throws(() => webex.logger.client_logRecord({level: 'info', message: {}}), TypeError);
+      assert.notCalled(write);
+    });
+  });
+
   describe('#filter', () => {
     it('redacts email addresses', () => {
       const message = {


### PR DESCRIPTION
# COMPLETES # N/A - proof of concept for configurable SDK log pipelines

## This pull request addresses

The Web Client needs to route SDK logs through its own OpenTelemetry runtime without making OpenTelemetry a dependency or default behavior of `webex-js-sdk`. The SDK should own the stable record contract, formatting boundary, and configurable transport fanout while preserving its existing console and buffered upload behavior by default.

## by making the following changes

- Stores a versioned, redacted structured record alongside the existing legacy log representation.
- Publishes a closed `logRecordSchema` v1 contract, shared attribute keys, controlled initiator and trigger taxonomies, and a 128-attribute limit.
- Generates readable event and operation instance IDs such as `joinMeeting_<uuid>`.
- Validates native OpenTelemetry identifiers without changing their required format:
  - trace IDs remain 32 lowercase hexadecimal characters
  - span IDs remain 16 lowercase hexadecimal characters
- Adds optional `logger.formatter(record)` and `logger.transports[].write(record)` contracts.
- Treats an explicit transport array as the complete output configuration:
  - omitted `transports` preserves the existing SDK console and buffer defaults
  - `[transport]` sends admitted records only to that transport
  - `[]` intentionally discards admitted records
- Formats each record once before fanout and isolates formatter or transport failures from SDK operation.
- Exports an OpenTelemetry-compatible formatter without importing the OpenTelemetry runtime.
- Preserves the existing `formatLogs()` and incremental `submitLogs` serialization when custom transports are omitted.
- Keeps the structured client-log entry point internal to the logger plugin for named events, event IDs, and scalar attributes.
- Redacts Basic/Bearer credentials and existing sensitive patterns before records reach any transport.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/plugin-logger test:unit` - 79 tests passed.
- `yarn workspace @webex/internal-plugin-support test:unit` - 43 tests passed on the earlier transport increment, covering legacy log submission compatibility.
- `yarn workspace @webex/plugin-logger build` - package built successfully for local `SDK_DIR` integration.
- `yarn workspace @webex/plugin-logger test:style` - no errors; 8 existing JSDoc warnings.
- Targeted Prettier checks passed for every changed file.
- Verified default behavior, one or multiple transports, an empty transport array, log-level admission, formatter-once fanout, formatter failures, transport failures, `logToBuffer`, legacy full/diff serialization, structured schema fields, taxonomy validation, attribute limits, readable event/operation IDs, strict native trace/span ID validation, and credential redaction.
- Linked this branch into `webex-web-client` through `SDK_DIR`.
- Playwright positive case passed with logs and traces enabled, validating the SDK transport, official batch pipelines, OTLP envelopes, Basic Auth header construction, native trace/span IDs, readable event/operation IDs, shared log-span correlation, and clock/taxonomy metadata.
- Playwright negative case passed with logs and traces disabled, validating zero collector requests and preservation of the existing SDK log buffer.
- Earlier manual integration validation sent linked-app log and trace batches directly to the integration collector with HTTP 200 responses and no CORS errors.

## POC boundaries and production follow-ups

- OpenTelemetry remains application-owned and opt-in; this SDK package does not add an OpenTelemetry runtime, provider, processor, exporter, endpoint, or credential.
- Schema evolution needs an owner, compatibility policy, generated documentation, and backend contract tests before v1 is treated as permanent.
- High-cardinality IDs must remain searchable attributes rather than default indexed dimensions; event and span names must remain stable and low-cardinality.
- Attribute value length limits, PII classification, retention, and backend index allowlists still need agreement with the collector/storage owners.
- Async transport backpressure and delivery guarantees belong to each transport implementation. The SDK deliberately does not add a second queue on top of the OpenTelemetry batch processor.

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Codex
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new targeted tests passed
- [x] I have updated the configuration and schema documentation accordingly

---
> ⚠️ AI Assisted Content 🤖
