### PR TITLE
fix(calling): config for reduced ice gathering time for ice-lite

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -359,7 +359,10 @@ async function initCalling(e) {
   const callingConfig = {
     clientConfig : clientConfig,
     callingClientConfig: callingClientConfig,
-    logger:loggerConfig
+    logger:loggerConfig,
+    iceGathering: {
+      reduceTimeoutForIceLite: true
+    }
   }
 
   calling = await Calling.init({webexConfig, callingConfig});

--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -346,6 +346,9 @@ async function initCalling(e) {
     },
     serviceData,
     jwe: jwtTokenForDestElm.value,
+    iceGathering: {
+      reduceTimeoutForIceLite: true,
+    },
   };
 
   if (callingClientConfig.discovery.country === 'Country') {
@@ -360,9 +363,6 @@ async function initCalling(e) {
     clientConfig : clientConfig,
     callingClientConfig: callingClientConfig,
     logger:loggerConfig,
-    iceGathering: {
-      reduceTimeoutForIceLite: true
-    }
   }
 
   calling = await Calling.init({webexConfig, callingConfig});

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -150,7 +150,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     log.setLogger(logLevel, CALLING_CLIENT_FILE);
     validateServiceData(this.serviceData);
 
-    this.callManager = getCallManager(this.webex, this.serviceData.indicator);
+    this.callManager = getCallManager(
+      this.webex,
+      this.serviceData.indicator,
+      this.sdkConfig?.iceGathering
+    );
     this.metricManager = getMetricManager(this.webex, this.serviceData.indicator);
 
     this.mediaEngine = Media;

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -6,7 +6,11 @@ import {EffectEvent} from '@webex/media-helpers';
 import {ERROR_TYPE, ERROR_LAYER} from '../../Errors/types';
 import * as Utils from '../../common/Utils';
 import {CALL_EVENT_KEYS, CallEvent, RoapEvent, RoapMessage} from '../../Events/types';
-import {DEFAULT_SESSION_TIMER, ICE_CANDIDATES_TIMEOUT} from '../constants';
+import {
+  DEFAULT_SESSION_TIMER,
+  ICE_CANDIDATES_TIMEOUT,
+  ICE_LITE_CANDIDATES_TIMEOUT,
+} from '../constants';
 import {CallDirection, CallType, ServiceIndicator, WebexRequestPayload} from '../../common/types';
 import {
   METRIC_EVENT,
@@ -807,6 +811,94 @@ describe('Call Tests', () => {
     expect(handleOutgoingCallConnectSpy).toHaveBeenCalled();
     expect(call['mediaConnection'].roapMessageReceived).toHaveBeenLastCalledWith(delayedOffer);
     expect(call['connectPending']).toBe(false);
+  });
+
+  const iceLiteOfferSdp =
+    'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n' +
+    'a=ice-lite\r\nm=audio 19564 UDP/TLS/RTP/SAVPF 0\r\na=sendrecv\r\n';
+  const fullIceOfferSdp =
+    'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n' +
+    'm=audio 19564 UDP/TLS/RTP/SAVPF 0\r\na=sendrecv\r\na=ice-ufrag:mLbW\r\n';
+
+  describe.each([
+    {
+      name: 'reduced timeout when the offer is ice-lite and reduceTimeoutForIceLite is enabled',
+      sdp: iceLiteOfferSdp,
+      iceGatheringConfig: {reduceTimeoutForIceLite: true},
+      expectedTimeout: ICE_LITE_CANDIDATES_TIMEOUT,
+    },
+    {
+      name: 'custom reduced timeout when the offer is ice-lite and iceLiteTimeout is overridden',
+      sdp: iceLiteOfferSdp,
+      iceGatheringConfig: {reduceTimeoutForIceLite: true, iceLiteTimeout: 750},
+      expectedTimeout: 750,
+    },
+    {
+      name: 'default timeout when the offer is ice-lite but reduceTimeoutForIceLite is disabled',
+      sdp: iceLiteOfferSdp,
+      iceGatheringConfig: {reduceTimeoutForIceLite: false},
+      expectedTimeout: ICE_CANDIDATES_TIMEOUT,
+    },
+    {
+      name: 'default timeout when the offer is ice-lite but no iceGathering config is provided',
+      sdp: iceLiteOfferSdp,
+      iceGatheringConfig: undefined,
+      expectedTimeout: ICE_CANDIDATES_TIMEOUT,
+    },
+    {
+      name: 'default timeout when reduceTimeoutForIceLite is enabled but the offer is not ice-lite',
+      sdp: fullIceOfferSdp,
+      iceGatheringConfig: {reduceTimeoutForIceLite: true},
+      expectedTimeout: ICE_CANDIDATES_TIMEOUT,
+    },
+  ])('ICE candidates timeout selection', ({name, sdp, iceGatheringConfig, expectedTimeout}) => {
+    it(`uses ${name}`, async () => {
+      const mockStream = {
+        outputStream: {
+          getAudioTracks: jest.fn().mockReturnValue([mockTrack]),
+        },
+        on: jest.fn(),
+        getEffectByKind: jest.fn().mockImplementation(() => mockEffect),
+      };
+
+      const localAudioStream =
+        mockStream as unknown as InternalMediaCoreModule.LocalMicrophoneStream;
+      const call = createCall(
+        activeUrl,
+        webex,
+        CallDirection.INBOUND,
+        deviceId,
+        mockLineId,
+        deleteCallFromCollection,
+        defaultServiceIndicator,
+        dest,
+        iceGatheringConfig
+      ) as Call;
+
+      webex.request.mockReturnValue({
+        statusCode: 200,
+        body: {
+          callId: 'mock-call-id',
+        },
+      } as WebexRequestPayload);
+
+      /* Buffer the remote offer before answering so it is available at media connection init. */
+      call.sendMediaStateMachineEvt({
+        type: 'E_RECV_ROAP_OFFER',
+        data: {seq: 1, messageType: 'OFFER', version: 1, sdp},
+      } as RoapEvent);
+
+      await call.answer(localAudioStream);
+
+      expect(mockInternalMediaCoreModule.RoapMediaConnection).toBeCalledOnceWith(
+        {...roapMediaConnectionConfig, iceCandidatesTimeout: expectedTimeout},
+        roapMediaConnectionOptions,
+        expect.any(String),
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
   });
 
   it('testing enabling/disabling the BNR on an active call', async () => {

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -44,6 +44,7 @@ import {
   DEVICES_ENDPOINT_RESOURCE,
   HOLD_ENDPOINT,
   ICE_CANDIDATES_TIMEOUT,
+  ICE_LITE_CANDIDATES_TIMEOUT,
   INITIAL_SEQ_NUMBER,
   MAX_CALL_KEEPALIVE_RETRY_COUNT,
   MEDIA_ENDPOINT_RESOURCE,
@@ -78,6 +79,7 @@ import {
   ICall,
   IceCandidateErrorEventPayload,
   IceEventPayload,
+  IceGatheringConfig,
   MediaContext,
   MidCallCallerId,
   MidCallEvent,
@@ -185,6 +187,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
   private callKeepaliveRetryCount = 0;
 
   private apiRequest: APIRequest;
+
+  private iceGatheringConfig?: IceGatheringConfig;
 
   private handleMediaRoapEvent = async (event: RoapMessageEvent) => {
     log.info(
@@ -455,7 +459,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     lineId: string,
     deleteCb: DeleteRecordCallBack,
     indicator: ServiceIndicator,
-    destination?: CallDetails
+    destination?: CallDetails,
+    iceGatheringConfig?: IceGatheringConfig
   ) {
     super();
     this.destination = destination;
@@ -464,6 +469,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.deviceId = deviceId;
     this.serviceIndicator = indicator;
     this.lineId = lineId;
+    this.iceGatheringConfig = iceGatheringConfig;
 
     /* istanbul ignore else */
     if (!this.sdkConnector.getWebex()) {
@@ -2365,6 +2371,39 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     }
   };
 
+  /**
+   * Determines the ICE candidate gathering timeout to use for the media connection.
+   *
+   * When the remote peer advertises itself as an ICE-lite agent (a=ice-lite) in its ROAP offer,
+   * it only provides host candidates and does not perform connectivity checks, so there is no
+   * need to wait the full ICE_CANDIDATES_TIMEOUT for local candidate gathering. In that case a
+   * shorter timeout is returned to avoid stalling media negotiation for ~3 seconds.
+   *
+   * This optimization is opt-in: it only applies when the SDK is initialized with
+   * `iceGathering.reduceTimeoutForIceLite` set to `true`. Otherwise the default
+   * ICE_CANDIDATES_TIMEOUT is always used.
+   *
+   * @returns The ICE candidates timeout in milliseconds.
+   */
+  private getIceCandidatesTimeout(): number {
+    if (!this.iceGatheringConfig?.reduceTimeoutForIceLite) {
+      return ICE_CANDIDATES_TIMEOUT;
+    }
+
+    const remoteSdp = this.remoteRoapMessage?.sdp;
+
+    if (remoteSdp && /^a=ice-lite[\r\n]*$/im.test(remoteSdp)) {
+      log.info('Remote offer advertises ice-lite, using reduced ICE candidates timeout', {
+        file: CALL_FILE,
+        method: METHODS.INIT_MEDIA_CONNECTION,
+      });
+
+      return this.iceGatheringConfig.iceLiteTimeout ?? ICE_LITE_CANDIDATES_TIMEOUT;
+    }
+
+    return ICE_CANDIDATES_TIMEOUT;
+  }
+
   /* istanbul ignore next */
   /**
    * Initialize Media Connection.
@@ -2378,7 +2417,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       {
         skipInactiveTransceivers: true,
         iceServers: [],
-        iceCandidatesTimeout: ICE_CANDIDATES_TIMEOUT,
+        iceCandidatesTimeout: this.getIceCandidatesTimeout(),
         sdpMunging: {
           convertPort9to0: true,
           addContentSlides: false,
@@ -3397,5 +3436,7 @@ export const createCall = (
   lineId: string,
   deleteCb: DeleteRecordCallBack,
   indicator: ServiceIndicator,
-  dest?: CallDetails
-): ICall => new Call(activeUrl, webex, dir, deviceId, lineId, deleteCb, indicator, dest);
+  dest?: CallDetails,
+  iceGatheringConfig?: IceGatheringConfig
+): ICall =>
+  new Call(activeUrl, webex, dir, deviceId, lineId, deleteCb, indicator, dest, iceGatheringConfig);

--- a/packages/calling/src/CallingClient/calling/callManager.test.ts
+++ b/packages/calling/src/CallingClient/calling/callManager.test.ts
@@ -177,6 +177,25 @@ describe('Call Manager Tests with respect to calls', () => {
     expect(callManager).toMatchObject(callManagerNew);
   });
 
+  it('threads iceGathering config from getCallManager into newly created calls', () => {
+    const iceGatheringConfig = {reduceTimeoutForIceLite: true, iceLiteTimeout: 750};
+
+    /* getCallManager returns the existing singleton but refreshes the ice gathering config on it. */
+    const configuredManager = getCallManager(webex, defaultServiceIndicator, iceGatheringConfig);
+
+    expect(configuredManager).toBe(callManager);
+    expect(configuredManager['iceGatheringConfig']).toEqual(iceGatheringConfig);
+
+    const call = configuredManager.createCall(CallDirection.OUTBOUND, deviceId, mockLineId, dest);
+
+    expect(call['iceGatheringConfig']).toEqual(iceGatheringConfig);
+
+    call.end();
+
+    /* Restore the singleton config so it does not leak into subsequent tests. */
+    configuredManager['setIceGatheringConfig'](undefined);
+  });
+
   it('create a call using call manager', async () => {
     callManager.updateLine('8a67806f-fc4d-446b-a131-31e71ea5b010', mockLine);
     webex.request.mockReturnValueOnce({

--- a/packages/calling/src/CallingClient/calling/callManager.ts
+++ b/packages/calling/src/CallingClient/calling/callManager.ts
@@ -11,6 +11,7 @@ import {CallDetails, CallDirection, CorrelationId, ServiceIndicator} from '../..
 import {
   ICall,
   ICallManager,
+  IceGatheringConfig,
   MediaState,
   MidCallEvent,
   MobiusAsyncEvent,
@@ -43,14 +44,22 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
 
   private isMobiusSocketListenerRegistered = false;
 
+  private iceGatheringConfig?: IceGatheringConfig;
+
   /**
    * @param webex -.
    * @param indicator - Service Indicator.
+   * @param iceGatheringConfig - Optional ICE candidate gathering configuration.
    */
-  constructor(webex: WebexSDK, indicator: ServiceIndicator) {
+  constructor(
+    webex: WebexSDK,
+    indicator: ServiceIndicator,
+    iceGatheringConfig?: IceGatheringConfig
+  ) {
     super();
     this.sdkConnector = SDKConnector;
     this.serviceIndicator = indicator;
+    this.iceGatheringConfig = iceGatheringConfig;
     if (!this.sdkConnector.getWebex()) {
       SDKConnector.setWebex(webex);
     }
@@ -102,7 +111,8 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
         }
       },
       this.serviceIndicator,
-      destination
+      destination,
+      this.iceGatheringConfig
     );
 
     this.callCollection[newCall.getCorrelationId()] = newCall;
@@ -518,15 +528,35 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
   private getLineId(deviceId: string) {
     return this.lineDict[deviceId].lineId;
   }
+
+  /**
+   * Updates the ICE candidate gathering configuration applied to newly created calls.
+   *
+   * The {@link CallManager} is a module-level singleton that may be first constructed by a
+   * collaborator (e.g. line or registration) that does not have the SDK config. This lets the
+   * `CallingClient` seed the config on the shared instance regardless of construction order.
+   *
+   * @param iceGatheringConfig - The ICE candidate gathering configuration.
+   */
+  public setIceGatheringConfig(iceGatheringConfig?: IceGatheringConfig) {
+    this.iceGatheringConfig = iceGatheringConfig;
+  }
 }
 
 /**
  * @param webex -.
  * @param indicator - Service Indicator.
+ * @param iceGatheringConfig - Optional ICE candidate gathering configuration.
  */
-export const getCallManager = (webex: WebexSDK, indicator: ServiceIndicator): ICallManager => {
+export const getCallManager = (
+  webex: WebexSDK,
+  indicator: ServiceIndicator,
+  iceGatheringConfig?: IceGatheringConfig
+): ICallManager => {
   if (!callManager) {
-    callManager = new CallManager(webex, indicator);
+    callManager = new CallManager(webex, indicator, iceGatheringConfig);
+  } else if (iceGatheringConfig) {
+    (callManager as CallManager).setIceGatheringConfig(iceGatheringConfig);
   }
 
   return callManager;

--- a/packages/calling/src/CallingClient/calling/types.ts
+++ b/packages/calling/src/CallingClient/calling/types.ts
@@ -235,6 +235,27 @@ export type IceCandidateErrorEventPayload = {
 };
 
 /**
+ * Configuration controlling ICE candidate gathering behaviour during media negotiation.
+ */
+export interface IceGatheringConfig {
+  /**
+   * When `true`, the SDK uses a reduced ICE candidate gathering timeout if the remote peer
+   * advertises itself as an ICE-lite agent (`a=ice-lite`) in its ROAP offer. ICE-lite peers only
+   * offer host candidates and do not perform connectivity checks, so waiting the full
+   * `ICE_CANDIDATES_TIMEOUT` for local candidate gathering is unnecessary and only stalls media
+   * negotiation. This optimization is opt-in and defaults to `false`.
+   */
+  reduceTimeoutForIceLite?: boolean;
+
+  /**
+   * Optional override, in milliseconds, for the reduced ICE candidate gathering timeout applied
+   * when {@link reduceTimeoutForIceLite} is enabled and the remote offer is ICE-lite. When not
+   * provided, the SDK default (`ICE_LITE_CANDIDATES_TIMEOUT`) is used.
+   */
+  iceLiteTimeout?: number;
+}
+
+/**
  * Represents an interface for managing call-related operations.
  */
 export interface ICall extends Eventing<CallEventTypes> {

--- a/packages/calling/src/CallingClient/constants.ts
+++ b/packages/calling/src/CallingClient/constants.ts
@@ -130,12 +130,7 @@ export const MOBIUS_EU_INT = 'mobius-eu-central-1.int.infra.webex.com';
 export const FAILOVER_CACHE_PREFIX = 'wxc-failover-state';
 export const ACTIVE_MOBIUS_STORAGE_KEY = 'wxc-active-mobius';
 export const ICE_CANDIDATES_TIMEOUT = 3000;
-/*
- * When the remote peer advertises itself as an ICE-lite agent (a=ice-lite), it only offers
- * host candidates and does not perform connectivity checks. In that case there is no benefit
- * in waiting the full ICE_CANDIDATES_TIMEOUT for local candidate gathering, so a much shorter
- * timeout is used to avoid stalling media negotiation.
- */
+// Reduced ICE candidates timeout used for ice-lite offers.
 export const ICE_LITE_CANDIDATES_TIMEOUT = 500;
 export const WCC_CALLING_RTMS_DOMAIN = 'wcc-calling-rtms-domain';
 

--- a/packages/calling/src/CallingClient/constants.ts
+++ b/packages/calling/src/CallingClient/constants.ts
@@ -130,6 +130,13 @@ export const MOBIUS_EU_INT = 'mobius-eu-central-1.int.infra.webex.com';
 export const FAILOVER_CACHE_PREFIX = 'wxc-failover-state';
 export const ACTIVE_MOBIUS_STORAGE_KEY = 'wxc-active-mobius';
 export const ICE_CANDIDATES_TIMEOUT = 3000;
+/*
+ * When the remote peer advertises itself as an ICE-lite agent (a=ice-lite), it only offers
+ * host candidates and does not perform connectivity checks. In that case there is no benefit
+ * in waiting the full ICE_CANDIDATES_TIMEOUT for local candidate gathering, so a much shorter
+ * timeout is used to avoid stalling media negotiation.
+ */
+export const ICE_LITE_CANDIDATES_TIMEOUT = 500;
 export const WCC_CALLING_RTMS_DOMAIN = 'wcc-calling-rtms-domain';
 
 // Define constants for method names

--- a/packages/calling/src/CallingClient/types.ts
+++ b/packages/calling/src/CallingClient/types.ts
@@ -4,7 +4,7 @@ import {ISDKConnector} from '../SDKConnector/types';
 import {Eventing} from '../Events/impl';
 import {CallingClientEventTypes} from '../Events/types';
 import {DeviceType, ServiceData} from '../common/types';
-import {ICall} from './calling/types';
+import {ICall, IceGatheringConfig} from './calling/types';
 import {CallingClientError} from '../Errors';
 import {ILine} from './line/types';
 
@@ -17,11 +17,18 @@ interface DiscoveryConfig {
   region: string;
 }
 
+export {IceGatheringConfig};
+
 export interface CallingClientConfig {
   logger?: LoggerConfig;
   discovery?: DiscoveryConfig;
   serviceData?: ServiceData;
   jwe?: string;
+
+  /**
+   * Optional configuration to tune ICE candidate gathering during media negotiation.
+   */
+  iceGathering?: IceGatheringConfig;
 }
 
 export type CallingClientErrorEmitterCallback = (

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -75,5 +75,5 @@ export {CallError, LineError} from './Errors';
 export {ICall, TransferType} from './CallingClient/calling/types';
 export {LOGGER} from './Logger/types';
 export {LocalMicrophoneStream} from '@webex/media-helpers';
-export {CallingClientConfig} from './CallingClient/types';
+export {CallingClientConfig, IceGatheringConfig} from './CallingClient/types';
 export {ServiceIndicator} from './common/types';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-hoc >

## This pull request addresses

### What
When a remote peer advertises itself as an ICE-lite agent (`a=ice-lite`) in its ROAP offer, it only provides host candidates and performs no connectivity checks — so waiting the full `ICE_CANDIDATES_TIMEOUT` (3s) for local candidate gathering just stalls media negotiation. This PR lets the SDK detect ice-lite offers and apply a much shorter timeout, gated behind a new **opt-in** SDK config.

### Config
New optional `iceGathering` block on `CallingClientConfig`:

```javascript
createClient(webex, {
  iceGathering: {
    reduceTimeoutForIceLite: true, // opt-in; defaults to false (preserves 3s behavior)
    iceLiteTimeout: 500,           // optional override; defaults to ICE_LITE_CANDIDATES_TIMEOUT
  },
});
```

## by making the following changes

- `IceGatheringConfig` type defined in `calling/types.ts`, re-exported via `CallingClient/types.ts`, and exposed publicly from `index.ts`.
- Config threaded through `CallingClient` → `getCallManager`/`CallManager` → `createCall` → `Call` (positional param, no signature-object refactor).
- `getCallManager` seeds the config on first construction and refreshes it on the existing singleton (order-independent).
- `Call.getIceCandidatesTimeout()` returns the reduced timeout only when the feature is enabled **and** the buffered remote offer is ice-lite; otherwise the default 3s is used.

### Behavior
Fully backward compatible — with no config (or `reduceTimeoutForIceLite` unset), the existing 3s timeout is unchanged.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Parametrized `call.test.ts` coverage: enabled+ice-lite → reduced, custom `iceLiteTimeout` → custom, disabled → default, no config → default, enabled+non-ice-lite → default.
- `callManager.test.ts`: verifies the singleton config refresh and that created calls receive it.
- All affected suites green (`call`, `callManager`, `CallingClient`); ESLint clean (only pre-existing warnings).
- Also did a sanity test by making/receiving call, mute/unmute, hold/resume

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
