### PR TITLE
feat(internal-plugin-metrics): report browser support flags on clientInfo

### DIFF
--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@webex/common": "workspace:*",
     "@webex/common-timers": "workspace:*",
-    "@webex/event-dictionary-ts": "^1.0.2215",
+    "@webex/event-dictionary-ts": "^1.0.2220",
     "@webex/test-helper-chai": "workspace:*",
     "@webex/test-helper-mock-webex": "workspace:*",
     "@webex/webex-core": "workspace:*",

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -289,6 +289,13 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       versionMetadata = extractVersionMetadata(providedClientVersion);
     }
 
+    // The host client owns the browser support policy, since it is the same decision that drives
+    // its blocked-browser page and outdated-browser banner. The SDK reports the booleans as given.
+    // @ts-ignore
+    const {isSupportedBrowserFamily, isOutdatedBrowserVersion} =
+      // @ts-ignore
+      this.webex.meetings.config?.metrics ?? {};
+
     if (!this.hasLoggedBrowserSerial) {
       this.logger.log(
         CALL_DIAGNOSTIC_LOG_IDENTIFIER,
@@ -331,6 +338,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           os: getOSNameInternal(),
           browser: getBrowserName(),
           browserVersion: getBrowserVersion(),
+          ...(isSupportedBrowserFamily !== undefined && {isSupportedBrowserFamily}),
+          ...(isOutdatedBrowserVersion !== undefined && {isOutdatedBrowserVersion}),
         },
       };
 
@@ -360,19 +369,6 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
 
       if (options?.vendorId) {
         origin.clientInfo.vendorId = options.vendorId;
-      }
-
-      // Set once by the host client rather than per event: the browser cannot change mid-session,
-      // so these stay constant for a correlationId. Call analyzer derives clientVersionStatus.
-      // @ts-ignore
-      const metricsConfig = this.webex.meetings.config?.metrics;
-
-      if (metricsConfig?.isSupportedBrowserFamily !== undefined) {
-        origin.clientInfo.isSupportedBrowserFamily = metricsConfig.isSupportedBrowserFamily;
-      }
-
-      if (metricsConfig?.isOutdatedBrowserVersion !== undefined) {
-        origin.clientInfo.isOutdatedBrowserVersion = metricsConfig.isOutdatedBrowserVersion;
       }
 
       return origin;

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -289,12 +289,17 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       versionMetadata = extractVersionMetadata(providedClientVersion);
     }
 
-    // Derived by the host client from the browser it observed, since the support policy that turns
-    // a browser and version into these booleans belongs to the client, not the SDK.
-    // @ts-ignore
-    const {isSupportedBrowserFamily, isOutdatedBrowserVersion} =
+    // Browser details and the support verdict can all be supplied by the host client, which is able
+    // to resolve wrapper browsers (Electron, WebOS) to the engine that actually determines
+    // capability. The browser fields fall back to the SDK's own detection when not supplied, the
+    // same way clientVersion falls back to the SDK version.
+    const {
+      browser: providedBrowser,
+      browserVersion: providedBrowserVersion,
+      isSupportedBrowserFamily,
+      isOutdatedBrowserVersion,
       // @ts-ignore
-      this.webex.meetings.config?.metrics ?? {};
+    } = this.webex.meetings.config?.metrics ?? {};
 
     if (!this.hasLoggedBrowserSerial) {
       this.logger.log(
@@ -336,8 +341,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           osVersion: getOSVersion() || 'unknown',
           subClientType: options?.subClientType || defaultSubClientType,
           os: getOSNameInternal(),
-          browser: getBrowserName(),
-          browserVersion: getBrowserVersion(),
+          browser: providedBrowser || getBrowserName(),
+          browserVersion: providedBrowserVersion || getBrowserVersion(),
           ...(isSupportedBrowserFamily === undefined ? {} : {isSupportedBrowserFamily}),
           ...(isOutdatedBrowserVersion === undefined ? {} : {isOutdatedBrowserVersion}),
         },

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -289,8 +289,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       versionMetadata = extractVersionMetadata(providedClientVersion);
     }
 
-    // The host client owns the browser support policy, since it is the same decision that drives
-    // its blocked-browser page and outdated-browser banner. The SDK reports the booleans as given.
+    // Derived by the host client from the browser it observed, since the support policy that turns
+    // a browser and version into these booleans belongs to the client, not the SDK.
     // @ts-ignore
     const {isSupportedBrowserFamily, isOutdatedBrowserVersion} =
       // @ts-ignore
@@ -338,8 +338,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           os: getOSNameInternal(),
           browser: getBrowserName(),
           browserVersion: getBrowserVersion(),
