### PR TITLE
fix(webex-core): match allowed domains on DNS label boundaries

### DIFF
--- a/packages/@webex/webex-core/src/lib/domains.ts
+++ b/packages/@webex/webex-core/src/lib/domains.ts
@@ -1,7 +1,16 @@
+import Url from 'url';
+
 // Lowercase and drop any leading/trailing dots so `.Webex.com` and `webex.com.`
-// compare equal to `webex.com`. DNS treats all three as the same name.
+// compare equal to `webex.com`. DNS treats all three as the same name. Brackets
+// are stripped so the two parsers' IPv6 spellings (`[::1]` vs `::1`) compare equal.
 const normalizeHostname = (value: string): string =>
-  typeof value === 'string' ? value.toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '') : '';
+  typeof value === 'string'
+    ? value
+        .toLowerCase()
+        .replace(/^\[|\]$/g, '')
+        .replace(/^\.+/, '')
+        .replace(/\.+$/, '')
+    : '';
 
 /**
  * Determine if a hostname is covered by an allowed domain, matching only on DNS
@@ -22,12 +31,20 @@ const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean
 /**
  * Find the allowed domain covering a url, or `undefined` if there is none.
  *
- * Parsing lives here rather than in the callers so every caller resolves the
- * host the same way the transport does. Node's legacy `Url.parse` ends the
- * authority at the first `%`, so it reads `https://webex.com%2eattacker.net` as
- * the host `webex.com`, while the browser (and `new URL`) percent-decode it to
- * `webex.com.attacker.net` and connect there. Authorizing on one parser while
- * the transport uses another is how a token reaches an attacker's host.
+ * Parsing lives here, and deliberately uses both url parsers, because this
+ * check authorizes an `Authorization` header and the two transports behind
+ * `@webex/http-core` disagree about what the host of a url is:
+ *
+ * - the browser transport (`request.shim.js` -> `xhr`) parses per WHATWG, which
+ *   percent-decodes the authority, so it reads `https://a%2eb.com` as `a.b.com`
+ * - the node transport (`request.js` -> the `request` package) uses Node's
+ *   legacy `Url.parse`, which ends the authority at the first `%`, so it reads
+ *   the same url as `a`
+ *
+ * Authorizing on one parser while a transport connects using the other is how a
+ * token reaches an attacker's host, in whichever direction the mismatch runs.
+ * So rather than picking a parser, require both to agree and fail closed when
+ * they do not: a url whose host is ambiguous is never an allowed domain.
  *
  * @param {string} url - The url to match the allowed domains against.
  * @param {Array<string>} allowedDomains - The configured allowed domains.
@@ -38,11 +55,17 @@ export const matchAllowedDomain = (
   allowedDomains: Array<string>
 ): string | undefined => {
   let hostname: string;
+  let legacyHostname: string;
 
   try {
     ({hostname} = new URL(url));
+    ({hostname: legacyHostname} = Url.parse(url));
   } catch {
     // Not a parsable absolute url, so it cannot belong to an allowed domain.
+    return undefined;
+  }
+
+  if (normalizeHostname(hostname) !== normalizeHostname(legacyHostname)) {
     return undefined;
   }
 

--- a/packages/@webex/webex-core/src/lib/domains.ts
+++ b/packages/@webex/webex-core/src/lib/domains.ts
@@ -12,11 +12,43 @@ const normalizeHostname = (value: string): string =>
  * @param {string} allowedDomain - The configured allowed domain.
  * @returns {boolean} - True when the hostname is the domain or a subdomain of it.
  */
