### PR TITLE
fix(webex-core): match allowed domains on DNS label boundaries

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1372,18 +1372,9 @@ export default class Meetings extends WebexPlugin {
           return this.request.getMeetingPreferences().then((res) => {
             if (res) {
               const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
-
-              // always take the value from this response, so that a re-register
-              // that no longer names a site clears the previous one instead of
-              // leaving a stale site in place and skipping the fallback below
               this.preferredWebexSite = preferredWebexSite;
-
-              // preferences may not name a site, and an empty value identifies
-              // no host to allow
-              if (preferredWebexSite) {
-                // @ts-ignore
-                this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
-              }
+              // @ts-ignore
+              this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
             }
 
             // fall back to getting the preferred site from the user information

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1372,9 +1372,14 @@ export default class Meetings extends WebexPlugin {
           return this.request.getMeetingPreferences().then((res) => {
             if (res) {
               const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
-              this.preferredWebexSite = preferredWebexSite;
-              // @ts-ignore
-              this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
+
+              // preferences may not name a site, in which case there is nothing
+              // to prefer and nothing to allow
+              if (preferredWebexSite) {
+                this.preferredWebexSite = preferredWebexSite;
+                // @ts-ignore
+                this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
+              }
             }
 
             // fall back to getting the preferred site from the user information

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1373,10 +1373,14 @@ export default class Meetings extends WebexPlugin {
             if (res) {
               const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
 
-              // preferences may not name a site, in which case there is nothing
-              // to prefer and nothing to allow
+              // always take the value from this response, so that a re-register
+              // that no longer names a site clears the previous one instead of
+              // leaving a stale site in place and skipping the fallback below
+              this.preferredWebexSite = preferredWebexSite;
+
+              // preferences may not name a site, and an empty value identifies
+              // no host to allow
               if (preferredWebexSite) {
-                this.preferredWebexSite = preferredWebexSite;
                 // @ts-ignore
                 this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
               }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -3432,8 +3432,38 @@ describe('plugin-meetings', () => {
           ]);
         });
 
-        it('should handle failure to get user information if scopes are insufficient', async () => {
-          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
+        it('should replace a previously set site when a later fetch does not name one', async () => {
+          await webex.meetings.fetchUserPreferredWebexSite();
+
+          assert.equal(webex.meetings.preferredWebexSite, 'go.webex.com');
+
+          // as happens when register() runs again on the same instance: the
+          // preferences no longer name a site, and the user has a different one
+          Object.assign(webex.internal.services, {
+            getMeetingPreferences: sinon.stub().returns(Promise.resolve({})),
+          });
+          Object.assign(webex.internal, {
+            user: {
+              get: sinon.stub().returns(
+                Promise.resolve({
+                  userPreferences: {
+                    userPreferencesItems: {preferredWebExSite: 'user-site.webex.com'},
+                  },
+                })
+              ),
+            },
+          });
+
+          await webex.meetings.fetchUserPreferredWebexSite();
+
+          assert.equal(webex.meetings.preferredWebexSite, 'user-site.webex.com');
+          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), [
+            'go.webex.com',
+            'user-site.webex.com',
+          ]);
+        });
+
+        it('should handle failure to get user information if scopes are insufficient', async () => {          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
           Object.assign(webex.people, {
             _getMe: sinon.stub().returns(Promise.reject()),
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -3432,38 +3432,8 @@ describe('plugin-meetings', () => {
           ]);
         });
 
-        it('should replace a previously set site when a later fetch does not name one', async () => {
-          await webex.meetings.fetchUserPreferredWebexSite();
-
-          assert.equal(webex.meetings.preferredWebexSite, 'go.webex.com');
-
-          // as happens when register() runs again on the same instance: the
-          // preferences no longer name a site, and the user has a different one
-          Object.assign(webex.internal.services, {
-            getMeetingPreferences: sinon.stub().returns(Promise.resolve({})),
-          });
-          Object.assign(webex.internal, {
-            user: {
-              get: sinon.stub().returns(
-                Promise.resolve({
-                  userPreferences: {
-                    userPreferencesItems: {preferredWebExSite: 'user-site.webex.com'},
-                  },
-                })
-              ),
-            },
-          });
-
-          await webex.meetings.fetchUserPreferredWebexSite();
-
-          assert.equal(webex.meetings.preferredWebexSite, 'user-site.webex.com');
-          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), [
-            'go.webex.com',
-            'user-site.webex.com',
-          ]);
-        });
-
-        it('should handle failure to get user information if scopes are insufficient', async () => {          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
+        it('should handle failure to get user information if scopes are insufficient', async () => {
+          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
           Object.assign(webex.people, {
             _getMe: sinon.stub().returns(Promise.reject()),
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -3486,7 +3486,7 @@ describe('plugin-meetings', () => {
             loggerProxySpy,
             'Failed to fetch preferred site from user - no site will be set'
           );
-          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), ['']);
+          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
         });
 
         it('should fall back to fetching the site from the user', async () => {
@@ -3504,7 +3504,6 @@ describe('plugin-meetings', () => {
 
           assert.equal(webex.meetings.preferredWebexSite, 'site.webex.com');
           assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), [
-            '',
             'site.webex.com',
           ]);
           assert.notCalled(loggerProxySpy);
@@ -3528,7 +3527,7 @@ describe('plugin-meetings', () => {
                 loggerProxySpy,
                 'Failed to fetch preferred site from user - no site will be set'
               );
-              assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), ['']);
+              assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
             });
           }
         );
@@ -3545,7 +3544,7 @@ describe('plugin-meetings', () => {
             loggerProxySpy,
             'Failed to fetch preferred site from user - no site will be set'
           );
-          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), ['']);
+          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
         });
 
         it('should fall back to fetching the site from the user', async () => {
@@ -3564,7 +3563,6 @@ describe('plugin-meetings', () => {
           assert.equal(webex.meetings.preferredWebexSite, 'site.webex.com');
           assert.notCalled(loggerProxySpy);
           assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), [
-            '',
             'site.webex.com',
           ]);
         });
@@ -3587,7 +3585,7 @@ describe('plugin-meetings', () => {
                 loggerProxySpy,
                 'Failed to fetch preferred site from user - no site will be set'
               );
-              assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), ['']);
+              assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
             });
           }
         );
