### PR TITLE
fix: added sendslot manager reset to Meeting.createMediaConnection

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8301,6 +8301,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this.mediaProperties.mediaDirection.receiveShare,
       ];
 
+      this.sendSlotManager.reset();
       this.sendSlotManager.createSlot(mc, MediaType.VideoMain, videoEnabled);
       this.sendSlotManager.createSlot(mc, MediaType.AudioMain, audioEnabled);
       this.sendSlotManager.createSlot(mc, MediaType.VideoSlides, shareEnabled);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4264,6 +4264,7 @@ describe('plugin-meetings', () => {
             unpublishStream: sinon.stub(),
             setNamedMediaGroups: sinon.stub(),
           });
+          sinon.spy(meeting.sendSlotManager, 'reset');
 
           await meeting.addMedia({
             allowMediaInLobby: true,
@@ -4276,6 +4277,7 @@ describe('plugin-meetings', () => {
             },
           });
 
+          assert.calledOnce(meeting.sendSlotManager.reset);
           assert.notCalled(publishStreamStub);
         });
 
@@ -4299,6 +4301,7 @@ describe('plugin-meetings', () => {
             }
             return videoSlot;
           });
+          sinon.spy(meeting.sendSlotManager, 'reset');
 
           await meeting.addMedia({
             allowMediaInLobby: true,
@@ -4311,6 +4314,7 @@ describe('plugin-meetings', () => {
             },
           });
 
+          assert.calledOnce(meeting.sendSlotManager.reset);
           assert.calledOnceWithExactly(audioSlot.publishStream, fakeMicrophoneStream);
           assert.calledOnceWithExactly(videoSlot.publishStream, fakeCameraStream);
         });
@@ -4333,11 +4337,13 @@ describe('plugin-meetings', () => {
 
           meeting.meetingState = 'ACTIVE';
           meeting.isMultistream = true;
+          sinon.spy(meeting.sendSlotManager, 'reset');
 
           await meeting.addMedia({
             mediaSettings: {},
           });
 
+          assert.calledOnce(meeting.sendSlotManager.reset);
           // check that rtcMetrics was passed to Media.createMediaConnection
           assert.calledOnce(Media.createMediaConnection);
           assert.calledWith(


### PR DESCRIPTION
# COMPLETES #

## This pull request addresses
I've seen a log where addMedia failed beacause there were some sendslots still there from a previous addMedia attempt - correlationId=8f48a0b0-5bb3-475f-96d4-78dbd6ca7e6b

## by making the following changes
Added reset of send slot manager in Meeting.createMediaConnection() before creating slots as the slots are valid only for a specific media connection and we're creating a new media connection in Meeting.createMediaConnection() so it's safe to always reset it.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