-export const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean => {
+const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean => {
   const host = normalizeHostname(hostname);
   const domain = normalizeHostname(allowedDomain);
 
   return !!host && !!domain && (host === domain || host.endsWith(`.${domain}`));
 };
 
-export default hostnameMatchesDomain;
+/**
+ * Find the allowed domain covering a url, or `undefined` if there is none.
+ *
+ * Parsing lives here rather than in the callers so every caller resolves the
+ * host the same way the transport does. Node's legacy `Url.parse` ends the
+ * authority at the first `%`, so it reads `https://webex.com%2eattacker.net` as
+ * the host `webex.com`, while the browser (and `new URL`) percent-decode it to
+ * `webex.com.attacker.net` and connect there. Authorizing on one parser while
+ * the transport uses another is how a token reaches an attacker's host.
+ *
+ * @param {string} url - The url to match the allowed domains against.
+ * @param {Array<string>} allowedDomains - The configured allowed domains.
+ * @returns {string} - The matching allowed domain, or undefined if there is none.
+ */
+export const matchAllowedDomain = (
+  url: string,
+  allowedDomains: Array<string>
+): string | undefined => {
+  let hostname: string;
+
+  try {
+    ({hostname} = new URL(url));
+  } catch {
+    // Not a parsable absolute url, so it cannot belong to an allowed domain.
+    return undefined;
+  }
+
+  return (allowedDomains || []).find((allowedDomain) =>
+    hostnameMatchesDomain(hostname, allowedDomain)
+  );
+};
+
+export default matchAllowedDomain;

--- a/packages/@webex/webex-core/src/lib/domains.ts
+++ b/packages/@webex/webex-core/src/lib/domains.ts
@@ -1,0 +1,22 @@
+// Lowercase and drop any leading/trailing dots so `.Webex.com` and `webex.com.`
+// compare equal to `webex.com`. DNS treats all three as the same name.
+const normalizeHostname = (value: string): string =>
+  typeof value === 'string' ? value.toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '') : '';
+
+/**
+ * Determine if a hostname is covered by an allowed domain, matching only on DNS
+ * label boundaries. A substring test would let `notwebex.com` and
+ * `webex.com.attacker.net` impersonate `webex.com`.
+ *
+ * @param {string} hostname - Hostname to test. Must not include a port.
+ * @param {string} allowedDomain - The configured allowed domain.
+ * @returns {boolean} - True when the hostname is the domain or a subdomain of it.
+ */
+export const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean => {
+  const host = normalizeHostname(hostname);
+  const domain = normalizeHostname(allowedDomain);
+
+  return !!host && !!domain && (host === domain || host.endsWith(`.${domain}`));
+};
+
+export default hostnameMatchesDomain;

--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -3,7 +3,7 @@ import AmpState from 'ampersand-state';
 import {union} from 'lodash';
 import ServiceDetail from './service-detail';
 import {IServiceDetail, ServiceGroup} from './types';