@@ -3604,7 +3602,7 @@ describe('plugin-meetings', () => {
             loggerProxySpy,
             'Failed to fetch preferred site from user - no site will be set'
           );
-          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), ['']);
+          assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
         });
       });
     });

--- a/packages/@webex/webex-core/README.md
+++ b/packages/@webex/webex-core/README.md
@@ -78,8 +78,11 @@ const webex = new WebexCore({
       // Validate domains against the allowed domains
       validateDomains: true,
 
-      // The allowed domains to validate domains against
-      allowedDomains: ['allowed-domain']
+      // The allowed domains to validate domains against. Each entry is a
+      // hostname, matched on label boundaries: an entry allows that host and
+      // its subdomains, so 'example.com' covers 'api.example.com' but not
+      // 'notexample.com'.
+      allowedDomains: ['example.com']
     }
   }
 });

--- a/packages/@webex/webex-core/src/lib/domains.ts
+++ b/packages/@webex/webex-core/src/lib/domains.ts
@@ -1,0 +1,73 @@
+import Url from 'url';
+
+// Lowercase and drop any leading/trailing dots so `.Example.com` and `example.com.`
+// compare equal to `example.com`. DNS treats all three as the same name. Brackets are
+// stripped so the two parsers' IPv6 spellings (`[::1]` vs `::1`) compare equal.
+const normalizeHostname = (value: string): string =>
+  typeof value === 'string'
+    ? value
+        .toLowerCase()
+        .replace(/^\[|\]$/g, '')
+        .replace(/^\.+/, '')
+        .replace(/\.+$/, '')
+    : '';
+
+/**
+ * Determine if a hostname is covered by an allowed domain, matching only on DNS
+ * label boundaries, so that a hostname is allowed only when it is the domain
+ * itself or a subdomain of it. Matching on a substring instead would treat
+ * unrelated hostnames that merely contain the domain as allowed.
+ *
+ * @param {string} hostname - Hostname to test. Must not include a port.
+ * @param {string} allowedDomain - The configured allowed domain.
+ * @returns {boolean} - True when the hostname is the domain or a subdomain of it.
+ */
+const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean => {
+  const host = normalizeHostname(hostname);
+  const domain = normalizeHostname(allowedDomain);
+
+  return !!host && !!domain && (host === domain || host.endsWith(`.${domain}`));
+};
+
+/**
+ * Find the allowed domain covering a url, or `undefined` if there is none.
+ *
+ * Parsing lives here rather than in the callers, and deliberately uses both url
+ * parsers, because this check gates an `Authorization` header. The two
+ * transports behind `@webex/http-core` do not use the same url parser: the
+ * browser transport parses per WHATWG, the node transport uses Node's legacy
+ * `Url.parse`, and for some inputs the two resolve different hosts.
+ *
+ * Rather than picking one, require both to agree and fail closed when they do
+ * not, so this check can never authorize a host that differs from the one a
+ * transport would actually connect to. Do not narrow this to a single parser.
+ *
+ * @param {string} url - The url to match the allowed domains against.
+ * @param {Array<string>} allowedDomains - The configured allowed domains.
+ * @returns {string} - The matching allowed domain, or undefined if there is none.
+ */
+export const matchAllowedDomain = (
+  url: string,
+  allowedDomains: Array<string>
+): string | undefined => {
+  let hostname: string;
+  let legacyHostname: string;
+
+  try {
+    ({hostname} = new URL(url));
+    ({hostname: legacyHostname} = Url.parse(url));
+  } catch {
+    // Not a parsable absolute url, so it cannot belong to an allowed domain.
+    return undefined;
+  }
+
+  if (normalizeHostname(hostname) !== normalizeHostname(legacyHostname)) {
+    return undefined;
+  }
+
+  return (allowedDomains || []).find((allowedDomain) =>
+    hostnameMatchesDomain(hostname, allowedDomain)
+  );
+};
+
+export default matchAllowedDomain;

