### PR TITLE
fix(webex-core): re-evaluate credentials on app level redirects

### DIFF
--- a/packages/@webex/webex-core/src/interceptors/redirect.js
+++ b/packages/@webex/webex-core/src/interceptors/redirect.js
@@ -11,6 +11,34 @@ const requestHeaderName = 'cisco-no-http-redirect';
 const responseHeaderName = 'cisco-location';
 const LOCUS_REDIRECT_ERROR = 2000002;
 const APPAPI_REDIRECT_ERROR = 404100;
+// The status code both body based redirects are documented to arrive with, and
+// the one `HttpStatusInterceptor` pairs each of the error codes above with.
+const REDIRECT_ERROR_STATUS_CODE = 404;
+
+/**
+ * Copies the options of a request that is about to be re-issued against a uri
+ * taken from the previous response.
+ *
+ * The copy drops any `authorization` header carried over from the previous
+ * request. `AuthInterceptor` returns early when a request already carries that
+ * header, so a carried-over header means the interceptor never evaluates the
+ * new uri. Dropping it lets the interceptor make its normal decision against
+ * the uri that is actually about to be requested.
+ *
+ * @param {Object} options - The options of the request being redirected.
+ * @returns {Object} - A copy of the options, without inherited credentials.
+ */
+function cloneOptionsForRedirect(options) {
+  const redirectOptions = clone(options);
+
+  // `clone()` is shallow, so `headers` is still the previous request's object.
+  if (redirectOptions.headers) {
+    redirectOptions.headers = {...redirectOptions.headers};
+    Reflect.deleteProperty(redirectOptions.headers, 'authorization');
+  }
+
+  return redirectOptions;
+}
 
 /**
  * @class
@@ -65,7 +93,7 @@ export default class RedirectInterceptor extends Interceptor {
   onResponse(options, response) {
     /* eslint-disable no-else-return */
     if (response.headers && response.headers[responseHeaderName]) {
-      options = clone(options);
+      options = cloneOptionsForRedirect(options);
       options.uri = response.headers[responseHeaderName];
       options.$redirectCount += 1;
       if (options.$redirectCount > this.webex.config.maxAppLevelRedirects) {
@@ -74,12 +102,13 @@ export default class RedirectInterceptor extends Interceptor {
 
       return this.webex.request(options);
     } else if (
+      response.statusCode === REDIRECT_ERROR_STATUS_CODE &&
       response.headers &&
       response.body &&
       response.body.errorCode === LOCUS_REDIRECT_ERROR &&
       response.body.location
     ) {
-      options = clone(options);
+      options = cloneOptionsForRedirect(options);
 
       this.webex.logger.warn('redirect: url redirects needed from', options.uri);
       if (response.options && response.options.qs) {
@@ -100,13 +129,14 @@ export default class RedirectInterceptor extends Interceptor {
 
       return this.webex.request(options);
     } else if (
+      response.statusCode === REDIRECT_ERROR_STATUS_CODE &&
       response.headers &&
       response.body &&
       response.body.code === APPAPI_REDIRECT_ERROR &&
       response.body.data &&
       response.body.data.siteFullUrl
     ) {
-      options = clone(options);
+      options = cloneOptionsForRedirect(options);
 
       this.webex.logger.warn('redirect: url redirects needed from', options.uri);
       if (response.options && response.options.qs) {

--- a/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
+++ b/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
@@ -7,8 +7,16 @@
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
-import {RedirectInterceptor, config, Credentials} from '@webex/webex-core';
-import {cloneDeep} from 'lodash';
+import {
+  AuthInterceptor,
+  RedirectInterceptor,
+  config,
+  Credentials,
+  Services,
+  ServicesV2,
+  Token,
+} from '@webex/webex-core';
+import {cloneDeep, merge} from 'lodash';
 
 describe('webex-core', () => {
   describe('Interceptors', () => {
@@ -20,8 +28,8 @@ describe('webex-core', () => {
           children: {
             credentials: Credentials,
           },
-          config: cloneDeep(config),
-          request: sinon.spy(),
+          config: merge(cloneDeep(config), {credentials: {client_secret: 'fake'}}),
+          request: sinon.stub().resolves({}),
         });
 
         interceptor = Reflect.apply(RedirectInterceptor.create, webex, []);
@@ -97,6 +105,20 @@ describe('webex-core', () => {
           assert.equal(interceptor.onResponse({$redirectCount: 5}, response), response);
         });
 
+        it('returns when a locus redirect body arrives on a response that is not a 404', () => {
+          const response = {
+            statusCode: 200,
+            headers: {},
+            body: {
+              errorCode: 2000002,
+              location: 'http://newlocus.example.com',
+            },
+          };
+
+          assert.equal(interceptor.onResponse({$redirectCount: 0}, response), response);
+          assert.notCalled(webex.request);
+        });
+
         it('redirects GET requests to new url on appapi redirect error', () => {
           const response = {
             statusCode: 404,
@@ -169,6 +191,28 @@ describe('webex-core', () => {
           });
         });
 
+        it('returns when an appapi redirect body arrives on a response that is not a 404', () => {
+          const response = {
+            statusCode: 200,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {
+                siteFullUrl: 'newlocus.example.com'
+              },
+            },
+          };
+
+          assert.equal(
+            interceptor.onResponse(
+              {$redirectCount: 0, uri: 'https://test.webex.com/meet/v1/join'},
+              response
+            ),
+            response
+          );
+          assert.notCalled(webex.request);
+        });
+
         it('removes authorization header when redirecting preJoin request to webex-appapi-service', () => {
           const response = {
             statusCode: 404,
@@ -203,7 +247,7 @@ describe('webex-core', () => {
           }));
         });
 
-        it('keeps authorization header for non-preJoin requests on appapi redirect', () => {
+        it('does not forward the authorization header for non-preJoin requests on appapi redirect', () => {
           const response = {
             statusCode: 404,
             headers: {},
@@ -229,13 +273,13 @@ describe('webex-core', () => {
           sinon.assert.calledWith(webex.request, sinon.match({
             $redirectCount: 1,
             uri: 'https://newlocus.example.com/meet/v1/join',
-            headers: {
-              authorization: 'Bearer token123',
-            },
           }));
+          assert.notProperty(webex.request.firstCall.args[0].headers, 'authorization');
+          // the options of the request being redirected are left untouched
+          assert.equal(options.headers.authorization, 'Bearer token123');
         });
 
-        it('keeps authorization header for preJoin requests to non-webex-appapi-service', () => {
+        it('does not forward the authorization header for preJoin requests to non-webex-appapi-service', () => {
           const response = {
             statusCode: 404,
             headers: {},
@@ -261,10 +305,123 @@ describe('webex-core', () => {
           sinon.assert.calledWith(webex.request, sinon.match({
             $redirectCount: 1,
             uri: 'https://newlocus.example.com/meet/v1/preJoin',
-            headers: {
-              authorization: 'Bearer token123',
-            },
           }));
+          assert.notProperty(webex.request.firstCall.args[0].headers, 'authorization');
+          assert.equal(options.headers.authorization, 'Bearer token123');
+        });
+      });
+
+      describe('#onResponse() against a real service catalog', () => {
+        // Whether a request carries credentials is decided by the auth
+        // interceptor, and it returns early when the request already has an
+        // authorization header. So asserting that the header is not forwarded
+        // is only half of it: these cases run the redirected request back
+        // through the auth interceptor, with a real catalog and real
+        // allowed-domain methods, to show that the decision is remade against
+        // the uri taken from the response.
+        const inheritedToken = 'Bearer inherited-token';
+        const allowedHost = 'locus-eu.webex.com';
+        const otherHost = 'unrelated.example';
+
+        const responses = {
+          'a cisco-location header': (host) => ({
+            statusCode: 404,
+            headers: {'cisco-location': `https://${host}/resource`},
+          }),
+          'a locus redirect error': (host) => ({
+            statusCode: 404,
+            headers: {},
+            body: {
+              errorCode: 2000002,
+              location: `https://${host}/resource`,
+            },
+          }),
+          'an appapi redirect error': (host) => ({
+            statusCode: 404,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {siteFullUrl: host},
+            },
+          }),
+        };
+
+        [
+          {name: 'Services', Constructor: Services},
+          {name: 'ServicesV2', Constructor: ServicesV2},
+        ].forEach(({name, Constructor}) => {
+          describe(name, () => {
+            let authInterceptor, getUserToken;
+
+            beforeEach(() => {
+              const services = new Constructor(undefined, {parent: webex});
+
+              services._getCatalog().setAllowedDomains(['webex.com']);
+              // the catalog holds no services, so a url that is not covered by
+              // an allowed domain has nothing else to authorize it
+              services.waitForService = sinon.stub().rejects(new Error('no such service'));
+
+              webex.internal.services = services;
+              webex.credentials.supertoken = new Token(
+                {
+                  access_token: 'ST1',
+                  token_type: 'Bearer',
+                },
+                {parent: webex}
+              );
+
+              getUserToken = sinon.spy(webex.credentials, 'getUserToken');
+              authInterceptor = Reflect.apply(AuthInterceptor.create, webex, []);
+            });
+
+            afterEach(() => {
+              getUserToken.restore();
+              delete webex.internal.services;
+            });
+
+            Object.keys(responses).forEach((trigger) => {
+              describe(`redirected by ${trigger}`, () => {
+                // Redirects the request and returns the options the redirected
+                // request was issued with.
+                const redirect = (host) => {
+                  const options = {
+                    $redirectCount: 0,
+                    uri: 'https://api.webex.com/resource',
+                    headers: {authorization: inheritedToken},
+                  };
+
+                  interceptor.onResponse(options, responses[trigger](host));
+
+                  assert.calledOnce(webex.request);
+                  // the options of the request being redirected are left untouched
+                  assert.equal(options.headers.authorization, inheritedToken);
+
+                  return webex.request.firstCall.args[0];
+                };
+
+                it('does not forward the authorization header', () => {
+                  assert.notProperty(redirect(allowedHost).headers, 'authorization');
+                });
+
+                it('authorizes the redirected request when the new uri is under an allowed domain', () =>
+                  authInterceptor.onRequest(redirect(allowedHost)).then((options) => {
+                    assert.equal(options.uri, `https://${allowedHost}/resource`);
+                    assert.equal(
+                      options.headers.authorization,
+                      webex.credentials.supertoken.toString()
+                    );
+                    assert.calledOnce(getUserToken);
+                  }));
+
+                it('does not authorize the redirected request when the new uri is not', () =>
+                  authInterceptor.onRequest(redirect(otherHost)).then((options) => {
+                    assert.equal(options.uri, `https://${otherHost}/resource`);
+                    assert.notProperty(options.headers, 'authorization');
+                    assert.notCalled(getUserToken);
+                  }));
+              });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/FPV-747

## This pull request addresses

`RedirectInterceptor.onResponse()` re-issues a request against a uri taken from the previous response. It copied the request options with lodash `clone()`, which is shallow, so the re-issued request kept the *same* `headers` object as the request it replaced.

`AuthInterceptor.onRequest()` returns early when a request already carries an `authorization` header. A carried-over header therefore meant `requiresCredentials()` never ran on the re-issued request, so neither the service catalog nor the allowed-domain list was evaluated against the uri that was about to be requested. All three redirect branches were affected: the `cisco-location` response header, the Locus `errorCode` body, and the AppAPI `code` / `siteFullUrl` body.

Separately, the two body-based branches keyed only off the response body and not off its status code, so they could act on a response that is not a redirect.

This is a different mechanism from #5144. That change made the allowed-domain comparison exact; this one is about that check not being reached. Neither fixes the other.

## by making the following changes

All three branches now copy `headers` as well, and drop the `authorization` inherited from the previous request, through a single shared helper:

```js
options = cloneOptionsForRedirect(options);
```

`AuthInterceptor` then makes its normal decision against the uri that is actually about to be requested — the catalog lookup and the allowed-domain check both run — instead of returning early. Switching `clone()` to `cloneDeep()` would not have been sufficient: it copies the header through unchanged.

The two body-based branches additionally require the `404` they are documented to arrive with. This is the same status `HttpStatusInterceptor` already pairs with each of the two error codes.

The existing `preJoin` / `webex-appapi-service` case still sets `authorization: false` explicitly, so that request stays unauthenticated — `AuthInterceptor` treats a falsy value as "delete it and do not add one".

### Compatibility

Legitimate redirects continue to be authorized. Their targets are Locus hosts under `wbx2.com` and Webex sites under `webex.com`, both of which are in `COMMERCIAL_ALLOWED_DOMAINS`. Foreign-cluster Locus hosts are additionally present in the service catalog, because `_formatReceivedHostmap()` collects every host that shares a service id, including those with `homeCluster: false`, and `findServiceUrlFromUrl()` matches against all of them. The same holds for FedRAMP, the narrowest allowlist, whose catalog and allowed domains are both gov hosts. On a legitimate redirect the header is re-attached by `AuthInterceptor` rather than carried over.

A caller that sets `headers.authorization` by hand, rather than letting `AuthInterceptor` attach it, no longer has that exact value forwarded across a redirect; the interceptor re-derives the header for the new uri. No in-tree caller that sets the header by hand is on a redirecting path, and those that do set it (`webinar`, `user`, `support`) set the user token, which is what the interceptor attaches. Callers that use `options.auth` are unaffected, because `AuthInterceptor` still returns early for those.

For the status code: `HttpStatusInterceptor` runs before `RedirectInterceptor` on responses, and already rejects a response of `400` or above carrying either body unless it is a `404`. The new condition therefore only changes what happens to responses below `400`, which are not redirects.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Automated: `yarn workspace @webex/webex-core test:unit` — 33 suites, 758 tests passing.
- Automated: each of the three branches is now exercised end to end against a real `Services` and a real `ServicesV2` catalog, following the pattern added in #5144. The real `hasAllowedDomains()` / `isAllowedDomainUrl()` are kept rather than stubbed, and `waitForService` is made to reject so that an allowed domain is the only thing that can authorize the request. Each branch asserts that the header is not forwarded, that a redirect to a uri under an allowed domain is still authorized with the user token, and that a redirect to a uri that is under neither the catalog nor an allowed domain is issued with no `authorization` header and does not request a token. The options of the request being redirected are asserted to be left untouched.
- Automated: both body-based branches assert that a redirect-shaped body on a non-404 response is returned rather than followed.
- Verified that all 22 new and changed assertions fail when the change is reverted.
- Automated: `yarn workspace @webex/plugin-meetings test:unit` — 3698 passing. No `plugin-meetings` changes; run because it is the largest consumer of the redirecting services.
- `yarn workspace @webex/webex-core test:style` — no new findings.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
