### PR TITLE
fix(webinar): filter hash tree sync response to requested dataset

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1339,6 +1339,26 @@ class HashTreeParser {
   }
 
   /**
+   * Returns a copy of a hash tree message restricted to a single dataset, keeping only the
+   * requested dataset and the elements belonging to it. Used to strip out datasets that Locus
+   * may include in a sync response but that we didn't request (e.g. "unjoined" sharing elements
+   * with "main"), which would otherwise be applied once per dataset.
+   *
+   * @param {HashTreeMessage} message the sync response message
+   * @param {string} dataSetName the dataset that was requested
+   * @returns {HashTreeMessage} a new message containing only the requested dataset
+   */
+  private filterMessageToDataSet(message: HashTreeMessage, dataSetName: string): HashTreeMessage {
+    return {
+      ...message,
+      dataSets: message.dataSets?.filter((ds) => ds.name === dataSetName),
+      locusStateElements: message.locusStateElements?.filter((el) =>
+        el.htMeta.dataSetNames?.includes(dataSetName)
+      ),
+    };
+  }
+
+  /**
    * Performs a sync for the given data set.
    *
    * @param {InternalDataSet} dataSet - The data set to sync
@@ -1472,9 +1492,13 @@ class HashTreeParser {
         // misleading "aborting sync" message for this already-completed sync
         dataSet.syncAbortController = undefined;
 
+        // we only requested this dataset, so restrict the response to it before processing
+        // (Locus may include shared datasets like "unjoined" alongside "main")
+        const filteredResponse = this.filterMessageToDataSet(syncResponse, dataSet.name);
+
         // the format of sync response is the same as messages, so we can reuse the same handler
         this.handleMessage(
-          syncResponse,
+          filteredResponse,
           `via sync API (${
             isInitialization ? 'init' : `${Object.keys(leavesData).length} mismatched leaves`
           })`

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1349,6 +1349,26 @@ class HashTreeParser {
    * @returns {HashTreeMessage} a new message containing only the requested dataset
    */
   private filterMessageToDataSet(message: HashTreeMessage, dataSetName: string): HashTreeMessage {
+    const filteredOutDataSets = message.dataSets?.filter((ds) => ds.name !== dataSetName) ?? [];
+    const filteredOutElements =
+      message.locusStateElements?.filter((el) => !el.htMeta.dataSetNames?.includes(dataSetName)) ??
+      [];
+
+    if (filteredOutDataSets.length > 0 || filteredOutElements.length > 0) {
+      LoggerProxy.logger.info(
+        `HashTreeParser#filterMessageToDataSet --> ${
+          this.debugId
+        } keeping only dataset "${dataSetName}", filtering out datasets: [${filteredOutDataSets
+          .map((ds) => `${ds.name}:${ds.version}`)
+          .join(',')}], elements: [${filteredOutElements
+          .map(
+            (el) =>
+              `${el.htMeta?.elementId?.type}:${el.htMeta?.elementId?.id}:${el.htMeta?.elementId?.version}`
+          )
+          .join(',')}]`
+      );
+    }
+
     return {
       ...message,
       dataSets: message.dataSets?.filter((ds) => ds.name === dataSetName),

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1781,6 +1781,110 @@ describe('HashTreeParser', () => {
         });
       });
 
