### PR TITLE
fix: bump internal-media-core to 2.29.0

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.28.2",
+    "@webex/internal-media-core": "2.29.0",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.34.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@webex/common": "workspace:*",
     "@webex/event-dictionary-ts": "^1.0.2215",
-    "@webex/internal-media-core": "2.28.2",
+    "@webex/internal-media-core": "2.29.0",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -44,7 +44,7 @@
     "@types/platform": "1.3.4",
     "@webex/common": "workspace:*",
     "@webex/common-timers": "workspace:*",
-    "@webex/internal-media-core": "2.28.2",
+    "@webex/internal-media-core": "2.29.0",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-feature": "workspace:*",
     "@webex/internal-plugin-metrics": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7443,7 +7443,7 @@ __metadata:
     "@web/dev-server": 0.4.5
     "@webex/common": "workspace:*"
     "@webex/common-timers": "workspace:*"
-    "@webex/internal-media-core": 2.28.2
+    "@webex/internal-media-core": 2.29.0
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-feature": "workspace:*"
     "@webex/internal-plugin-metrics": "workspace:*"
@@ -7783,23 +7783,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.28.2":
-  version: 2.28.2
-  resolution: "@webex/internal-media-core@npm:2.28.2"
+"@webex/internal-media-core@npm:2.29.0":
+  version: 2.29.0
+  resolution: "@webex/internal-media-core@npm:2.29.0"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@babel/runtime-corejs2": ^7.25.0
     "@webex/rtcstats": ^1.5.5
     "@webex/ts-sdp": 1.8.2
     "@webex/web-capabilities": ^1.10.0
-    "@webex/web-client-media-engine": 3.42.1
+    "@webex/web-client-media-engine": 3.43.0
     events: ^3.3.0
     ip-anonymize: ^0.1.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: c3a4421d7a4d3dfa25f3f45497ae304d4f66d953e56b33caaba747b7d4f700e36f3838e02cdb2d4f5c882d2330d3039ae308261787bd44d21fad00a31a5a9e91
+  checksum: 987c019abc4c18487646687e78d303a63c4c7e994c2fd186098a14e672de6297268982a58c799007b38d9c85fd22ef2bc5f2750b88e9c5bef8692ffdec2bdc34
   languageName: node
   linkType: hard
 
@@ -8631,7 +8631,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.28.2
+    "@webex/internal-media-core": 2.29.0
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8899,7 +8899,7 @@ __metadata:
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/event-dictionary-ts": ^1.0.2215
-    "@webex/internal-media-core": 2.28.2
+    "@webex/internal-media-core": 2.29.0
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -9633,9 +9633,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.42.1":
-  version: 3.42.1
-  resolution: "@webex/web-client-media-engine@npm:3.42.1"
+"@webex/web-client-media-engine@npm:3.43.0":
+  version: 3.43.0
+  resolution: "@webex/web-client-media-engine@npm:3.43.0"
   dependencies:
     "@webex/json-multistream": ^2.4.3
     "@webex/rtcstats": ^1.5.5
@@ -9648,7 +9648,7 @@ __metadata:
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: 76b3e84e6de0be04804bd177f95cad8ba089152f0454b49a9b148fb4715f6f0abaaa15030731d870c17f660b41b4e65a376f49669981e8dc470548be9008513c
+  checksum: b1de9fbe73d99f8204aff8c0f90e3656486a5db03a89ab214978e803b68dec482132fe87f9db622f07b467e2aa52abc26c657be6170c286491df46877d328906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

# COMPLETES [SPARK-833463](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-833463)


## This pull request addresses

Keeping SDK media dependencies aligned with the latest `@webex/internal-media-core` release so meetings, calling, and media helpers pick up upstream media diagnostics and stats improvements.

## by making the following changes

### Dependency updates

| Package | Previous | New | Updated in |
| --- | --- | --- | --- |
| `@webex/internal-media-core` | `2.28.2` | `2.29.0` | `media-helpers`, `plugin-meetings`, `calling` |
| `@webex/web-client-media-engine` *(transitive)* | `3.42.1` | `3.43.0` | via `yarn.lock` |

No SDK source code changes — this PR only bumps dependency versions and refreshes the lockfile.

### What's new upstream (2.28.2 → 2.29.0)

#### 1. Remote audio first-frame delay detection (`internal-media-core`)

`StatsMonitor` now detects when inbound remote audio takes too long to produce its first decoded frame after media monitoring starts.

- Adds `REMOTE_AUDIO_FIRST_FRAME_DELAY_THRESHOLD_MS` (**5000 ms**)
- Adds new inbound audio issue subtype: `InboundAudioIssueSubTypes.REMOTE_AUDIO_FIRST_FRAME_DELAY`
- Adds `StatsMonitor.start()` / `StatsMonitor.stop()` lifecycle hooks to anchor the measurement window
- After 5 s, if no `firstAudioFrameTimestamp` is seen (or delay exceeds threshold), emits an inbound audio issue event

**SDK impact:** meetings and calling that use `StatsAnalyzer` / `StatsMonitor` can now surface this via the existing `MEDIA_INBOUND_AUDIO_ISSUE_DETECTED` event (`media:inboundAudio:issueDetected`). `media-helpers` re-exports the new `InboundAudioIssueSubTypes` value.

#### 2. Inbound RTP stats enrichment (`web-client-media-engine` 3.43.0)

WCME now maps `receivedAudioFrameCount` from encoded stream metadata into inbound RTP stats. This lets `StatsMonitor` tell whether the encoded audio transform path is active before evaluating first-frame delay.

**SDK impact:** improved media quality diagnostics without API changes in the SDK itself.

### Affected SDK packages

- **`@webex/media-helpers`** — inherits updated WCME/media-core types and re-exports
- **`@webex/plugin-meetings`** — meeting media connections and stats analyzer behavior
- **`@webex/calling`** — calling media stack

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] `yarn install` completes successfully with updated lockfile
- [ ] `yarn workspace @webex/media-helpers test:unit`
- [ ] `yarn workspace @webex/plugin-meetings test:unit`
- [ ] `yarn workspace @webex/calling test:unit`
- [ ] Join a meeting and verify remote audio plays normally

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
