### PR TITLE
fix: get accurate localSDPGenRemoteSDPRecv not affected by timeout

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7543,14 +7543,21 @@ export default class Meeting extends StatelessWebexPlugin {
         // @ts-ignore
         const cdl = this.webex.internal.newMetrics.callDiagnosticLatencies;
 
-        // Save the remote-sdp-received timestamp before submitting the client event so we can
-        // calculate and include localSDPGenRemoteSDPRecv in the client event payload
-        cdl.saveTimestamp({
-          key: 'client.media-engine.remote-sdp-received',
-          options: {meetingId: this.id},
-        });
-
-        const localSDPGenRemoteSDPRecv = cdl.getLocalSDPGenRemoteSDPRecv();
+        // Compute the offer->answer latency from when the local SDP offer was generated up to now,
+        // rather than from the stored remote-sdp-received timestamp. That stored timestamp uses
+        // saveFirstTimestampOnly, so if waitForRemoteSDPAnswer() already timed out and submitted a
+        // remote-sdp-received event, the stored value would be pinned to the timeout time and would
+        // under-report an answer that arrives late. This handler fires exactly when the answer is
+        // processed, so Date.now() is the accurate "received" time.
+        // (submitClientEvent below still records the remote-sdp-received timestamp used by the CA
+        // join-time metric, so we don't need to save it here.)
+        const localSdpGeneratedTimestamp = cdl.latencyTimestamps.get(
+          'client.media-engine.local-sdp-generated'
+        );
+        const localSDPGenRemoteSDPRecv =
+          localSdpGeneratedTimestamp !== undefined
+            ? Date.now() - localSdpGeneratedTimestamp
+            : undefined;
 
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({
@@ -7561,11 +7568,6 @@ export default class Meeting extends StatelessWebexPlugin {
             },
           },
           options: {meetingId: this.id},
-        });
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ROAP_OFFER_TO_ANSWER_LATENCY, {
-          correlation_id: this.correlationId,
-          latency: localSDPGenRemoteSDPRecv,
-          meetingId: this.id,
         });
 
         if (this.deferSDPAnswer) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2082,8 +2082,16 @@ describe('plugin-meetings', () => {
         [
           {description: '409 error from join()', statusCode: 409, useCause: false},
           {description: '403 error from join()', statusCode: 403, useCause: false},
-          {description: '409 error in cause (e.g. AddMediaFailed)', statusCode: 409, useCause: true},
-          {description: '403 error in cause (e.g. AddMediaFailed)', statusCode: 403, useCause: true},
+          {
+            description: '409 error in cause (e.g. AddMediaFailed)',
+            statusCode: 409,
+            useCause: true,
+          },
+          {
+            description: '403 error in cause (e.g. AddMediaFailed)',
+            statusCode: 403,
+            useCause: true,
+          },
         ].forEach(({description, statusCode, useCause}) => {
           it(`should re-join on retry when ${description}`, async () => {
             const error = useCause
@@ -2099,7 +2107,11 @@ describe('plugin-meetings', () => {
 
             const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
 
-            assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+            assert.deepEqual(result, {
+              join: fakeJoinResult,
+              media: test4,
+              multistreamEnabled: true,
+            });
 
             // join() should be called twice — once for the first attempt, once for the re-join
             assert.calledTwice(meeting.join);
@@ -2114,9 +2126,7 @@ describe('plugin-meetings', () => {
           meeting.join = sinon.stub().callsFake(() => Promise.resolve(fakeJoinResult));
           sinon.stub(meeting, 'leave').resolves();
 
-          await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions})
-          );
+          await assert.isRejected(meeting.joinWithMedia({joinOptions, mediaOptions}));
 
           // JOIN_WITH_MEDIA_RETRY_MAX_COUNT is 2, so we expect 3 attempts total (initial + 2 retries)
           assert.callCount(meeting.join, 3);
@@ -11684,6 +11694,8 @@ describe('plugin-meetings', () => {
           });
 
           it('handles REMOTE_SDP_ANSWER_PROCESSED correctly', () => {
+            // capture the start timestamp before any fake timers are installed
+            const localSdpGeneratedTimestamp = Date.now() - 100;
             const clock = sinon.useFakeTimers();
             sinon.spy(clock, 'clearTimeout');
             meeting.deferSDPAnswer = {
@@ -11691,54 +11703,56 @@ describe('plugin-meetings', () => {
             };
             meeting.sdpResponseTimer = '1234';
 
-            webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
-            webex.internal.newMetrics.callDiagnosticLatencies.getLocalSDPGenRemoteSDPRecv = sinon
-              .stub()
-              .returns(100);
+            // latency is computed as Date.now() - the stored local-sdp-generated timestamp,
+            // so it is unaffected by any earlier remote-sdp-received timestamp saved on timeout
+            webex.internal.newMetrics.callDiagnosticLatencies.latencyTimestamps = new Map([
+              ['client.media-engine.local-sdp-generated', localSdpGeneratedTimestamp],
+            ]);
 
             eventListeners[MediaConnectionEventNames.REMOTE_SDP_ANSWER_PROCESSED]();
-
-            // the remote-sdp-received timestamp must be saved before the latency is computed
-            // so that getLocalSDPGenRemoteSDPRecv() has an end timestamp to use
-            assert.calledOnceWithExactly(
-              webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp,
-              {
-                key: 'client.media-engine.remote-sdp-received',
-                options: {meetingId: meeting.id},
-              }
-            );
-            assert(
-              webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp.calledBefore(
-                webex.internal.newMetrics.callDiagnosticLatencies.getLocalSDPGenRemoteSDPRecv
-              )
-            );
 
             assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
             assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
               name: 'client.media-engine.remote-sdp-received',
               payload: {
                 eventData: {
-                  localSDPGenRemoteSDPRecv: 100,
+                  localSDPGenRemoteSDPRecv: sinon.match(
+                    (value) => typeof value === 'number' && value >= 100 && value < 5000
+                  ),
                 },
               },
               options: {meetingId: meeting.id},
             });
 
-            assert.calledOnce(Metrics.sendBehavioralMetric);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.ROAP_OFFER_TO_ANSWER_LATENCY,
-              {
-                correlation_id: meeting.correlationId,
-                meetingId: meeting.id,
-                latency: 100,
-              }
-            );
+            // the high-volume ROAP_OFFER_TO_ANSWER_LATENCY behavioral metric is no longer sent
+            assert.notCalled(Metrics.sendBehavioralMetric);
 
             assert.calledOnce(meeting.deferSDPAnswer.resolve);
             assert.calledOnce(clock.clearTimeout);
             assert.calledWith(clock.clearTimeout, '1234');
             assert.equal(meeting.sdpResponseTimer, undefined);
+          });
+
+          it('sends undefined localSDPGenRemoteSDPRecv when the local-sdp-generated timestamp is missing', () => {
+            meeting.deferSDPAnswer = {
+              resolve: sinon.stub(),
+            };
+
+            // no local-sdp-generated timestamp stored -> latency cannot be computed
+            webex.internal.newMetrics.callDiagnosticLatencies.latencyTimestamps = new Map();
+
+            eventListeners[MediaConnectionEventNames.REMOTE_SDP_ANSWER_PROCESSED]();
+
+            assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
+            assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
+              name: 'client.media-engine.remote-sdp-received',
+              payload: {
+                eventData: {
+                  localSDPGenRemoteSDPRecv: undefined,
+                },
+              },
+              options: {meetingId: meeting.id},
+            });
           });
 
           it('handles LOCAL_SDP_OFFER_GENERATED correctly', () => {
@@ -15561,11 +15575,7 @@ describe('plugin-meetings', () => {
           // Only the client whose /sync request tracking id matches the tracking id echoed back on
           // the top-level LLM event envelope records the LLM arrival; onLocusSyncLlmMessage is a
           // no-op otherwise.
-          assert.calledOnceWithExactly(
-            meeting.onLocusSyncLlmMessage,
-            meeting.id,
-            event.trackingId
-          );
+          assert.calledOnceWithExactly(meeting.onLocusSyncLlmMessage, meeting.id, event.trackingId);
         });
 
         it('does not attempt sync completion when the tracking id is missing', () => {
@@ -15584,7 +15594,6 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(meeting.locusInfo.parse, meeting, event.data);
           assert.notCalled(meeting.onLocusSyncLlmMessage);
         });
-
       });
 
       describe('#onLocusSyncLlmMessage', () => {
@@ -15631,11 +15640,7 @@ describe('plugin-meetings', () => {
             'meeting-1',
             'sync-tracking-id'
           );
-          assert.calledOnceWithExactly(
-            meeting.emitLocusSyncCompleteMetric,
-            'meeting-1',
-            completed
-          );
+          assert.calledOnceWithExactly(meeting.emitLocusSyncCompleteMetric, 'meeting-1', completed);
         });
 
         it('does not emit when completion returns undefined (only one milestone is in)', () => {
@@ -15659,13 +15664,10 @@ describe('plugin-meetings', () => {
           webex.internal.newMetrics.submitClientEvent.resetHistory();
           webex.internal.llm.getWebSocketUrl = sinon.stub().returns('wss://llm-websocket-url');
 
-          meeting.emitLocusSyncCompleteMetric(
-            'meeting-1',
-            {
-              dataSet: 'main',
-              syncLatency: {totalTime: 50},
-            }
-          );
+          meeting.emitLocusSyncCompleteMetric('meeting-1', {
+            dataSet: 'main',
+            syncLatency: {totalTime: 50},
+          });
 
           assert.calledOnceWithExactly(webex.internal.newMetrics.submitClientEvent, {
             name: 'client.locus.sync.complete',
@@ -15688,13 +15690,10 @@ describe('plugin-meetings', () => {
           webex.internal.newMetrics.submitClientEvent.resetHistory();
           webex.internal.llm.getWebSocketUrl = sinon.stub().returns(undefined);
 
-          meeting.emitLocusSyncCompleteMetric(
-            'meeting-1',
-            {
-              dataSet: 'main',
-              syncLatency: {totalTime: 50},
-            }
-          );
+          meeting.emitLocusSyncCompleteMetric('meeting-1', {
+            dataSet: 'main',
+            syncLatency: {totalTime: 50},
+          });
 
           assert.calledOnceWithExactly(webex.internal.newMetrics.submitClientEvent, {
             name: 'client.locus.sync.complete',


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-835771

## This pull request addresses
we send client.media-engine.remote-sdp-received on timeout, which affects the localSDPGenRemoteSDPRecv calculation

## by making the following changes
make the metric not dependant on the client.media-engine.remote-sdp-received event, instead using Date.now()

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