-          ...(isSupportedBrowserFamily !== undefined && {isSupportedBrowserFamily}),
-          ...(isOutdatedBrowserVersion !== undefined && {isOutdatedBrowserVersion}),
+          ...(isSupportedBrowserFamily === undefined ? {} : {isSupportedBrowserFamily}),
+          ...(isOutdatedBrowserVersion === undefined ? {} : {isOutdatedBrowserVersion}),
         },
       };
 

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -362,6 +362,19 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         origin.clientInfo.vendorId = options.vendorId;
       }
 
+      // Set once by the host client rather than per event: the browser cannot change mid-session,
+      // so these stay constant for a correlationId. Call analyzer derives clientVersionStatus.
+      // @ts-ignore
+      const metricsConfig = this.webex.meetings.config?.metrics;
+
+      if (metricsConfig?.isSupportedBrowserFamily !== undefined) {
+        origin.clientInfo.isSupportedBrowserFamily = metricsConfig.isSupportedBrowserFamily;
+      }
+
+      if (metricsConfig?.isOutdatedBrowserVersion !== undefined) {
+        origin.clientInfo.isOutdatedBrowserVersion = metricsConfig.isOutdatedBrowserVersion;
+      }
+
       return origin;
     }
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -394,6 +394,32 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('builds origin correctly with browser details provided by the host client', () => {
+        // host resolves wrapper browsers (WebOS, Electron) to the engine that determines capability
+        webex.meetings.config.metrics.browser = 'WebOS Browser';
+        webex.meetings.config.metrics.browserVersion = '108.0.0.0';
+
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.equal(res.clientInfo.browser, 'WebOS Browser');
+        assert.equal(res.clientInfo.browserVersion, '108.0.0.0');
+      });
+
+      it('falls back to SDK browser detection when the host provides nothing', () => {
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.equal(res.clientInfo.browser, getBrowserName());
+        assert.equal(res.clientInfo.browserVersion, getBrowserVersion());
+      });
+
       it('builds origin correctly with the browser support flags from config', () => {
         // `false` is the meaningful "unsupported family" signal, so it must survive a truthy check
         webex.meetings.config.metrics.isSupportedBrowserFamily = false;

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -394,6 +394,38 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('builds origin correctly with the browser support flags from config', () => {
+        // `false` is the meaningful "unsupported family" signal, so it must survive a truthy check
+        webex.meetings.config.metrics.isSupportedBrowserFamily = false;
+        webex.meetings.config.metrics.isOutdatedBrowserVersion = true;
+
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.deepEqual(res, {
+          clientInfo: {
+            browser: getBrowserName(),
+            browserVersion: getBrowserVersion(),
+            clientType: 'TEAMS_CLIENT',
+            clientVersion: 'webex-js-sdk/webex-version',
+            publicNetworkPrefix: '1.3.4.0',
+            localNetworkPrefix: '192.168.1.80',
+            os: getOSNameInternal(),
+            osVersion: getOSVersion() || 'unknown',
+            subClientType: 'WEB_APP',
+            isSupportedBrowserFamily: false,
+            isOutdatedBrowserVersion: true,
+          },
+          environment: 'meeting_evn',
+          name: 'endpoint',
+          networkType: 'unknown',
+          userAgent,
+        });
+      });
+
       it('should build origin correctly with no meeting or stats analyzer', () => {
         //@ts-ignore
         const res = cd.getOrigin();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7707,6 +7707,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/event-dictionary-ts@npm:^1.0.2220":
+  version: 1.0.2220
+  resolution: "@webex/event-dictionary-ts@npm:1.0.2220"
+  dependencies:
+    amf-client-js: ^5.2.6
+    json-schema-to-typescript: ^15.0.4
+    minimist: ^1.2.8
+    shelljs: ^0.8.5
+    webapi-parser: ^0.5.0
+  checksum: 63078dff6261a170db655f06615ad53d7bf7c049b39e442743a42f74db6df9f32b4be77c1cbf6fcf17c13739979411d30ad90ba80000ce2254c44ccef7022f58
+  languageName: node
+  linkType: hard
+
 "@webex/helper-html@workspace:*, @webex/helper-html@workspace:packages/@webex/helper-html":
   version: 0.0.0-use.local
   resolution: "@webex/helper-html@workspace:packages/@webex/helper-html"
@@ -8243,7 +8256,7 @@ __metadata:
     "@webex/common": "workspace:*"
     "@webex/common-timers": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/event-dictionary-ts": ^1.0.2215
+    "@webex/event-dictionary-ts": ^1.0.2220
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"


### PR DESCRIPTION
## Summary

Two related changes to `origin.clientInfo` on call analyzer diagnostic events.

**1. Report two new fields** added in [event-dictionary #2539](https://sqbu-github.cisco.com/WebExSquared/event-dictionary/pull/2539) (WEBEX-499767): `isSupportedBrowserFamily` and `isOutdatedBrowserVersion`. The SDK does not decide these and holds no browser support policy — turning a browser and version into a support verdict is a client policy decision, so it stays with the client that owns it.

**2. Let a host client supply `browser` and `browserVersion`**, falling back to the SDK's own `BrowserDetection` when not supplied — mirroring how `clientVersion` already falls back to the SDK version:

```ts
browser: providedBrowser || getBrowserName(),
browserVersion: providedBrowserVersion || getBrowserVersion(),
```

This exists because the flags in (1) are *derived from a browser observation*, and the SDK re-observes the user agent independently, so the two could disagree. A host that resolves wrapper browsers can now keep them consistent.

Measured across 12 user agents, opting in changes very little:

| | result |
| --- | --- |
| `browser` (name) | **unchanged in all 12** — host and SDK both use bowser's name |
| `browserVersion` | changes in **2**, both fixes |

- **WebOS** — bowser yields an empty version, which the batcher strips, so `browserVersion` is **absent on call analyzer events today**. A host can supply the Chrome version it already resolves (`108.0.0.0`).
- **Electron** — `28.0.0` becomes the Chrome engine version `120.0.0.0`, which is what actually determines capability and what `isOutdatedBrowserVersion` is computed from.

Nothing changes for any consumer that does not opt in; there is a test asserting the fallback.

## Where the values are read from

`getOrigin()` is the only place `clientInfo` is built, and it already groups its inputs by lifetime:

| source | fields | nature |
| --- | --- | --- |
| environment, via memoized `BrowserDetection` | `os`, `osVersion`, `browser`, `browserVersion` | session constant, observed |
| `webex.meetings.config.metrics` | `clientType`, `subClientType`, `clientVersion` (+ derived `majorVersion` / `minorVersion`) | session constant, host owned |
| per-event `options` | `clientLaunchMethod`, `browserLaunchMethod`, `vendorId` | varies per event or flow |

The browser cannot change mid-session, so both flags are session constant and host owned, placing them with `clientType` / `subClientType` / `clientVersion`. They are read from `webex.meetings.config.metrics` and set inside the `clientInfo` literal next to `browser` and `browserVersion`, since they describe the browser.

Per-event `options` would not work regardless of preference. `prepareDiagnosticEvent()` is shared by ClientEvent, FeatureEvent and MediaQualityEvent, but `submitMQE()` is only called from inside `plugin-meetings` (`meeting/index.ts`) on a timer. A host client never calls it and so can never pass it options. Config is the only channel that reaches all three event types.

## Optional-key handling

```ts
...(isSupportedBrowserFamily === undefined ? {} : {isSupportedBrowserFamily}),
...(isOutdatedBrowserVersion === undefined ? {} : {isOutdatedBrowserVersion}),
```

The guard tests `undefined` rather than truthiness because `false` is the meaningful "unsupported family" signal and a truthy check would silently drop it. The `=== undefined ? {} : {x}` form matches the existing `httpStatusCode` handling in this file. The keys stay absent when a host sets nothing, which the existing `#getOrigin` tests assert by comparing the exact `clientInfo` shape.

## Dependency

Raises the `@webex/event-dictionary-ts` floor in `internal-plugin-metrics` to `^1.0.2220`, the first published version containing the fields. Verified this is genuinely required: building against `1.0.2215` fails with `TS2339: Property 'isSupportedBrowserFamily' does not exist`. `plugin-meetings` is intentionally left at `^1.0.2215` since it does not reference the new fields.

## Testing

- Three new unit tests: the support flags (asserting `false` / `true` specifically to guard the falsy case), host-supplied browser details, and fallback to SDK detection when the host supplies nothing.
- `yarn test:unit` for `internal-plugin-metrics`: **496 passing** vs **493 passing** on the unmodified branch, with the same single pre-existing `MetricsBatcher` failure before and after.
- `tsc` clean, `eslint` clean.
- Validated in a real browser rather than only against mocks: the Webex web client was built with `SDK_DIR` pointed at this branch and `getOrigin()` was called on the live SDK.

| case | result |
| --- | --- |
| host supplies all four values | all four land on `origin.clientInfo` |
| `isSupportedBrowserFamily: false` | survives, including through `JSON.stringify` — confirms the guard is not a truthiness check |
| host supplies nothing | both keys absent; `browser` / `browserVersion` fall back to `BrowserDetection` (`Chrome` / `151.0.0.0`) |
| host overrides browser details | `WebOS Browser` / `108.0.0.0` reported instead of SDK detection |

## Related

- Jira: https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-499767
- Event dictionary: https://sqbu-github.cisco.com/WebExSquared/event-dictionary/pull/2539
- Web client counterpart (computes the values): https://github.com/WebexServices/webex-web-client/pull/11721