--- a/packages/@webex/webex-core/src/lib/domains.ts
+++ b/packages/@webex/webex-core/src/lib/domains.ts
@@ -1,8 +1,14 @@
 import Url from 'url';
 
-// Lowercase and drop any leading/trailing dots so `.Example.com` and `example.com.`
-// compare equal to `example.com`. DNS treats all three as the same name. Brackets are
-// stripped so the two parsers' IPv6 spellings (`[::1]` vs `::1`) compare equal.
+import {uniq} from 'lodash';
+
+// Canonicalise a hostname for comparison: lowercase, drop the brackets around
+// an IPv6 literal, and drop leading/trailing dots. DNS treats `Example.com`,
+// `example.com.` and `example.com` as the same name.
+//
+// Node's `url.domainToASCII` looks like the standard way to do this, but the
+// `url` polyfill this package bundles for the browser does not implement it,
+// so it cannot be used here. It also leaves trailing dots in place.
 const normalizeHostname = (value: string): string =>
   typeof value === 'string'
     ? value
@@ -11,6 +17,19 @@ const normalizeHostname = (value: string): string =>
         .replace(/^\.+/, '')
         .replace(/\.+$/, '')
     : '';
+
+/**
+ * Canonicalise a list of configured allowed domains, discarding any entry that
+ * is not a usable hostname. Callers normalise on the way in so the stored list
+ * is already canonical, rather than re-deriving it on every request.
+ *
+ * @param {Array<string>} allowedDomains - The configured allowed domains.
+ * @returns {Array<string>} - Normalized, de-duplicated, non-empty entries.
+ */
+export const normalizeAllowedDomains = (allowedDomains: Array<string>): Array<string> =>
+  uniq(
+    (Array.isArray(allowedDomains) ? allowedDomains : []).map(normalizeHostname).filter(Boolean)
+  );
 
 /**
  * Determine if a hostname is covered by an allowed domain, matching only on DNS
@@ -23,6 +42,8 @@ const normalizeHostname = (value: string): string =>
  * @returns {boolean} - True when the hostname is the domain or a subdomain of it.
  */
 const hostnameMatchesDomain = (hostname: string, allowedDomain: string): boolean => {
+  // The stored list is normalized on write, but `allowedDomains` is a public
+  // property, so normalize again here rather than trust it.
   const host = normalizeHostname(hostname);
   const domain = normalizeHostname(allowedDomain);
 

--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -3,6 +3,7 @@ import AmpState from 'ampersand-state';
 import {union} from 'lodash';
 import ServiceDetail from './service-detail';
 import {IServiceDetail, ServiceGroup} from './types';
+import {matchAllowedDomain} from '../domains';
 
 /**
  * @class
@@ -210,20 +211,14 @@ const ServiceCatalog = AmpState.extend({
   },
 
   /**
-   * Finds an allowed domain that matches a specific url.
+   * Finds an allowed domain that matches a specific url. The url's hostname
+   * must be the allowed domain itself or a subdomain of it.
    *
    * @param {string} url - The url to match the allowed domains against.
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url: string): string {
-    try {
-      const urlObj = new URL(url);
-
-      return this.allowedDomains.find((allowedDomain) => urlObj.host.includes(allowedDomain));
-    } catch {
-      // If the URL is invalid or can't be found, return undefined
-      return undefined;
-    }
+    return matchAllowedDomain(url, this.allowedDomains);
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -3,7 +3,7 @@ import AmpState from 'ampersand-state';
 import {union} from 'lodash';
 import ServiceDetail from './service-detail';
 import {IServiceDetail, ServiceGroup} from './types';
-import {matchAllowedDomain} from '../domains';
+import {matchAllowedDomain, normalizeAllowedDomains} from '../domains';
 
 /**
  * @class
@@ -277,7 +277,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {void}
    */
   setAllowedDomains(allowedDomains: Array<string>): void {
-    this.allowedDomains = [...allowedDomains];
+    this.allowedDomains = normalizeAllowedDomains(allowedDomains);
   },
 
   /**
@@ -286,7 +286,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {void}
    */
   addAllowedDomains(newAllowedDomains: Array<string>): void {
-    this.allowedDomains = union(this.allowedDomains, newAllowedDomains);
+    this.allowedDomains = union(this.allowedDomains, normalizeAllowedDomains(newAllowedDomains));
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -4,6 +4,7 @@ import AmpState from 'ampersand-state';
 
 import {union} from 'lodash';
 import ServiceUrl from './service-url';
+import {matchAllowedDomain} from '../domains';
 
 /* eslint-disable no-underscore-dangle */
 /**
@@ -268,19 +269,14 @@ const ServiceCatalog = AmpState.extend({
   },
 
   /**
-   * Finds an allowed domain that matches a specific url.
+   * Finds an allowed domain that matches a specific url. The url's hostname
+   * must be the allowed domain itself or a subdomain of it.
    *
    * @param {string} url - The url to match the allowed domains against.
    * @returns {string} - The matching allowed domain.
    */
   findAllowedDomain(url) {
-    const urlObj = Url.parse(url);
-
-    if (!urlObj.host) {
-      return undefined;
-    }
-
-    return this.allowedDomains.find((allowedDomain) => urlObj.host.includes(allowedDomain));
+    return matchAllowedDomain(url, this.allowedDomains);
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -4,7 +4,7 @@ import AmpState from 'ampersand-state';
 
 import {union} from 'lodash';
 import ServiceUrl from './service-url';
-import {matchAllowedDomain} from '../domains';
+import {matchAllowedDomain, normalizeAllowedDomains} from '../domains';
 
 /* eslint-disable no-underscore-dangle */
 /**
@@ -363,7 +363,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {void}
    */
   setAllowedDomains(allowedDomains) {
-    this.allowedDomains = [...allowedDomains];
+    this.allowedDomains = normalizeAllowedDomains(allowedDomains);
   },
 
   /**
@@ -372,7 +372,7 @@ const ServiceCatalog = AmpState.extend({
    * @returns {void}
    */
   addAllowedDomains(newAllowedDomains) {
-    this.allowedDomains = union(this.allowedDomains, newAllowedDomains);
+    this.allowedDomains = union(this.allowedDomains, normalizeAllowedDomains(newAllowedDomains));
   },
 
   /**

--- a/packages/@webex/webex-core/test/unit/spec/interceptors/auth.js
+++ b/packages/@webex/webex-core/test/unit/spec/interceptors/auth.js
@@ -14,6 +14,8 @@ import {
   AuthInterceptor,
   config,
   Credentials,
+  Services,
+  ServicesV2,
   WebexHttpError,
   Token,
   serviceConstants,
@@ -377,6 +379,60 @@ describe('webex-core', () => {
               service: 'locus',
             })
             .then(() => assert.calledOnce(waitForService));
+        });
+      });
+
+      describe('#onRequest() against a real service catalog', () => {
+        // The cases above stub `isAllowedDomainUrl`, so they answer the
+        // allowed-domain question themselves and cannot show that the catalog
+        // matcher is reached by the code that attaches the token. These use a
+        // real catalog and real allowed-domain methods.
+        [
+          {name: 'Services', Constructor: Services},
+          {name: 'ServicesV2', Constructor: ServicesV2},
+        ].forEach(({name, Constructor}) => {
+          describe(name, () => {
+            let getUserToken;
+
+            beforeEach(() => {
+              const services = new Constructor(undefined, {parent: webex});
+
+              services._getCatalog().setAllowedDomains(['webex.com']);
+              // the catalog holds no services, so a url that is not covered by
+              // an allowed domain has nothing else to authorize it
+              services.waitForService = sinon.stub().rejects(new Error('no such service'));
+
+              webex.internal.services = services;
+              getUserToken = sinon.spy(webex.credentials, 'getUserToken');
+            });
+
+            afterEach(() => {
+              getUserToken.restore();
+              delete webex.internal.services;
+            });
+
+            it('adds the authorization header for a url under an allowed domain', () =>
+              interceptor
+                .onRequest({uri: 'https://api.webex.com/resource', headers: {}})
+                .then((options) => {
+                  assert.equal(
+                    options.headers.authorization,
+                    webex.credentials.supertoken.toString()
+                  );
+                  assert.calledOnce(getUserToken);
+                }));
+
+            [
+              'https://notwebex.com/resource',
+              'https://webex.com.unrelated.example/resource',
+            ].forEach((uri) => {
+              it(`does not add the authorization header for ${uri}`, () =>
+                interceptor.onRequest({uri, headers: {}}).then((options) => {
+                  assert.notProperty(options.headers, 'authorization');
+                  assert.notCalled(getUserToken);
+                }));
+            });
+          });
         });
       });
 

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -101,8 +101,24 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        // callers may add an unset entry, which must match nothing
-        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
+        // Shaped like a real catalog rather than a tidy list: the commercial
+        // domains the sdk ships with, a multi-part suffix, sites added at
+        // runtime from meeting preferences, an entry that overlaps another,
+        // and an unset entry, which callers can add and which must match
+        // nothing.
+        domains.push(
+          'wbx2.com',
+          'ciscospark.com',
+          'webex.com',
+          'webexapis.com',
+          'broadcloud.com.au',
+          'webexgov.us',
+          'example-a.com',
+          'example-b.com',
+          'example-c.com',
+          'go.example-a.com',
+          ''
+        );
 
         catalog.setAllowedDomains(domains);
       });
@@ -112,20 +128,36 @@ describe('webex-core', () => {
       });
 
       [
-        // the domain itself and its subdomains match
-        ['https://webex.com/resource/id', 'webex.com'],
-        ['https://api.webex.com/resource/id', 'webex.com'],
+        // real service hosts resolve to the entry that covers them
+        ['https://u2c-a.wbx2.com/u2c/api/v1/limited/catalog', 'wbx2.com'],
+        ['https://conv-a.wbx2.com/conversation/api/v1/conversations', 'wbx2.com'],
+        ['https://foobar.ciscospark.com/resource/id', 'ciscospark.com'],
+        ['https://idbroker.webex.com/idb/token', 'webex.com'],
+        ['https://webexapis.com/v1/people/me', 'webexapis.com'],
+        // an entry is not required to be a bare registrable domain
+        ['https://foo.broadcloud.com.au/resource/id', 'broadcloud.com.au'],
         ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // the domain itself and its subdomains match
+        ['https://example-a.com/resource/id', 'example-a.com'],
+        ['https://sub.example-b.com/resource/id', 'example-b.com'],
+        ['https://deep.sub.example-c.com/resource/id', 'example-c.com'],
+        // overlapping entries resolve to the first covering entry in the list
+        ['https://go.example-a.com/resource/id', 'example-a.com'],
         // an explicit port must not defeat the match
-        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
-        ['https://webex.com:8443/resource/id', 'webex.com'],
+        ['https://example-a.com:8443/resource/id', 'example-a.com'],
+        ['https://u2c-a.wbx2.com:8000/resource/id', 'wbx2.com'],
         // hostname comparison is case insensitive
-        ['https://API.Webex.COM/resource/id', 'webex.com'],
-        // a partial label must not match
+        ['https://U2C-A.WBX2.COM/resource/id', 'wbx2.com'],
+        // a trailing dot is the same name
+        ['https://u2c-a.wbx2.com./resource/id', 'wbx2.com'],
+        // a sibling registrable domain must not match
         ['https://notwebex.com/resource/id', undefined],
         ['https://mywebexgov.us/resource/id', undefined],
         ['https://webex.company/resource/id', undefined],
         ['https://webex.com-unrelated.example/resource/id', undefined],
+        ['https://example-a.community/resource/id', undefined],
+        // a partial label must not match, even against a multi-part entry
+        ['https://broadcloud.com/resource/id', undefined],
         // the domain matches only as a suffix, on a label boundary
         ['https://webex.com.unrelated.example/resource/id', undefined],
         ['https://unrelated.example/webex.com/resource/id', undefined],
@@ -156,7 +188,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -176,7 +208,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -186,11 +218,23 @@ describe('webex-core', () => {
       });
 
       it('sets the allowed domain entries to new values', () => {
-        const newValues = ['example-d', 'example-e', 'example-f'];
+        const newValues = ['example-d.com', 'example-e.com', 'example-f.com'];
 
         catalog.setAllowedDomains(newValues);
 
         assert.notDeepInclude(domains, newValues);
+      });
+
+      it('canonicalizes entries and discards those that are not usable', () => {
+        catalog.setAllowedDomains([
+          'Example-D.COM',
+          'example-d.com',
+          'example-e.com.',
+          '',
+          undefined,
+        ]);
+
+        assert.deepEqual(catalog.getAllowedDomains(), ['example-d.com', 'example-e.com']);
       });
     });
 
@@ -198,7 +242,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -208,13 +252,16 @@ describe('webex-core', () => {
       });
 
       it('merge the allowed domain entries with new values', () => {
-        const newValues = ['example-c', 'example-e', 'example-f'];
+        const newValues = ['example-c.com', 'example-e.com', 'example-f.com'];
 
         catalog.addAllowedDomains(newValues);
 
         const list = catalog.getAllowedDomains();
 
-        assert.match(['example-a', 'example-b', 'example-c', 'example-e', 'example-f'], list);
+        assert.match(
+          ['example-a.com', 'example-b.com', 'example-c.com', 'example-e.com', 'example-f.com'],
+          list
+        );
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -101,7 +101,8 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        // callers may add an unset entry, which must match nothing
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
 
         catalog.setAllowedDomains(domains);
       });
@@ -110,10 +111,42 @@ describe('webex-core', () => {
         domains.length = 0;
       });
 
-      it('finds an allowed domain that matches a specific url', () => {
-        const domain = catalog.findAllowedDomain('http://example-a.com/resource/id');
-
-        assert.include(domains, domain);
+      [
+        // the domain itself and its subdomains match
+        ['https://webex.com/resource/id', 'webex.com'],
+        ['https://api.webex.com/resource/id', 'webex.com'],
+        ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // an explicit port must not defeat the match
+        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
+        ['https://webex.com:8443/resource/id', 'webex.com'],
+        // hostname comparison is case insensitive
+        ['https://API.Webex.COM/resource/id', 'webex.com'],
+        // a partial label must not match
+        ['https://notwebex.com/resource/id', undefined],
+        ['https://mywebexgov.us/resource/id', undefined],
+        // the domain matches only as a suffix, on a label boundary
+        ['https://webex.com.unrelated.example/resource/id', undefined],
+        ['https://unrelated.example/webex.com/resource/id', undefined],
+        ['https://unrelated.example/?next=https://webex.com', undefined],
+        // userinfo is not the host
+        ['https://webex.com@unrelated.example/resource/id', undefined],
+        // an encoded or unusual separator is not a label boundary, and the url
+        // parsers used by the transports do not agree on where these end the
+        // host, so they must not resolve to an allowed domain
+        ['https://webex.com%2eunrelated.example/resource/id', undefined],
+        ['https://webex.com%2Eunrelated.example/resource/id', undefined],
+        ['https://unrelated.example%2ewebex.com/resource/id', undefined],
+        ['https://unrelated.example%2Ewebex.com/resource/id', undefined],
+        ['https://unrelated.example;.webex.com/resource/id', undefined],
+        // an empty allowed domain entry matches nothing
+        ['https://unrelated.example/resource/id', undefined],
+        // unparseable urls
+        ['', undefined],
+        ['not a url', undefined],
+      ].forEach(([url, expected]) => {
+        it(`returns ${expected} for ${url || '<empty>'}`, () => {
+          assert.equal(catalog.findAllowedDomain(url), expected);
+        });
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/service-catalog.ts
@@ -124,6 +124,8 @@ describe('webex-core', () => {
         // a partial label must not match
         ['https://notwebex.com/resource/id', undefined],
         ['https://mywebexgov.us/resource/id', undefined],
+        ['https://webex.company/resource/id', undefined],
+        ['https://webex.com-unrelated.example/resource/id', undefined],
         // the domain matches only as a suffix, on a label boundary
         ['https://webex.com.unrelated.example/resource/id', undefined],
         ['https://unrelated.example/webex.com/resource/id', undefined],

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -101,8 +101,24 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        // callers may add an unset entry, which must match nothing
-        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
+        // Shaped like a real catalog rather than a tidy list: the commercial
+        // domains the sdk ships with, a multi-part suffix, sites added at
+        // runtime from meeting preferences, an entry that overlaps another,
+        // and an unset entry, which callers can add and which must match
+        // nothing.
+        domains.push(
+          'wbx2.com',
+          'ciscospark.com',
+          'webex.com',
+          'webexapis.com',
+          'broadcloud.com.au',
+          'webexgov.us',
+          'example-a.com',
+          'example-b.com',
+          'example-c.com',
+          'go.example-a.com',
+          ''
+        );
 
         catalog.setAllowedDomains(domains);
       });
@@ -112,20 +128,36 @@ describe('webex-core', () => {
       });
 
       [
-        // the domain itself and its subdomains match
-        ['https://webex.com/resource/id', 'webex.com'],
-        ['https://api.webex.com/resource/id', 'webex.com'],
+        // real service hosts resolve to the entry that covers them
+        ['https://u2c-a.wbx2.com/u2c/api/v1/limited/catalog', 'wbx2.com'],
+        ['https://conv-a.wbx2.com/conversation/api/v1/conversations', 'wbx2.com'],
+        ['https://foobar.ciscospark.com/resource/id', 'ciscospark.com'],
+        ['https://idbroker.webex.com/idb/token', 'webex.com'],
+        ['https://webexapis.com/v1/people/me', 'webexapis.com'],
+        // an entry is not required to be a bare registrable domain
+        ['https://foo.broadcloud.com.au/resource/id', 'broadcloud.com.au'],
         ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // the domain itself and its subdomains match
+        ['https://example-a.com/resource/id', 'example-a.com'],
+        ['https://sub.example-b.com/resource/id', 'example-b.com'],
+        ['https://deep.sub.example-c.com/resource/id', 'example-c.com'],
+        // overlapping entries resolve to the first covering entry in the list
+        ['https://go.example-a.com/resource/id', 'example-a.com'],
         // an explicit port must not defeat the match
-        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
-        ['https://webex.com:8443/resource/id', 'webex.com'],
+        ['https://example-a.com:8443/resource/id', 'example-a.com'],
+        ['https://u2c-a.wbx2.com:8000/resource/id', 'wbx2.com'],
         // hostname comparison is case insensitive
-        ['https://API.Webex.COM/resource/id', 'webex.com'],
-        // a partial label must not match
+        ['https://U2C-A.WBX2.COM/resource/id', 'wbx2.com'],
+        // a trailing dot is the same name
+        ['https://u2c-a.wbx2.com./resource/id', 'wbx2.com'],
+        // a sibling registrable domain must not match
         ['https://notwebex.com/resource/id', undefined],
         ['https://mywebexgov.us/resource/id', undefined],
         ['https://webex.company/resource/id', undefined],
         ['https://webex.com-unrelated.example/resource/id', undefined],
+        ['https://example-a.community/resource/id', undefined],
+        // a partial label must not match, even against a multi-part entry
+        ['https://broadcloud.com/resource/id', undefined],
         // the domain matches only as a suffix, on a label boundary
         ['https://webex.com.unrelated.example/resource/id', undefined],
         ['https://unrelated.example/webex.com/resource/id', undefined],
@@ -156,7 +188,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -195,7 +227,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -205,11 +237,23 @@ describe('webex-core', () => {
       });
 
       it('sets the allowed domain entries to new values', () => {
-        const newValues = ['example-d', 'example-e', 'example-f'];
+        const newValues = ['example-d.com', 'example-e.com', 'example-f.com'];
 
         catalog.setAllowedDomains(newValues);
 
         assert.notDeepInclude(domains, newValues);
+      });
+
+      it('canonicalizes entries and discards those that are not usable', () => {
+        catalog.setAllowedDomains([
+          'Example-D.COM',
+          'example-d.com',
+          'example-e.com.',
+          '',
+          undefined,
+        ]);
+
+        assert.deepEqual(catalog.getAllowedDomains(), ['example-d.com', 'example-e.com']);
       });
     });
 
@@ -217,7 +261,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        domains.push('example-a.com', 'example-b.com', 'example-c.com');
 
         catalog.setAllowedDomains(domains);
       });
@@ -227,13 +271,16 @@ describe('webex-core', () => {
       });
 
       it('merge the allowed domain entries with new values', () => {
-        const newValues = ['example-c', 'example-e', 'example-f'];
+        const newValues = ['example-c.com', 'example-e.com', 'example-f.com'];
 
         catalog.addAllowedDomains(newValues);
 
         const list = catalog.getAllowedDomains();
 
-        assert.match(['example-a', 'example-b', 'example-c', 'example-e', 'example-f'], list);
+        assert.match(
+          ['example-a.com', 'example-b.com', 'example-c.com', 'example-e.com', 'example-f.com'],
+          list
+        );
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -101,7 +101,8 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push('example-a', 'example-b', 'example-c');
+        // callers may add an unset entry, which must match nothing
+        domains.push('webex.com', 'webexgov.us', 'webex.umi.ai', '');
 
         catalog.setAllowedDomains(domains);
       });
@@ -110,10 +111,42 @@ describe('webex-core', () => {
         domains.length = 0;
       });
 
-      it('finds an allowed domain that matches a specific url', () => {
-        const domain = catalog.findAllowedDomain('http://example-a.com/resource/id');
-
-        assert.include(domains, domain);
+      [
+        // the domain itself and its subdomains match
+        ['https://webex.com/resource/id', 'webex.com'],
+        ['https://api.webex.com/resource/id', 'webex.com'],
+        ['https://a.b.webexgov.us/resource/id', 'webexgov.us'],
+        // an explicit port must not defeat the match
+        ['https://localhost.webex.umi.ai:8000/resource/id', 'webex.umi.ai'],
+        ['https://webex.com:8443/resource/id', 'webex.com'],
+        // hostname comparison is case insensitive
+        ['https://API.Webex.COM/resource/id', 'webex.com'],
+        // a partial label must not match
+        ['https://notwebex.com/resource/id', undefined],
+        ['https://mywebexgov.us/resource/id', undefined],
+        // the domain matches only as a suffix, on a label boundary
+        ['https://webex.com.unrelated.example/resource/id', undefined],
+        ['https://unrelated.example/webex.com/resource/id', undefined],
+        ['https://unrelated.example/?next=https://webex.com', undefined],
+        // userinfo is not the host
+        ['https://webex.com@unrelated.example/resource/id', undefined],
+        // an encoded or unusual separator is not a label boundary, and the url
+        // parsers used by the transports do not agree on where these end the
+        // host, so they must not resolve to an allowed domain
+        ['https://webex.com%2eunrelated.example/resource/id', undefined],
+        ['https://webex.com%2Eunrelated.example/resource/id', undefined],
+        ['https://unrelated.example%2ewebex.com/resource/id', undefined],
+        ['https://unrelated.example%2Ewebex.com/resource/id', undefined],
+        ['https://unrelated.example;.webex.com/resource/id', undefined],
+        // an empty allowed domain entry matches nothing
+        ['https://unrelated.example/resource/id', undefined],
+        // unparseable urls
+        ['', undefined],
+        ['not a url', undefined],
+      ].forEach(([url, expected]) => {
+        it(`returns ${expected} for ${url || '<empty>'}`, () => {
+          assert.equal(catalog.findAllowedDomain(url), expected);
+        });
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -124,6 +124,8 @@ describe('webex-core', () => {
         // a partial label must not match
         ['https://notwebex.com/resource/id', undefined],
         ['https://mywebexgov.us/resource/id', undefined],
+        ['https://webex.company/resource/id', undefined],
+        ['https://webex.com-unrelated.example/resource/id', undefined],
         // the domain matches only as a suffix, on a label boundary
         ['https://webex.com.unrelated.example/resource/id', undefined],
         ['https://unrelated.example/webex.com/resource/id', undefined],


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/FPV-688

## This pull request addresses

`ServiceCatalog.findAllowedDomain` compared a request's host against each configured allowed domain using a substring test, rather than matching on DNS label boundaries. As a result a hostname that merely contained an allowed domain could be treated as allowed.

The result of this check is used by the auth interceptor to decide whether a request carries an `Authorization` header, so the match needs to be exact.

## by making the following changes

Match on DNS label boundaries, so a hostname is allowed only when it is the allowed domain itself or a subdomain of it:

```ts
host === domain || host.endsWith(`.${domain}`)
```

Both catalogs (`services` and `services-v2`) now share a single helper, `lib/domains.ts`. The helper also owns the url parsing, so the two catalogs cannot resolve a host differently.

Configured domains are canonicalized once when they are set, rather than on every request, so the stored list is canonical and `getAllowedDomains()` returns predictable values. Entries that are not usable hostnames are discarded at that point. Matching still normalizes defensively, because `allowedDomains` is a public property that can be assigned directly.

### Compatibility

Entries in `allowedDomains` are now matched as complete hostnames. An entry that is only a fragment of a domain — for example `example` intended to cover `example.com` — no longer matches. An entry that is empty, or otherwise not a usable hostname, is discarded when the allowed domains are set.

Every configuration shipped in this repo, and every value supplied at runtime from meeting preferences, is already a complete hostname, so no in-tree configuration changes behaviour. Downstream configurations that rely on fragments will need to use complete hostnames. The `allowedDomains` example in `packages/@webex/webex-core/README.md` predated boundary matching and has been corrected.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Automated: `yarn workspace @webex/webex-core test:unit` — 33 suites, 738 tests passing. The catalog specs are seeded with fixtures shaped like a real catalog (the commercial domains, a multi-part suffix such as `broadcloud.com.au`, sites added at runtime, an entry that overlaps another, and an unset entry) and exercised with real service hostnames such as `u2c-a.wbx2.com`, `conv-a.wbx2.com`, `foobar.ciscospark.com` and `idbroker.webex.com`. Cases cover exact and subdomain matches, first-match ordering for overlapping entries, explicit ports, mixed case, trailing dots, partial labels, suffix and middle-label matching, userinfo, encoded and unusual separators in the authority, empty allowlist entries, and unparseable urls.
- Manual: verified the commercial, FedRAMP, controlled and ITE `allowedDomains` configurations against real `Services` instances — every legitimate service url still resolves to its allowed domain, no environment regresses, and a configuration supplied with mixed case, duplicates and an unset entry collapses to a single canonical entry.
- Automated: `yarn workspace @webex/plugin-meetings test:unit` — 214 passing. No `plugin-meetings` source changes; only the `fetchUserPreferredWebexSite` expectations move, because the catalog no longer stores an empty entry.
- Automated: the allowed-domain check is covered end to end through `AuthInterceptor.onRequest()` against a real `Services` and `ServicesV2` catalog, asserting the header is attached for a url under an allowed domain and that the token is never requested for one that is not. Verified these fail if the matcher is reverted to a substring comparison.
- Lint and `tsconfig.typecheck.json` clean.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.



