### PR TITLE
feat: skip emitting no-audio metrics in lobby

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8494,7 +8494,8 @@ export default class Meeting extends StatelessWebexPlugin {
           return !member.isSelf && !member.isPairedWithSelf && !member.isAudioMuted;
         });
 
-        if (atLeastOneUnmutedOtherMember) {
+        // we also ignore any issues while we're waiting in the lobby, as we're not receiving any audio yet
+        if (atLeastOneUnmutedOtherMember && !this.isUserUnadmitted) {
           this.mediaProperties.sendMediaIssueMetric('inbound_audio', data.issueSubType, {
             correlationId: this.correlationId,
             isMultistream: this.isMultistream,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6208,6 +6208,7 @@ describe('plugin-meetings', () => {
                 member2: unmutedMember,
                 member3: selfMember,
               });
+              meeting.isUserUnadmitted = false;
 
               // Reset the stub to clear any previous calls
               TriggerProxy.trigger.resetHistory();
@@ -6232,6 +6233,41 @@ describe('plugin-meetings', () => {
                   isMultistream: meeting.isMultistream,
                 }
               );
+            });
+
+            it('should not trigger event or metric when the user is in the lobby', () => {
+              const fakeEventData = {issueSubType: 'DECODE_RESULTS_IN_ZERO_AUDIO_LEVEL'};
+
+              const unmutedMember = {
+                isSelf: false,
+                isPairedWithSelf: false,
+                isAudioMuted: false,
+              };
+              const selfMember = {
+                isSelf: true,
+                isPairedWithSelf: false,
+                isAudioMuted: false,
+              };
+              meeting.members.membersCollection.getAll = sinon.stub().returns({
+                member1: unmutedMember,
+                member2: selfMember,
+              });
+              meeting.isUserUnadmitted = true;
+
+              // Reset the stub to clear any previous calls
+              TriggerProxy.trigger.resetHistory();
+
+              // Emit the event from statsMonitor
+              listeners[StatsMonitorEventNames.INBOUND_AUDIO_ISSUE](fakeEventData);
+
+              assert.neverCalledWith(
+                TriggerProxy.trigger,
+                meeting,
+                sinon.match.object,
+                EVENT_TRIGGERS.MEDIA_INBOUND_AUDIO_ISSUE_DETECTED,
+                fakeEventData
+              );
+              assert.notCalled(meeting.mediaProperties.sendMediaIssueMetric);
             });
           });
         });


### PR DESCRIPTION
# COMPLETES #SPARK-838466

## This pull request addresses

The `MEDIA_ISSUE_DETECTED` behavioral metric emitted for inbound audio issues did not record whether the meeting was using a multistream or transcoded media connection. Without that dimension the metric cannot be sliced by connection type, so it is impossible to tell whether a spike in `inbound_audio` issues is specific to multistream.

Separately, the inbound audio issue detection was running for users still waiting in the lobby. Unadmitted users are not receiving meeting audio yet, so any inbound audio issue reported in that state is spurious — it was polluting the metric and surfacing a misleading `media:inboundAudio:issueDetected` event to the client app.

## by making the following changes

- `MediaProperties.sendMediaIssueMetric()` now takes a `metadata` object (`{correlationId, isMultistream}`) in place of the previous positional `correlationId` argument. The whole object is spread into the behavioral metric payload, so adding further dimensions later no longer requires a signature change.
- `Meeting.createStatsAnalyzer()` passes `isMultistream` alongside `correlationId` when reporting an `inbound_audio` issue.
- The inbound audio issue handler now also checks `!this.isUserUnadmitted`. While the local user is in the lobby, neither the behavioral metric nor the `media:inboundAudio:issueDetected` app event is emitted.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

> Note: `sendMediaIssueMetric()` is an internal method with a single call site inside `plugin-meetings`; it is not part of the public SDK surface, so the signature change is not breaking for integrators.

## The following scenarios were tested

Unit tests in `packages/@webex/plugin-meetings`:

`test/unit/spec/media/properties.ts` — updated the four existing `sendMediaIssueMetric` specs to the new metadata-object signature, asserting the full metadata is forwarded into the metric payload:

- sends a behavioral metric with the correct parameters
- increments the issue count while throttled and resets it once the metric goes out
- tracks different issue types separately in counters
- flushes throttled metrics when `unsetPeerConnection()` is called

`test/unit/spec/meeting/index.js` — `INBOUND_AUDIO_ISSUE` event handling:

- does not trigger the event or metric when no unmuted other members exist (existing)
- triggers the event and sends the metric with `{correlationId, isMultistream}` when at least one other member is unmuted (updated for the new signature)
- does not trigger the event or metric when the user is in the lobby (new)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