-import {hostnameMatchesDomain} from '../domains';
+import {matchAllowedDomain} from '../domains';
 
 /**
  * @class
@@ -218,17 +218,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url: string): string {
-    try {
-      // `hostname` rather than `host` so an explicit port doesn't defeat the match.
-      const {hostname} = new URL(url);
-
-      return this.allowedDomains.find((allowedDomain) =>
-        hostnameMatchesDomain(hostname, allowedDomain)
-      );
-    } catch {
-      // If the URL is invalid or can't be found, return undefined
-      return undefined;
-    }
+    return matchAllowedDomain(url, this.allowedDomains);
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -3,6 +3,7 @@ import AmpState from 'ampersand-state';
 import {union} from 'lodash';
 import ServiceDetail from './service-detail';
 import {IServiceDetail, ServiceGroup} from './types';
+import {hostnameMatchesDomain} from '../domains';
 
 /**
  * @class
@@ -210,16 +211,20 @@ const ServiceCatalog = AmpState.extend({
   },
 
   /**
-   * Finds an allowed domain that matches a specific url.
+   * Finds an allowed domain that matches a specific url. The url's hostname
+   * must be the allowed domain itself or a subdomain of it.
    *
    * @param {string} url - The url to match the allowed domains against.
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url: string): string {
     try {
-      const urlObj = new URL(url);
+      // `hostname` rather than `host` so an explicit port doesn't defeat the match.
+      const {hostname} = new URL(url);
 
-      return this.allowedDomains.find((allowedDomain) => urlObj.host.includes(allowedDomain));
+      return this.allowedDomains.find((allowedDomain) =>
+        hostnameMatchesDomain(hostname, allowedDomain)
+      );
     } catch {
       // If the URL is invalid or can't be found, return undefined
       return undefined;

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -4,7 +4,7 @@ import AmpState from 'ampersand-state';
 
 import {union} from 'lodash';
 import ServiceUrl from './service-url';
-import {hostnameMatchesDomain} from '../domains';
+import {matchAllowedDomain} from '../domains';
 
 /* eslint-disable no-underscore-dangle */
 /**
@@ -276,16 +276,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url) {
-    // `hostname` rather than `host` so an explicit port doesn't defeat the match.
-    const {hostname} = Url.parse(url);
-
-    if (!hostname) {
-      return undefined;
-    }
-
-    return this.allowedDomains.find((allowedDomain) =>
-      hostnameMatchesDomain(hostname, allowedDomain)
-    );
+    return matchAllowedDomain(url, this.allowedDomains);
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -4,6 +4,7 @@ import AmpState from 'ampersand-state';
 
 import {union} from 'lodash';
 import ServiceUrl from './service-url';
+import {hostnameMatchesDomain} from '../domains';
 
 /* eslint-disable no-underscore-dangle */
 /**
@@ -268,19 +269,23 @@ const ServiceCatalog = AmpState.extend({
   },
 
   /**
-   * Finds an allowed domain that matches a specific url.
+   * Finds an allowed domain that matches a specific url. The url's hostname
+   * must be the allowed domain itself or a subdomain of it.
    *
    * @param {string} url - The url to match the allowed domains against.
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url) {
-    const urlObj = Url.parse(url);
+    // `hostname` rather than `host` so an explicit port doesn't defeat the match.
+    const {hostname} = Url.parse(url);
 
-    if (!urlObj.host) {
+    if (!hostname) {
       return undefined;
     }
 
-    return this.allowedDomains.find((allowedDomain) => urlObj.host.includes(allowedDomain));
+    return this.allowedDomains.find((allowedDomain) =>
+      hostnameMatchesDomain(hostname, allowedDomain)
+    );
   },
 
   /**

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -101,7 +101,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai');
 
         catalog.setAllowedDomains(domains);
       });
@@ -110,10 +110,32 @@ describe('webex-core', () => {
         domains.length = 0;
       });
 
-      it('finds an allowed domain that matches a specific url', () => {
-        const domain = catalog.findAllowedDomain('http://example-a.com/resource/id');
-
-        assert.include(domains, domain);
+      [
+        // matches on label boundaries
+        ['https://webex.com/resource/id', 'webex.com'],
+        ['https://api.webex.com/resource/id', 'webex.com'],
+        ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // an explicit port must not defeat the match
+        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
+        ['https://webex.com:8443/resource/id', 'webex.com'],
+        // hostnames are case insensitive
+        ['https://API.Webex.COM/resource/id', 'webex.com'],
+        // partial labels must not match
+        ['https://notwebex.com/resource/id', undefined],
+        ['https://mywebexgov.us/resource/id', undefined],
+        // the allowed domain must not appear as a prefix or middle label
+        ['https://webex.com.attacker.net/resource/id', undefined],
+        ['https://attacker.net/webex.com/resource/id', undefined],
+        ['https://attacker.net/?next=https://webex.com', undefined],
+        // userinfo must not be treated as the host
+        ['https://webex.com@attacker.net/resource/id', undefined],
+        // unparseable urls
+        ['', undefined],
+        ['not a url', undefined],
+      ].forEach(([url, expected]) => {
+        it(`returns ${expected} for ${url || '<empty>'}`, () => {
+          assert.equal(catalog.findAllowedDomain(url), expected);
+        });
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -101,7 +101,9 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai');
+        // the empty entry mirrors plugin-meetings calling
+        // `addAllowedDomains([preferredWebexSite])` with an unset site
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
 
         catalog.setAllowedDomains(domains);
       });
@@ -129,6 +131,12 @@ describe('webex-core', () => {
         ['https://attacker.net/?next=https://webex.com', undefined],
         // userinfo must not be treated as the host
         ['https://webex.com@attacker.net/resource/id', undefined],
+        // percent-encoding must not hide the real host: `new URL` decodes
+        // `%2e` to `.`, so the request would go to webex.com.attacker.net
+        ['https://webex.com%2eattacker.net/resource/id', undefined],
+        ['https://webex.com%2Eattacker.net/resource/id', undefined],
+        // an empty allowed domain entry must not match everything
+        ['https://attacker.net/resource/id', undefined],
         // unparseable urls
         ['', undefined],
         ['not a url', undefined],

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -131,10 +131,14 @@ describe('webex-core', () => {
         ['https://attacker.net/?next=https://webex.com', undefined],
         // userinfo must not be treated as the host
         ['https://webex.com@attacker.net/resource/id', undefined],
-        // percent-encoding must not hide the real host: `new URL` decodes
-        // `%2e` to `.`, so the request would go to webex.com.attacker.net
+        // percent-encoding must not hide the real host. The two url parsers
+        // behind http-core disagree on these, and each transport would connect
+        // somewhere the other parser did not authorize, so both must reject.
         ['https://webex.com%2eattacker.net/resource/id', undefined],
         ['https://webex.com%2Eattacker.net/resource/id', undefined],
+        ['https://attacker.net%2ewebex.com/resource/id', undefined],
+        ['https://attacker.net%2Ewebex.com/resource/id', undefined],
+        ['https://attacker.net;.webex.com/resource/id', undefined],
         // an empty allowed domain entry must not match everything
         ['https://attacker.net/resource/id', undefined],
         // unparseable urls

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -101,7 +101,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai');
 
         catalog.setAllowedDomains(domains);
       });
@@ -110,10 +110,32 @@ describe('webex-core', () => {
         domains.length = 0;
       });
 
-      it('finds an allowed domain that matches a specific url', () => {
-        const domain = catalog.findAllowedDomain('http://example-a.com/resource/id');
-
-        assert.include(domains, domain);
+      [
+        // matches on label boundaries
+        ['https://webex.com/resource/id', 'webex.com'],
+        ['https://api.webex.com/resource/id', 'webex.com'],
+        ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // an explicit port must not defeat the match
+        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
+        ['https://webex.com:8443/resource/id', 'webex.com'],
+        // hostnames are case insensitive
+        ['https://API.Webex.COM/resource/id', 'webex.com'],
+        // partial labels must not match
+        ['https://notwebex.com/resource/id', undefined],
+        ['https://mywebexgov.us/resource/id', undefined],
+        // the allowed domain must not appear as a prefix or middle label
+        ['https://webex.com.attacker.net/resource/id', undefined],
+        ['https://attacker.net/webex.com/resource/id', undefined],
+        ['https://attacker.net/?next=https://webex.com', undefined],
+        // userinfo must not be treated as the host
+        ['https://webex.com@attacker.net/resource/id', undefined],
+        // unparseable urls
+        ['', undefined],
+        ['not a url', undefined],
+      ].forEach(([url, expected]) => {
+        it(`returns ${expected} for ${url || '<empty>'}`, () => {
+          assert.equal(catalog.findAllowedDomain(url), expected);
+        });
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -101,7 +101,9 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai');
+        // the empty entry mirrors plugin-meetings calling
+        // `addAllowedDomains([preferredWebexSite])` with an unset site
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
 
         catalog.setAllowedDomains(domains);
       });
@@ -129,6 +131,12 @@ describe('webex-core', () => {
         ['https://attacker.net/?next=https://webex.com', undefined],
         // userinfo must not be treated as the host
         ['https://webex.com@attacker.net/resource/id', undefined],
+        // percent-encoding must not hide the real host: `new URL` decodes
+        // `%2e` to `.`, so the request would go to webex.com.attacker.net
+        ['https://webex.com%2eattacker.net/resource/id', undefined],
+        ['https://webex.com%2Eattacker.net/resource/id', undefined],
+        // an empty allowed domain entry must not match everything
+        ['https://attacker.net/resource/id', undefined],
         // unparseable urls
         ['', undefined],
         ['not a url', undefined],

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -131,10 +131,14 @@ describe('webex-core', () => {
         ['https://attacker.net/?next=https://webex.com', undefined],
         // userinfo must not be treated as the host
         ['https://webex.com@attacker.net/resource/id', undefined],
-        // percent-encoding must not hide the real host: `new URL` decodes
-        // `%2e` to `.`, so the request would go to webex.com.attacker.net
+        // percent-encoding must not hide the real host. The two url parsers
+        // behind http-core disagree on these, and each transport would connect
+        // somewhere the other parser did not authorize, so both must reject.
         ['https://webex.com%2eattacker.net/resource/id', undefined],
         ['https://webex.com%2Eattacker.net/resource/id', undefined],
+        ['https://attacker.net%2ewebex.com/resource/id', undefined],
+        ['https://attacker.net%2Ewebex.com/resource/id', undefined],
+        ['https://attacker.net;.webex.com/resource/id', undefined],
         // an empty allowed domain entry must not match everything
         ['https://attacker.net/resource/id', undefined],
         // unparseable urls


### PR DESCRIPTION
Superseded by #5144.