### PR TITLE
fix(webex-core): bound services readiness by startup deadline

### DIFF
--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -1366,23 +1366,29 @@ const Services = WebexPlugin.extend({
   },
 
   /**
-   * Await any in-flight credentials refresh, then flip `services.ready` so
-   * `webex.ready` can fire. Closes the parallel-refresh window: if a credential
-   * refresh is in flight when initial catalog collection settles, we must not
-   * signal ready until the refresh has resolved - otherwise downstream
-   * consumers may observe `canAuthorize`/token state that is about to change
-   * under them.
+   * Await any in-flight credentials refresh until the startup deadline, then
+   * flip `services.ready` so `webex.ready` can fire.
    *
    * @private
+   * @param {Promise<void>} [startupDeadline]
    * @returns {Promise<void>}
    */
-  async _finalizeReady(): Promise<void> {
+  async _finalizeReady(startupDeadline?: Promise<void>): Promise<void> {
     const {credentials} = this.webex;
 
     if (credentials && credentials.isRefreshing) {
-      await new Promise<void>((resolve) => {
-        credentials.once('change:isRefreshing', resolve);
+      let onChangeIsRefreshing = () => {};
+      const refreshSettled = new Promise<void>((resolve) => {
+        onChangeIsRefreshing = resolve;
+        credentials.once('change:isRefreshing', onChangeIsRefreshing);
+
+        if (!credentials.isRefreshing) {
+          resolve();
+        }
       });
+
+      await (startupDeadline ? Promise.race([refreshSettled, startupDeadline]) : refreshSettled);
+      credentials.off('change:isRefreshing', onChangeIsRefreshing);
     }
 
     this.ready = true;
@@ -1480,25 +1486,26 @@ const Services = WebexPlugin.extend({
     // catalogs. We listen for 'loaded' instead of 'ready' because `services.ready`
     // now blocks `webex.ready` - listening to 'ready' would deadlock.
     this.listenToOnce(this.webex, 'loaded', async () => {
+      const initTimeoutMs = this.webex.config?.services?.catalogInitTimeout;
+      let cancelStartupDeadline = () => {};
+      const startupDeadline = new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, initTimeoutMs);
+
+        cancelStartupDeadline = () => clearTimeout(timeout);
+      });
+      const finalizeReady = () =>
+        this._finalizeReady(startupDeadline).finally(cancelStartupDeadline);
+
       const warmed = await this._loadCatalogFromCache();
       if (warmed) {
         catalog.isReady = true;
-        await this._finalizeReady();
+        await finalizeReady();
 
         return;
       }
       const {supertoken} = this.webex.credentials;
-
-      // Race init against a hard timeout so a hung request never leaves
-      // `services.ready` false forever - that would stall `webex.ready` and
-      // leave consumers waiting on it indefinitely. Timeout is configurable via
-      // `config.services.catalogInitTimeout` (defaults to 15s in config).
-      const initTimeoutMs = this.webex.config?.services?.catalogInitTimeout;
-      const initServiceCatalogsTimeout = new Promise<never>((_, reject) => {
-        setTimeout(
-          () => reject(new Error(`services: init timed out after ${initTimeoutMs}ms`)),
-          initTimeoutMs
-        );
+      const initServiceCatalogsTimeout = startupDeadline.then(() => {
+        throw new Error(`services: init timed out after ${initTimeoutMs}ms`);
       });
 
       // Validate if the supertoken exists.
@@ -1513,7 +1520,7 @@ const Services = WebexPlugin.extend({
               `services: failed to init initial services when credentials available, ${error?.message}`
             );
           })
-          .finally(() => this._finalizeReady());
+          .finally(finalizeReady);
       } else {
         const {email} = this.webex.config;
 
@@ -1527,7 +1534,7 @@ const Services = WebexPlugin.extend({
               `services: failed to init initial services when no credentials available, ${error?.message}`
             );
           })
-          .finally(() => this._finalizeReady());
+          .finally(finalizeReady);
 
         // Handle fresh login: 'loaded' fires before OAuth completes, so listen
         // for `canAuthorize` flipping true and then collect the postauth catalog.

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -1396,23 +1396,29 @@ const Services = WebexPlugin.extend({
   },
 
   /**
-   * Await any in-flight credentials refresh, then flip `services.ready` so
-   * `webex.ready` can fire. Closes the parallel-refresh window: if a credential
-   * refresh is in flight when initial catalog collection settles, we must not
-   * signal ready until the refresh has resolved - otherwise downstream
-   * consumers may observe `canAuthorize`/token state that is about to change
-   * under them.
+   * Await any in-flight credentials refresh until the startup deadline, then
+   * flip `services.ready` so `webex.ready` can fire.
    *
    * @private
+   * @param {Promise<void>} [startupDeadline]
    * @returns {Promise<void>}
    */
-  async _finalizeReady() {
+  async _finalizeReady(startupDeadline) {
     const {credentials} = this.webex;
 
     if (credentials && credentials.isRefreshing) {
-      await new Promise((resolve) => {
-        credentials.once('change:isRefreshing', resolve);
+      let onChangeIsRefreshing = () => {};
+      const refreshSettled = new Promise((resolve) => {
+        onChangeIsRefreshing = resolve;
+        credentials.once('change:isRefreshing', onChangeIsRefreshing);
+
+        if (!credentials.isRefreshing) {
+          resolve();
+        }
       });
+
+      await (startupDeadline ? Promise.race([refreshSettled, startupDeadline]) : refreshSettled);
+      credentials.off('change:isRefreshing', onChangeIsRefreshing);
     }
 
     this.ready = true;
@@ -1517,26 +1523,26 @@ const Services = WebexPlugin.extend({
     // catalogs. We listen for 'loaded' instead of 'ready' because `services.ready`
     // now blocks `webex.ready` - listening to 'ready' would deadlock.
     this.listenToOnce(this.webex, 'loaded', async () => {
+      const initTimeoutMs = this.webex.config?.services?.catalogInitTimeout;
+      let cancelStartupDeadline = () => {};
+      const startupDeadline = new Promise((resolve) => {
+        const timeout = setTimeout(resolve, initTimeoutMs);
+
+        cancelStartupDeadline = () => clearTimeout(timeout);
+      });
+      const finalizeReady = () =>
+        this._finalizeReady(startupDeadline).finally(cancelStartupDeadline);
+
       const cachedCatalog = await this._loadCatalogFromCache();
       if (cachedCatalog) {
         catalog.isReady = true;
-        await this._finalizeReady();
+        await finalizeReady();
 
         return; // skip initServiceCatalogs() on reload when cache exists
       }
       const {supertoken} = this.webex.credentials;
-
-      // Race init against a hard timeout so a hung request never leaves
-      // `services.ready` false forever - that would stall `webex.ready` and
-      // leave consumers waiting on it indefinitely. Timeout is configurable via
-      // `config.services.catalogInitTimeout` (defaults to 15s in config).
-      const initTimeoutMs = this.webex.config?.services?.catalogInitTimeout;
-
-      const initServiceCatalogsTimeout = new Promise((_, reject) => {
-        setTimeout(
-          () => reject(new Error(`services: init timed out after ${initTimeoutMs}ms`)),
-          initTimeoutMs
-        );
+      const initServiceCatalogsTimeout = startupDeadline.then(() => {
+        throw new Error(`services: init timed out after ${initTimeoutMs}ms`);
       });
 
       // Validate if the supertoken exists.
@@ -1551,7 +1557,7 @@ const Services = WebexPlugin.extend({
               `services: failed to init initial services when credentials available, ${error?.message}`
             );
           })
-          .finally(() => this._finalizeReady());
+          .finally(finalizeReady);
       } else {
         const {email} = this.webex.config;
 
@@ -1565,7 +1571,7 @@ const Services = WebexPlugin.extend({
               `services: failed to init initial services when no credentials available, ${error?.message}`
             );
           })
-          .finally(() => this._finalizeReady());
+          .finally(finalizeReady);
 
         // Handle fresh login: 'loaded' fires before OAuth completes, so listen
         // for `canAuthorize` flipping true and then collect the postauth catalog.

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
@@ -266,6 +266,41 @@ describe('webex-core', () => {
         );
       });
 
+      it('does not extend the init timeout for an in-flight credentials refresh', async () => {
+        const clock = sinon.useFakeTimers();
+        let onChangeIsRefreshing: (() => void) | undefined;
+
+        services.listenToOnce = sinon.stub();
+        services.initServiceCatalogs = sinon.stub().returns(new Promise(() => {}));
+        services.webex.credentials = {
+          supertoken: {access_token: 'token'},
+          isRefreshing: true,
+          once: sinon.stub().callsFake((event: string, callback: () => void) => {
+            if (event === 'change:isRefreshing') onChangeIsRefreshing = callback;
+          }),
+          off: sinon.stub(),
+        };
+        services.logger.error = sinon.stub();
+
+        services.initialize();
+        services.listenToOnce.getCall(0).args[2]();
+        services.listenToOnce.getCall(1).args[2]();
+
+        await clock.tickAsync(15_000);
+        clock.restore();
+
+        assert.isTrue(services.initFailed);
+        assert.isTrue(
+          services.ready,
+          'credential refresh must not extend the catalog init deadline'
+        );
+        sinon.assert.calledOnceWithExactly(
+          services.webex.credentials.off,
+          'change:isRefreshing',
+          onChangeIsRefreshing
+        );
+      });
+
       it('awaits an in-flight credentials refresh before flipping services.ready=true', async () => {
         services.listenToOnce = sinon.stub();
         services.initServiceCatalogs = sinon.stub().returns(Promise.resolve());
@@ -277,6 +312,7 @@ describe('webex-core', () => {
           once: sinon.stub().callsFake((event: string, cb: () => void) => {
             if (event === 'change:isRefreshing') onChangeIsRefreshing = cb;
           }),
+          off: sinon.stub(),
         };
 
         services.initialize();
@@ -407,6 +443,7 @@ describe('webex-core', () => {
           once: sinon.stub().callsFake((event: string, cb: () => void) => {
             if (event === 'change:isRefreshing') onChangeIsRefreshing = cb;
           }),
+          off: sinon.stub(),
         };
 
         const settled = services._finalizeReady();
@@ -419,6 +456,37 @@ describe('webex-core', () => {
         await settled;
 
         assert.isTrue(services.ready);
+      });
+
+      it('sets ready=true when the startup deadline settles before credentials refresh', async () => {
+        let resolveDeadline = () => {};
+        let onChangeIsRefreshing: (() => void) | undefined;
+        const deadline = new Promise<void>((resolve) => {
+          resolveDeadline = resolve;
+        });
+
+        services.webex.credentials = {
+          isRefreshing: true,
+          once: sinon.stub().callsFake((event: string, callback: () => void) => {
+            if (event === 'change:isRefreshing') onChangeIsRefreshing = callback;
+          }),
+          off: sinon.stub(),
+        };
+
+        const settled = services._finalizeReady(deadline);
+
+        await waitForAsync();
+        assert.isFalse(services.ready);
+
+        resolveDeadline();
+        await settled;
+
+        assert.isTrue(services.ready);
+        sinon.assert.calledOnceWithExactly(
+          services.webex.credentials.off,
+          'change:isRefreshing',
+          onChangeIsRefreshing
+        );
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -269,6 +269,41 @@ describe('webex-core', () => {
         );
       });
 
+      it('does not extend the init timeout for an in-flight credentials refresh', async () => {
+        const clock = sinon.useFakeTimers();
+        let onChangeIsRefreshing;
+
+        services.listenToOnce = sinon.stub();
+        services.initServiceCatalogs = sinon.stub().returns(new Promise(() => {}));
+        services.webex.credentials = {
+          supertoken: {access_token: 'token'},
+          isRefreshing: true,
+          once: sinon.stub().callsFake((event, callback) => {
+            if (event === 'change:isRefreshing') onChangeIsRefreshing = callback;
+          }),
+          off: sinon.stub(),
+        };
+        services.logger.error = sinon.stub();
+
+        services.initialize();
+        services.listenToOnce.getCall(0).args[2]();
+        services.listenToOnce.getCall(1).args[2]();
+
+        await clock.tickAsync(15_000);
+        clock.restore();
+
+        assert.isTrue(services.initFailed);
+        assert.isTrue(
+          services.ready,
+          'credential refresh must not extend the catalog init deadline'
+        );
+        sinon.assert.calledOnceWithExactly(
+          services.webex.credentials.off,
+          'change:isRefreshing',
+          onChangeIsRefreshing
+        );
+      });
+
       it('awaits an in-flight credentials refresh before flipping services.ready=true', async () => {
         services.listenToOnce = sinon.stub();
         services.initServiceCatalogs = sinon.stub().returns(Promise.resolve());
@@ -280,6 +315,7 @@ describe('webex-core', () => {
           once: sinon.stub().callsFake((event, cb) => {
             if (event === 'change:isRefreshing') onChangeIsRefreshing = cb;
           }),
+          off: sinon.stub(),
         };
 
         services.initialize();
@@ -413,6 +449,7 @@ describe('webex-core', () => {
           once: sinon.stub().callsFake((event, cb) => {
             if (event === 'change:isRefreshing') onChangeIsRefreshing = cb;
           }),
+          off: sinon.stub(),
         };
 
         const settled = services._finalizeReady();
@@ -426,6 +463,37 @@ describe('webex-core', () => {
         await settled;
 
         assert.isTrue(services.ready);
+      });
+
+      it('sets ready=true when the startup deadline settles before credentials refresh', async () => {
+        let resolveDeadline = () => {};
+        let onChangeIsRefreshing;
+        const deadline = new Promise((resolve) => {
+          resolveDeadline = resolve;
+        });
+
+        services.webex.credentials = {
+          isRefreshing: true,
+          once: sinon.stub().callsFake((event, callback) => {
+            if (event === 'change:isRefreshing') onChangeIsRefreshing = callback;
+          }),
+          off: sinon.stub(),
+        };
+
+        const settled = services._finalizeReady(deadline);
+
+        await waitForAsync();
+        assert.isFalse(services.ready);
+
+        resolveDeadline();
+        await settled;
+
+        assert.isTrue(services.ready);
+        sinon.assert.calledOnceWithExactly(
+          services.webex.credentials.off,
+          'change:isRefreshing',
+          onChangeIsRefreshing
+        );
       });
     });
 


### PR DESCRIPTION
# COMPLETES #N/A

No linked issue. This is an SDK follow-up to [WebexServices/webex-web-client#11544](https://github.com/WebexServices/webex-web-client/pull/11544).

## This pull request addresses

When `services.waitForCatalogInit` is enabled, catalog initialization is bounded by `catalogInitTimeout`, but readiness finalization can subsequently wait without a timeout while credentials are refreshing. A refresh that remains in flight can therefore keep `services.ready` and `webex.ready` pending beyond the advertised startup bound.

## by making the following changes

- Create one startup deadline when gated catalog initialization begins and reuse it for catalog initialization and readiness finalization.
- Wait for an in-flight credential refresh only until the remaining startup deadline, then release services readiness.
- Recheck refresh state after registering the listener and remove the listener after either refresh completion or deadline settlement.
- Apply the same contract to Services V1 and Services V2.
- Add focused tests for hung refreshes, normal refresh completion, deadline settlement, and listener cleanup.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/webex-core build:src`
- `yarn workspace @webex/webex-core test:unit --targets services/services.js` — 78 tests passed.
- `yarn workspace @webex/webex-core test:unit --targets services-v2/services-v2.ts` — 81 tests passed.
- `yarn lint:staged` — ESLint passed for all four changed files.
- Webex Web Client signed-in Playwright regression with the feature enabled and both catalog and refresh requests held open — startup was released at the shared deadline.
- Webex Web Client signed-in Playwright negative case with the feature disabled — existing immediate-ready behavior was preserved.
- The same Playwright test against the previously published SDK reproduced the regression: enabled failed at `services.ready`; disabled passed.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - OpenAI Codex
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

---
> ⚠️ AI Assisted Content 🤖