+      it('filters a "main" sync response down to the requested dataset, ignoring shared datasets like "unjoined"', async () => {
+        // Set up a parser where both "main" and "unjoined" are visible and share the core locus
+        // element (they always advance to the same version on the server).
+        const sharedInitialLocus = {
+          dataSets: [createDataSet('main', 16, 1000), createDataSet('unjoined', 16, 1000)],
+          locus: {
+            url: locusUrl,
+            htMeta: {
+              elementId: {type: 'locus', id: 0, version: 200},
+              dataSetNames: ['main', 'unjoined'],
+            },
+            links: {resources: {visibleDataSets: {url: visibleDataSetsUrl}}},
+            participants: [],
+          },
+        };
+        const sharedMetadata = {
+          htMeta: {elementId: {type: 'metadata', id: 5, version: 50}, dataSetNames: ['self']},
+          visibleDataSets: [
+            {name: 'main', url: `${locusUrl}/datasets/main`},
+            {name: 'unjoined', url: `${locusUrl}/datasets/unjoined`},
+          ],
+        };
+
+        const parser = createHashTreeParser(sharedInitialLocus, sharedMetadata);
+
+        // both datasets have their own hash tree, sharing the locus element
+        assert.exists(parser.dataSets.main.hashTree);
+        assert.exists(parser.dataSets.unjoined.hashTree);
+
+        // start the sync timer with a normal "main" message (mismatched root hash)
+        const message = {
+          dataSets: [{...createDataSet('main', 16, 1100), root: 'a'.repeat(32)}],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'locus' as const, id: 0, version: 201},
+                dataSetNames: ['main'],
+              },
+              data: {info: {id: 'initial-update'}},
+            },
+          ],
+        };
+        parser.handleMessage(message, 'initial message');
+        assert.calledOnce(callback);
+        callback.resetHistory();
+
+        const mainDataSetUrl = parser.dataSets.main.url;
+
+        mockGetHashesFromLocusResponse(
+          mainDataSetUrl,
+          new Array(16).fill('0'.repeat(32)),
+          createDataSet('main', 16, 1101)
+        );
+
+        // The sync response for "main" also carries the "unjoined" dataset, the shared locus
+        // element tagged with both datasets, and an "unjoined"-only element - all of which must
+        // be filtered out so that only the requested "main" data is processed.
+        const mainSyncDataSet = createDataSet('main', 16, 1101);
+        mainSyncDataSet.root = parser.dataSets.main.hashTree.getRootHash();
+        mockSendSyncRequestResponse(mainDataSetUrl, {
+          dataSets: [mainSyncDataSet, createDataSet('unjoined', 16, 1101)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'locus' as const, id: 0, version: 202},
+                dataSetNames: ['main', 'unjoined'],
+              },
+              data: {info: {id: 'synced-shared-locus'}},
+            },
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 99, version: 500},
+                dataSetNames: ['unjoined'],
+              },
+              data: {person: {name: 'unjoined-only'}},
+            },
+          ],
+        });
+
+        await clock.tickAsync(1000);
+
+        // the "unjoined" dataset info must NOT be updated from a "main" sync response
+        expect(parser.dataSets.unjoined.version).to.equal(1000);
+
+        // the shared locus element is reported exactly once (not once per dataset), and the
+        // "unjoined"-only element is not reported at all
+        assert.calledOnceWithExactly(callback, {
+          updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
+          updatedObjects: [
+            {
+              htMeta: {
+                elementId: {type: 'locus', id: 0, version: 202},
+                dataSetNames: ['main', 'unjoined'],
+              },
+              data: {info: {id: 'synced-shared-locus'}},
+            },
+          ],
+        });
+      });
+
       describe('emits MEETING_ENDED when 409/2403004 is returned', () => {
           it('when /hashtree returns 409', async () => {
             const parser = createHashTreeParser();

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -13,6 +13,7 @@ import testUtils from '@webex/plugin-meetings/test/utils/testUtils';
 import { some } from 'lodash';
 import Metrics from '@webex/plugin-meetings/src/metrics';
 import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
+import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 
 const visibleDataSetsUrl = 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/visibleDataSets';
 
@@ -159,6 +160,7 @@ describe('HashTreeParser', () => {
   let callback: sinon.SinonStub;
   let mathRandomStub: sinon.SinonStub;
   let metricsStub: sinon.SinonStub;
+  let loggerInfoStub: sinon.SinonStub;
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();
@@ -166,11 +168,13 @@ describe('HashTreeParser', () => {
     callback = sinon.stub();
     mathRandomStub = sinon.stub(Math, 'random').returns(0);
     metricsStub = sinon.stub(Metrics, 'sendBehavioralMetric');
+    loggerInfoStub = sinon.stub(LoggerProxy.logger, 'info');
   });
   afterEach(() => {
     clock.restore();
     mathRandomStub.restore();
     metricsStub.restore();
+    loggerInfoStub.restore();
   });
 
   // Helper to create a HashTreeParser instance with common defaults
@@ -1883,6 +1887,14 @@ describe('HashTreeParser', () => {
             },
           ],
         });
+
+        // the filtered-out dataset and element are logged
+        assert.calledWith(
+          loggerInfoStub,
+          sinon.match(
+            'keeping only dataset "main", filtering out datasets: [unjoined:1101], elements: [participant:99:500]'
+          )
+        );
       });
 
       describe('emits MEETING_ENDED when 409/2403004 is returned', () => {


### PR DESCRIPTION
A sync request is scoped to a single dataset, but Locus may include additional datasets in the response (e.g. "unjoined" shares core Locus elements with "main" and advances to the same version). Processing the response as-is applied the shared elements once per dataset, producing duplicate LOCUS objects and triggering the LOCUS_HASH_TREE_UNSUPPORTED_OPERATION metric.

Filter the sync response down to the requested dataset before processing.

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-841547

## This pull request addresses
filter the sync response data

## by making the following changes

When we send a sync request for the main dataset, the response may contain both the main and unjoin datasets. To ensure the data is processed correctly, we should first filter the returned datasets based on the requested dataset, and then process only the filtered results.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
