### PR TITLE
fix(oauth): exchange outcome

### DIFF
--- a/packages/@webex/plugin-authorization-browser-first-party/README.md
+++ b/packages/@webex/plugin-authorization-browser-first-party/README.md
@@ -178,13 +178,30 @@ webex.authorization.initQRCodeLogin();
 
 ### Properties
 
-| Property           | Type             | Description                                               |
-| ------------------ | ---------------- | --------------------------------------------------------- |
-| `isAuthorizing`    | boolean          | True while a grant request is in flight                   |
-| `isAuthenticating` | boolean          | Alias of `isAuthorizing`                                  |
-| `ready`            | boolean          | Set true after initial redirect/code processing completes |
-| `eventEmitter`     | EventEmitter     | Emits QR/Device login lifecycle events                    |
-| `Events`           | enum-like object | Accessible names for event types                          |
+| Property                               | Type             | Description                                               |
+| -------------------------------------- | ---------------- | --------------------------------------------------------- |
+| `initialAuthorizationCodeGrantOutcome` | string           | Retained outcome of the automatic initialization exchange |
+| `isAuthorizing`                        | boolean          | True while a grant request is in flight                   |
+| `isAuthenticating`                     | boolean          | Alias of `isAuthorizing`                                  |
+| `ready`                                | boolean          | Set true after initial redirect/code processing completes |
+| `eventEmitter`                         | EventEmitter     | Emits QR/Device login lifecycle events                    |
+| `Events`                               | enum-like object | Accessible names for event types                          |
+
+#### Initial authorization-code grant outcome
+
+`initialAuthorizationCodeGrantOutcome` describes only the automatic
+`requestAuthorizationCodeGrant()` call made while this authorization plugin
+instance initializes. Read it after `ready`:
+
+- `not_attempted`: initialization did not invoke the exchange.
+- `success`: the initialization exchange fulfilled.
+- `failure`: the initialization exchange threw or rejected.
+
+The value is a historical result retained for the lifetime of the SDK instance
+and is not reset by logout. It does not represent current authorization state
+or credentials hydrated from storage. It also does not track guest or device
+authentication, errors before the exchange begins, token refreshes, or
+authorization-code exchanges requested later on the same SDK instance.
 
 ## Security Considerations
 

--- a/packages/@webex/plugin-authorization-browser-first-party/README.md
+++ b/packages/@webex/plugin-authorization-browser-first-party/README.md
@@ -189,6 +189,14 @@ webex.authorization.initQRCodeLogin();
 
 #### Initial authorization-code grant outcome
 
+```javascript
+import {InitialAuthorizationCodeGrantOutcomes} from '@webex/plugin-authorization-browser-first-party';
+
+const didInitialExchangeSucceed =
+  webex.authorization.initialAuthorizationCodeGrantOutcome ===
+  InitialAuthorizationCodeGrantOutcomes.success;
+```
+
 `initialAuthorizationCodeGrantOutcome` describes only the automatic
 `requestAuthorizationCodeGrant()` call made while this authorization plugin
 instance initializes. Read it after `ready`:
@@ -200,8 +208,14 @@ instance initializes. Read it after `ready`:
 The value is a historical result retained for the lifetime of the SDK instance
 and is not reset by logout. It does not represent current authorization state
 or credentials hydrated from storage. It also does not track guest or device
-authentication, errors before the exchange begins, token refreshes, or
-authorization-code exchanges requested later on the same SDK instance.
+authentication, token refreshes, or authorization-code exchanges requested
+later on the same SDK instance.
+
+OAuth redirect errors and CSRF validation failures occur before the exchange,
+so the value remains `not_attempted`; these errors can throw before `ready`
+becomes `true`. A non-redirecting logout does not cancel an initialization
+exchange already in flight. If that exchange later settles, it can still update
+credentials and this retained outcome.
 
 ## Security Considerations
 

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -39,6 +39,13 @@ export const Events = {
   qRCodeLogin: 'qRCodeLogin',
 };
 
+export const InitialAuthorizationCodeGrantOutcomes = {
+  failure: 'failure',
+  notAttempted: 'not_attempted',
+  pending: 'pending',
+  success: 'success',
+};
+
 /**
  * Browser support for OAuth2 for first-party (Webex Web Client) usage.
  *
@@ -93,6 +100,13 @@ const Authorization = WebexPlugin.extend({
     isAuthorizing: {
       default: false,
       type: 'boolean',
+    },
+    /**
+     * Retains the outcome of the automatic startup authorization-code exchange.
+     */
+    initialAuthorizationCodeGrantOutcome: {
+      default: InitialAuthorizationCodeGrantOutcomes.notAttempted,
+      type: 'string',
     },
     /**
      * Indicates that the plugin has finished any automatic startup
@@ -232,8 +246,16 @@ const Authorization = WebexPlugin.extend({
       this.webex.internal.services
         .collectPreauthCatalog(preauthCatalogParams)
         .catch(() => Promise.resolve()) // Non-fatal if catalog collection fails
-        .then(() => this.requestAuthorizationCodeGrant({code, codeVerifier}))
+        .then(() => {
+          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.pending;
+
+          return this.requestAuthorizationCodeGrant({code, codeVerifier});
+        })
+        .then(() => {
+          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.success;
+        })
         .catch((error) => {
+          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.failure;
           this.logger.warn('authorization: failed initial authorization code grant request', error);
         })
         .then(() => {

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -86,9 +86,15 @@ const Authorization = WebexPlugin.extend({
      * performed during this authorization plugin instance's initialization.
      *
      * This historical value does not represent current authorization state,
-     * credentials hydrated from storage, guest authentication, errors before the
-     * exchange begins, or authorization-code exchanges requested later on the
-     * same SDK instance. It is not reset by logout.
+     * credentials hydrated from storage, guest authentication, or
+     * authorization-code exchanges requested later on the same SDK instance. It
+     * is not reset by logout. OAuth redirect errors and CSRF validation failures
+     * occur before the exchange, so the value remains not_attempted; these errors
+     * can throw before ready becomes true.
+     *
+     * Calling logout({noRedirect: true}) does not cancel an initialization
+     * exchange already in flight. If that exchange later settles, it can still
+     * update credentials and this retained outcome.
      *
      * Interpret only after authorization readiness:
      * - not_attempted: initialization did not invoke requestAuthorizationCodeGrant()

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -288,6 +288,7 @@ const Authorization = WebexPlugin.extend({
           this._initialAuthorizationCodeGrantOutcome =
             InitialAuthorizationCodeGrantOutcomes.pending;
 
+          // Outcome changes emit synchronously; a listener may log out and invalidate this grant.
           if (!isCurrentInitialAuthorizationCodeGrant()) {
             return undefined;
           }

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -42,7 +42,6 @@ export const Events = {
 export const InitialAuthorizationCodeGrantOutcomes = {
   failure: 'failure',
   notAttempted: 'not_attempted',
-  pending: 'pending',
   success: 'success',
 };
 
@@ -77,8 +76,9 @@ export const InitialAuthorizationCodeGrantOutcomes = {
 const Authorization = WebexPlugin.extend({
   derived: {
     /**
-     * Retains the outcome of the automatic startup authorization-code exchange.
-     * Resets to not_attempted when the SDK logs out.
+     * When enabled by configuration, retains the outcome of the automatic
+     * startup authorization-code exchange for the lifetime of this SDK instance.
+     * Interpret only after authorization readiness.
      * @instance
      * @memberof AuthorizationBrowserFirstParty
      * @readonly
@@ -143,15 +143,6 @@ const Authorization = WebexPlugin.extend({
    * @public
    */
   eventEmitter: new EventEmitter(),
-
-  /**
-   * Monotonically increasing id used to invalidate stale startup exchanges.
-   * @instance
-   * @memberof AuthorizationBrowserFirstParty
-   * @type {number}
-   * @private
-   */
-  _initialAuthorizationCodeGrantGeneration: 0,
 
   /**
    * Stores the timer ID for QR code polling (device authorization)
@@ -265,44 +256,20 @@ const Authorization = WebexPlugin.extend({
       preauthCatalogParams = {orgId};
     }
 
-    this._initialAuthorizationCodeGrantGeneration += 1;
-    const initialAuthorizationCodeGrantGeneration = this._initialAuthorizationCodeGrantGeneration;
-    const isCurrentInitialAuthorizationCodeGrant = () =>
-      initialAuthorizationCodeGrantGeneration === this._initialAuthorizationCodeGrantGeneration;
-
     // Defer token exchange until next tick in case credentials plugin not ready yet
     process.nextTick(() => {
-      if (!isCurrentInitialAuthorizationCodeGrant()) {
-        this.ready = true;
-        return;
-      }
-
       this.webex.internal.services
         .collectPreauthCatalog(preauthCatalogParams)
         .catch(() => Promise.resolve()) // Non-fatal if catalog collection fails
+        .then(() => this.requestAuthorizationCodeGrant({code, codeVerifier}))
         .then(() => {
-          if (!isCurrentInitialAuthorizationCodeGrant()) {
-            return undefined;
-          }
-
-          this._initialAuthorizationCodeGrantOutcome =
-            InitialAuthorizationCodeGrantOutcomes.pending;
-
-          // Outcome changes emit synchronously; a listener may log out and invalidate this grant.
-          if (!isCurrentInitialAuthorizationCodeGrant()) {
-            return undefined;
-          }
-
-          return this.requestAuthorizationCodeGrant({code, codeVerifier});
-        })
-        .then(() => {
-          if (isCurrentInitialAuthorizationCodeGrant()) {
+          if (this.config.enableInitialAuthorizationCodeGrantOutcomeTracking) {
             this._initialAuthorizationCodeGrantOutcome =
               InitialAuthorizationCodeGrantOutcomes.success;
           }
         })
         .catch((error) => {
-          if (isCurrentInitialAuthorizationCodeGrant()) {
+          if (this.config.enableInitialAuthorizationCodeGrantOutcomeTracking) {
             this._initialAuthorizationCodeGrantOutcome =
               InitialAuthorizationCodeGrantOutcomes.failure;
           }
@@ -496,7 +463,12 @@ const Authorization = WebexPlugin.extend({
     this._verifySecurityToken(location.query, {requireMatch: true});
     this._cleanUrl(location);
 
-    const {id_token: idToken, email, error, state: {csrf_token, ...state}} = location.query;
+    const {
+      id_token: idToken,
+      email,
+      error,
+      state: {csrf_token, ...state},
+    } = location.query;
 
     return {idToken, email, error, state};
   },
@@ -513,9 +485,6 @@ const Authorization = WebexPlugin.extend({
    * @returns {Promise<void>}
    */
   logout(options = {}) {
-    this._initialAuthorizationCodeGrantGeneration += 1;
-    this._initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.notAttempted;
-
     if (!options.noRedirect) {
       this.webex.getWindow().location = this.webex.credentials.buildLogoutUrl(options);
     }

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -39,6 +39,12 @@ export const Events = {
   qRCodeLogin: 'qRCodeLogin',
 };
 
+/**
+ * Terminal outcomes for the automatic authorization-code exchange performed
+ * during authorization plugin initialization.
+ *
+ * @enum {string}
+ */
 export const InitialAuthorizationCodeGrantOutcomes = {
   failure: 'failure',
   notAttempted: 'not_attempted',
@@ -76,9 +82,19 @@ export const InitialAuthorizationCodeGrantOutcomes = {
 const Authorization = WebexPlugin.extend({
   derived: {
     /**
-     * When enabled by configuration, retains the outcome of the automatic
-     * startup authorization-code exchange for the lifetime of this SDK instance.
-     * Interpret only after authorization readiness.
+     * Retains the terminal outcome of the automatic authorization-code exchange
+     * performed during this authorization plugin instance's initialization.
+     *
+     * This historical value does not represent current authorization state,
+     * credentials hydrated from storage, guest authentication, errors before the
+     * exchange begins, or authorization-code exchanges requested later on the
+     * same SDK instance. It is not reset by logout.
+     *
+     * Interpret only after authorization readiness:
+     * - not_attempted: initialization did not invoke requestAuthorizationCodeGrant()
+     * - success: the initialization exchange fulfilled
+     * - failure: the initialization exchange threw or rejected
+     *
      * @instance
      * @memberof AuthorizationBrowserFirstParty
      * @readonly
@@ -263,16 +279,12 @@ const Authorization = WebexPlugin.extend({
         .catch(() => Promise.resolve()) // Non-fatal if catalog collection fails
         .then(() => this.requestAuthorizationCodeGrant({code, codeVerifier}))
         .then(() => {
-          if (this.config.enableInitialAuthorizationCodeGrantOutcomeTracking) {
-            this._initialAuthorizationCodeGrantOutcome =
-              InitialAuthorizationCodeGrantOutcomes.success;
-          }
+          this._initialAuthorizationCodeGrantOutcome =
+            InitialAuthorizationCodeGrantOutcomes.success;
         })
         .catch((error) => {
-          if (this.config.enableInitialAuthorizationCodeGrantOutcomeTracking) {
-            this._initialAuthorizationCodeGrantOutcome =
-              InitialAuthorizationCodeGrantOutcomes.failure;
-          }
+          this._initialAuthorizationCodeGrantOutcome =
+            InitialAuthorizationCodeGrantOutcomes.failure;
           this.logger.warn('authorization: failed initial authorization code grant request', error);
         })
         .then(() => {

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -77,6 +77,20 @@ export const InitialAuthorizationCodeGrantOutcomes = {
 const Authorization = WebexPlugin.extend({
   derived: {
     /**
+     * Retains the outcome of the automatic startup authorization-code exchange.
+     * Resets to not_attempted when the SDK logs out.
+     * @instance
+     * @memberof AuthorizationBrowserFirstParty
+     * @readonly
+     * @type {string}
+     */
+    initialAuthorizationCodeGrantOutcome: {
+      deps: ['_initialAuthorizationCodeGrantOutcome'],
+      fn() {
+        return this._initialAuthorizationCodeGrantOutcome;
+      },
+    },
+    /**
      * Alias of {@link AuthorizationBrowserFirstParty#isAuthorizing}
      * @instance
      * @memberof AuthorizationBrowserFirstParty
@@ -102,10 +116,10 @@ const Authorization = WebexPlugin.extend({
       type: 'boolean',
     },
     /**
-     * Retains the outcome of the automatic startup authorization-code exchange.
-     * Resets to not_attempted when the SDK logs out.
+     * Internal backing state for the initial authorization-code grant outcome.
+     * @private
      */
-    initialAuthorizationCodeGrantOutcome: {
+    _initialAuthorizationCodeGrantOutcome: {
       default: InitialAuthorizationCodeGrantOutcomes.notAttempted,
       type: 'string',
     },
@@ -129,6 +143,15 @@ const Authorization = WebexPlugin.extend({
    * @public
    */
   eventEmitter: new EventEmitter(),
+
+  /**
+   * Monotonically increasing id used to invalidate stale startup exchanges.
+   * @instance
+   * @memberof AuthorizationBrowserFirstParty
+   * @type {number}
+   * @private
+   */
+  _initialAuthorizationCodeGrantGeneration: 0,
 
   /**
    * Stores the timer ID for QR code polling (device authorization)
@@ -242,21 +265,46 @@ const Authorization = WebexPlugin.extend({
       preauthCatalogParams = {orgId};
     }
 
+    this._initialAuthorizationCodeGrantGeneration += 1;
+    const initialAuthorizationCodeGrantGeneration = this._initialAuthorizationCodeGrantGeneration;
+    const isCurrentInitialAuthorizationCodeGrant = () =>
+      initialAuthorizationCodeGrantGeneration === this._initialAuthorizationCodeGrantGeneration;
+
     // Defer token exchange until next tick in case credentials plugin not ready yet
     process.nextTick(() => {
+      if (!isCurrentInitialAuthorizationCodeGrant()) {
+        this.ready = true;
+        return;
+      }
+
       this.webex.internal.services
         .collectPreauthCatalog(preauthCatalogParams)
         .catch(() => Promise.resolve()) // Non-fatal if catalog collection fails
         .then(() => {
-          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.pending;
+          if (!isCurrentInitialAuthorizationCodeGrant()) {
+            return undefined;
+          }
+
+          this._initialAuthorizationCodeGrantOutcome =
+            InitialAuthorizationCodeGrantOutcomes.pending;
+
+          if (!isCurrentInitialAuthorizationCodeGrant()) {
+            return undefined;
+          }
 
           return this.requestAuthorizationCodeGrant({code, codeVerifier});
         })
         .then(() => {
-          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.success;
+          if (isCurrentInitialAuthorizationCodeGrant()) {
+            this._initialAuthorizationCodeGrantOutcome =
+              InitialAuthorizationCodeGrantOutcomes.success;
+          }
         })
         .catch((error) => {
-          this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.failure;
+          if (isCurrentInitialAuthorizationCodeGrant()) {
+            this._initialAuthorizationCodeGrantOutcome =
+              InitialAuthorizationCodeGrantOutcomes.failure;
+          }
           this.logger.warn('authorization: failed initial authorization code grant request', error);
         })
         .then(() => {
@@ -464,7 +512,8 @@ const Authorization = WebexPlugin.extend({
    * @returns {Promise<void>}
    */
   logout(options = {}) {
-    this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.notAttempted;
+    this._initialAuthorizationCodeGrantGeneration += 1;
+    this._initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.notAttempted;
 
     if (!options.noRedirect) {
       this.webex.getWindow().location = this.webex.credentials.buildLogoutUrl(options);

--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -103,6 +103,7 @@ const Authorization = WebexPlugin.extend({
     },
     /**
      * Retains the outcome of the automatic startup authorization-code exchange.
+     * Resets to not_attempted when the SDK logs out.
      */
     initialAuthorizationCodeGrantOutcome: {
       default: InitialAuthorizationCodeGrantOutcomes.notAttempted,
@@ -463,6 +464,8 @@ const Authorization = WebexPlugin.extend({
    * @returns {Promise<void>}
    */
   logout(options = {}) {
+    this.initialAuthorizationCodeGrantOutcome = InitialAuthorizationCodeGrantOutcomes.notAttempted;
+
     if (!options.noRedirect) {
       this.webex.getWindow().location = this.webex.credentials.buildLogoutUrl(options);
     }

--- a/packages/@webex/plugin-authorization-browser-first-party/src/config.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/config.js
@@ -5,11 +5,6 @@
 export default {
   credentials: {
     /**
-     * Enables retention of the automatic startup authorization-code grant outcome.
-     * @type {boolean}
-     */
-    enableInitialAuthorizationCodeGrantOutcomeTracking: false,
-    /**
      * Controls whether {@link Authorization#initiateLogin()} requests a token
      * or an auth code. Anything other than 'confidential' will be treated as
      * 'public'

--- a/packages/@webex/plugin-authorization-browser-first-party/src/config.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/config.js
@@ -13,12 +13,6 @@ export default {
      */
     clientType: 'public',
 
-    /**
-     * Exchanges a refresh token for a new token bundle.
-     * @param {Webex} webex
-     * @param {Token} token
-     * @returns {Promise<Object>}
-     */
     refreshCallback(webex, token) {
       /* eslint-disable camelcase */
       return webex

--- a/packages/@webex/plugin-authorization-browser-first-party/src/config.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/config.js
@@ -5,6 +5,11 @@
 export default {
   credentials: {
     /**
+     * Enables retention of the automatic startup authorization-code grant outcome.
+     * @type {boolean}
+     */
+    enableInitialAuthorizationCodeGrantOutcomeTracking: false,
+    /**
      * Controls whether {@link Authorization#initiateLogin()} requests a token
      * or an auth code. Anything other than 'confidential' will be treated as
      * 'public'
@@ -13,6 +18,12 @@ export default {
      */
     clientType: 'public',
 
+    /**
+     * Exchanges a refresh token for a new token bundle.
+     * @param {Webex} webex
+     * @param {Token} token
+     * @returns {Promise<Object>}
+     */
     refreshCallback(webex, token) {
       /* eslint-disable camelcase */
       return webex

--- a/packages/@webex/plugin-authorization-browser-first-party/src/index.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/index.js
@@ -14,5 +14,5 @@ registerPlugin('authorization', Authorization, {
   proxies,
 });
 
-export {default, Events} from './authorization';
+export {default, Events, InitialAuthorizationCodeGrantOutcomes} from './authorization';
 export {default as config} from './config';

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -14,7 +14,11 @@ import {base64, patterns} from '@webex/common';
 import {merge, times} from 'lodash';
 import CryptoJS from 'crypto-js';
 import Authorization from '@webex/plugin-authorization-browser-first-party';
-import {Events, InitialAuthorizationCodeGrantOutcomes} from '../../../src';
+import {
+  config as authorizationConfig,
+  Events,
+  InitialAuthorizationCodeGrantOutcomes,
+} from '../../../src';
 
 // Necessary to require lodash this way in order to stub the method
 const lodash = require('lodash');
@@ -136,7 +140,9 @@ describe('plugin-authorization-browser-first-party', () => {
     describe('#initialize()', () => {
       describe('when there is a code in the url', () => {
         it('exchanges it for an access token and sets ready', () => {
-          const webex = makeWebex('http://example.com/?code=5');
+          const webex = makeWebex('http://example.com/?code=5', undefined, undefined, {
+            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
+          });
 
           assert.isFalse(webex.authorization.ready);
           assert.isFalse(webex.credentials.canAuthorize);
@@ -155,179 +161,18 @@ describe('plugin-authorization-browser-first-party', () => {
           });
         });
 
-        it('retains pending until the automatic exchange settles', async () => {
-          let resolveGrant;
-          const grantPromise = new Promise((resolve) => {
-            resolveGrant = resolve;
-          });
-          const requestAuthorizationCodeGrantStub = sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .returns(grantPromise);
+        it('does not retain the exchange outcome when tracking is disabled by default', async () => {
           const webex = makeWebex('http://example.com/?code=5');
 
-          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
-
-          assert.calledOnceWithExactly(requestAuthorizationCodeGrantStub, {
-            code: '5',
-            codeVerifier: undefined,
-          });
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.pending
+          assert.isFalse(
+            authorizationConfig.credentials.enableInitialAuthorizationCodeGrantOutcomeTracking
           );
-          assert.isFalse(webex.authorization.ready);
-
-          resolveGrant();
           await webex.authorization.when('change:ready');
 
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.success
-          );
-        });
-
-        it('does not start deferred authorization after logout', async () => {
-          const collectPreauthCatalogStub = sinon
-            .stub(Services.prototype, 'collectPreauthCatalog')
-            .resolves();
-          const requestAuthorizationCodeGrantStub = sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .resolves();
-          const webex = makeWebex('http://example.com/?code=5');
-          const readyPromise = webex.authorization.when('change:ready');
-
-          webex.authorization.logout({noRedirect: true});
-          await readyPromise;
-
-          assert.notCalled(collectPreauthCatalogStub);
-          assert.notCalled(requestAuthorizationCodeGrantStub);
+          assert.isTrue(webex.credentials.canAuthorize);
           assert.equal(
             webex.authorization.initialAuthorizationCodeGrantOutcome,
             InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-        });
-
-        it('does not start the authorization exchange after logout during preauth', async () => {
-          let resolvePreauth;
-          const preauthPromise = new Promise((resolve) => {
-            resolvePreauth = resolve;
-          });
-          const collectPreauthCatalogStub = sinon
-            .stub(Services.prototype, 'collectPreauthCatalog')
-            .returns(preauthPromise);
-          const requestAuthorizationCodeGrantStub = sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .resolves();
-          const webex = makeWebex('http://example.com/?code=5');
-          const readyPromise = webex.authorization.when('change:ready');
-
-          await new Promise((resolve) => process.nextTick(resolve));
-          assert.calledOnce(collectPreauthCatalogStub);
-
-          webex.authorization.logout({noRedirect: true});
-          resolvePreauth();
-          await readyPromise;
-
-          assert.notCalled(requestAuthorizationCodeGrantStub);
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-        });
-
-        it('does not start the authorization exchange when a pending listener logs out', async () => {
-          const requestAuthorizationCodeGrantStub = sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .resolves();
-          const webex = makeWebex('http://example.com/?code=5');
-          const readyPromise = webex.authorization.when('change:ready');
-
-          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', () => {
-            if (
-              webex.authorization.initialAuthorizationCodeGrantOutcome ===
-              InitialAuthorizationCodeGrantOutcomes.pending
-            ) {
-              webex.authorization.logout({noRedirect: true});
-            }
-          });
-
-          await readyPromise;
-
-          assert.notCalled(requestAuthorizationCodeGrantStub);
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-          assert.isTrue(webex.authorization.ready);
-        });
-
-        it('does not retain success when logout occurs during the exchange', async () => {
-          let resolveGrant;
-          const grantPromise = new Promise((resolve) => {
-            resolveGrant = resolve;
-          });
-
-          sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .returns(grantPromise);
-
-          const webex = makeWebex('http://example.com/?code=5');
-
-          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
-
-          const changeSpy = sinon.spy();
-
-          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
-          webex.authorization.logout({noRedirect: true});
-          resolveGrant();
-          await webex.authorization.when('change:ready');
-
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-          assert.calledOnceWithExactly(
-            changeSpy,
-            webex.authorization,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-        });
-
-        it('does not retain failure when logout occurs during the exchange', async () => {
-          const error = new Error('exchange rejected after logout');
-          let rejectGrant;
-          const grantPromise = new Promise((resolve, reject) => {
-            rejectGrant = reject;
-          });
-
-          sinon
-            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
-            .returns(grantPromise);
-
-          const webex = makeWebex('http://example.com/?code=5');
-
-          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
-
-          const changeSpy = sinon.spy();
-
-          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
-          webex.authorization.logout({noRedirect: true});
-          rejectGrant(error);
-          await webex.authorization.when('change:ready');
-
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-          assert.calledOnceWithExactly(
-            changeSpy,
-            webex.authorization,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
-          );
-          assert.calledOnceWithExactly(
-            webex.logger.warn,
-            'authorization: failed initial authorization code grant request',
-            error
           );
         });
 
@@ -462,7 +307,9 @@ describe('plugin-authorization-browser-first-party', () => {
             .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
             .throws(error);
 
-          const webex = makeWebex(`http://example.com?code=${code}`);
+          const webex = makeWebex(`http://example.com?code=${code}`, undefined, undefined, {
+            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
+          });
 
           return webex.authorization.when('change:ready').then(() => {
             assert.calledOnce(requestAuthorizationCodeGrantStub);
@@ -485,7 +332,9 @@ describe('plugin-authorization-browser-first-party', () => {
 
           sinon.stub(Authorization.prototype, 'requestAuthorizationCodeGrant').rejects(error);
 
-          const webex = makeWebex('http://example.com?code=5');
+          const webex = makeWebex('http://example.com?code=5', undefined, undefined, {
+            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
+          });
 
           await webex.authorization.when('change:ready');
 
@@ -710,23 +559,6 @@ describe('plugin-authorization-browser-first-party', () => {
           });
         });
       });
-
-      it('does not reset the retained initial exchange outcome', () => {
-        const webex = makeWebex();
-
-        webex.authorization._initialAuthorizationCodeGrantOutcome =
-          InitialAuthorizationCodeGrantOutcomes.success;
-        sinon
-          .stub(webex.authorization, 'initiateAuthorizationCodeGrant')
-          .returns(Promise.resolve());
-
-        return webex.authorization.initiateLogin().then(() => {
-          assert.equal(
-            webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.success
-          );
-        });
-      });
     });
 
     describe('#initiateAuthorizationCodeGrant()', () => {
@@ -823,43 +655,6 @@ describe('plugin-authorization-browser-first-party', () => {
             data: {loginUrl: testLoginUrl},
           });
         });
-      });
-    });
-
-    describe('#logout()', () => {
-      it('resets the retained outcome without redirecting', () => {
-        const webex = makeWebex();
-        const changeSpy = sinon.spy();
-
-        webex.authorization._initialAuthorizationCodeGrantOutcome =
-          InitialAuthorizationCodeGrantOutcomes.success;
-        webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
-
-        webex.authorization.logout({noRedirect: true});
-
-        assert.equal(
-          webex.authorization.initialAuthorizationCodeGrantOutcome,
-          InitialAuthorizationCodeGrantOutcomes.notAttempted
-        );
-        assert.calledOnce(changeSpy);
-        assert.equal(webex.getWindow().location.href, 'https://example.com');
-      });
-
-      it('resets the retained outcome before redirecting', () => {
-        const logoutUrl = 'https://example.com/logout';
-        const webex = makeWebex();
-
-        webex.authorization._initialAuthorizationCodeGrantOutcome =
-          InitialAuthorizationCodeGrantOutcomes.failure;
-        sinon.stub(webex.credentials, 'buildLogoutUrl').returns(logoutUrl);
-
-        webex.authorization.logout();
-
-        assert.equal(
-          webex.authorization.initialAuthorizationCodeGrantOutcome,
-          InitialAuthorizationCodeGrantOutcomes.notAttempted
-        );
-        assert.equal(webex.getWindow().location, logoutUrl);
       });
     });
 

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -536,6 +536,23 @@ describe('plugin-authorization-browser-first-party', () => {
           });
         });
       });
+
+      it('does not reset the retained initial exchange outcome', () => {
+        const webex = makeWebex();
+
+        webex.authorization.initialAuthorizationCodeGrantOutcome =
+          InitialAuthorizationCodeGrantOutcomes.success;
+        sinon
+          .stub(webex.authorization, 'initiateAuthorizationCodeGrant')
+          .returns(Promise.resolve());
+
+        return webex.authorization.initiateLogin().then(() => {
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.success
+          );
+        });
+      });
     });
 
     describe('#initiateAuthorizationCodeGrant()', () => {
@@ -632,6 +649,43 @@ describe('plugin-authorization-browser-first-party', () => {
             data: {loginUrl: testLoginUrl},
           });
         });
+      });
+    });
+
+    describe('#logout()', () => {
+      it('resets the retained outcome without redirecting', () => {
+        const webex = makeWebex();
+        const changeSpy = sinon.spy();
+
+        webex.authorization.initialAuthorizationCodeGrantOutcome =
+          InitialAuthorizationCodeGrantOutcomes.success;
+        webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
+
+        webex.authorization.logout({noRedirect: true});
+
+        assert.equal(
+          webex.authorization.initialAuthorizationCodeGrantOutcome,
+          InitialAuthorizationCodeGrantOutcomes.notAttempted
+        );
+        assert.calledOnce(changeSpy);
+        assert.equal(webex.getWindow().location.href, 'https://example.com');
+      });
+
+      it('resets the retained outcome before redirecting', () => {
+        const logoutUrl = 'https://example.com/logout';
+        const webex = makeWebex();
+
+        webex.authorization.initialAuthorizationCodeGrantOutcome =
+          InitialAuthorizationCodeGrantOutcomes.failure;
+        sinon.stub(webex.credentials, 'buildLogoutUrl').returns(logoutUrl);
+
+        webex.authorization.logout();
+
+        assert.equal(
+          webex.authorization.initialAuthorizationCodeGrantOutcome,
+          InitialAuthorizationCodeGrantOutcomes.notAttempted
+        );
+        assert.equal(webex.getWindow().location, logoutUrl);
       });
     });
 

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -104,6 +104,35 @@ describe('plugin-authorization-browser-first-party', () => {
       sinon.restore();
     });
 
+    it('exposes the initial authorization code grant outcome as readonly', () => {
+      const webex = makeWebex();
+      const changeSpy = sinon.spy();
+
+      webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
+
+      assert.equal(
+        webex.authorization.initialAuthorizationCodeGrantOutcome,
+        InitialAuthorizationCodeGrantOutcomes.notAttempted
+      );
+      assert.throws(() => {
+        webex.authorization.initialAuthorizationCodeGrantOutcome =
+          InitialAuthorizationCodeGrantOutcomes.success;
+      }, /derived property, it can't be set directly/);
+
+      webex.authorization._initialAuthorizationCodeGrantOutcome =
+        InitialAuthorizationCodeGrantOutcomes.success;
+
+      assert.equal(
+        webex.authorization.initialAuthorizationCodeGrantOutcome,
+        InitialAuthorizationCodeGrantOutcomes.success
+      );
+      assert.calledOnceWithExactly(
+        changeSpy,
+        webex.authorization,
+        InitialAuthorizationCodeGrantOutcomes.success
+      );
+    });
+
     describe('#initialize()', () => {
       describe('when there is a code in the url', () => {
         it('exchanges it for an access token and sets ready', () => {
@@ -154,6 +183,151 @@ describe('plugin-authorization-browser-first-party', () => {
           assert.equal(
             webex.authorization.initialAuthorizationCodeGrantOutcome,
             InitialAuthorizationCodeGrantOutcomes.success
+          );
+        });
+
+        it('does not start deferred authorization after logout', async () => {
+          const collectPreauthCatalogStub = sinon
+            .stub(Services.prototype, 'collectPreauthCatalog')
+            .resolves();
+          const requestAuthorizationCodeGrantStub = sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .resolves();
+          const webex = makeWebex('http://example.com/?code=5');
+          const readyPromise = webex.authorization.when('change:ready');
+
+          webex.authorization.logout({noRedirect: true});
+          await readyPromise;
+
+          assert.notCalled(collectPreauthCatalogStub);
+          assert.notCalled(requestAuthorizationCodeGrantStub);
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+        });
+
+        it('does not start the authorization exchange after logout during preauth', async () => {
+          let resolvePreauth;
+          const preauthPromise = new Promise((resolve) => {
+            resolvePreauth = resolve;
+          });
+          const collectPreauthCatalogStub = sinon
+            .stub(Services.prototype, 'collectPreauthCatalog')
+            .returns(preauthPromise);
+          const requestAuthorizationCodeGrantStub = sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .resolves();
+          const webex = makeWebex('http://example.com/?code=5');
+          const readyPromise = webex.authorization.when('change:ready');
+
+          await new Promise((resolve) => process.nextTick(resolve));
+          assert.calledOnce(collectPreauthCatalogStub);
+
+          webex.authorization.logout({noRedirect: true});
+          resolvePreauth();
+          await readyPromise;
+
+          assert.notCalled(requestAuthorizationCodeGrantStub);
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+        });
+
+        it('does not start the authorization exchange when a pending listener logs out', async () => {
+          const requestAuthorizationCodeGrantStub = sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .resolves();
+          const webex = makeWebex('http://example.com/?code=5');
+          const readyPromise = webex.authorization.when('change:ready');
+
+          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', () => {
+            if (
+              webex.authorization.initialAuthorizationCodeGrantOutcome ===
+              InitialAuthorizationCodeGrantOutcomes.pending
+            ) {
+              webex.authorization.logout({noRedirect: true});
+            }
+          });
+
+          await readyPromise;
+
+          assert.notCalled(requestAuthorizationCodeGrantStub);
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+          assert.isTrue(webex.authorization.ready);
+        });
+
+        it('does not retain success when logout occurs during the exchange', async () => {
+          let resolveGrant;
+          const grantPromise = new Promise((resolve) => {
+            resolveGrant = resolve;
+          });
+
+          sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .returns(grantPromise);
+
+          const webex = makeWebex('http://example.com/?code=5');
+
+          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
+
+          const changeSpy = sinon.spy();
+
+          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
+          webex.authorization.logout({noRedirect: true});
+          resolveGrant();
+          await webex.authorization.when('change:ready');
+
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+          assert.calledOnceWithExactly(
+            changeSpy,
+            webex.authorization,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+        });
+
+        it('does not retain failure when logout occurs during the exchange', async () => {
+          const error = new Error('exchange rejected after logout');
+          let rejectGrant;
+          const grantPromise = new Promise((resolve, reject) => {
+            rejectGrant = reject;
+          });
+
+          sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .returns(grantPromise);
+
+          const webex = makeWebex('http://example.com/?code=5');
+
+          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
+
+          const changeSpy = sinon.spy();
+
+          webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
+          webex.authorization.logout({noRedirect: true});
+          rejectGrant(error);
+          await webex.authorization.when('change:ready');
+
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+          assert.calledOnceWithExactly(
+            changeSpy,
+            webex.authorization,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+          assert.calledOnceWithExactly(
+            webex.logger.warn,
+            'authorization: failed initial authorization code grant request',
+            error
           );
         });
 
@@ -540,7 +714,7 @@ describe('plugin-authorization-browser-first-party', () => {
       it('does not reset the retained initial exchange outcome', () => {
         const webex = makeWebex();
 
-        webex.authorization.initialAuthorizationCodeGrantOutcome =
+        webex.authorization._initialAuthorizationCodeGrantOutcome =
           InitialAuthorizationCodeGrantOutcomes.success;
         sinon
           .stub(webex.authorization, 'initiateAuthorizationCodeGrant')
@@ -657,7 +831,7 @@ describe('plugin-authorization-browser-first-party', () => {
         const webex = makeWebex();
         const changeSpy = sinon.spy();
 
-        webex.authorization.initialAuthorizationCodeGrantOutcome =
+        webex.authorization._initialAuthorizationCodeGrantOutcome =
           InitialAuthorizationCodeGrantOutcomes.success;
         webex.authorization.on('change:initialAuthorizationCodeGrantOutcome', changeSpy);
 
@@ -675,7 +849,7 @@ describe('plugin-authorization-browser-first-party', () => {
         const logoutUrl = 'https://example.com/logout';
         const webex = makeWebex();
 
-        webex.authorization.initialAuthorizationCodeGrantOutcome =
+        webex.authorization._initialAuthorizationCodeGrantOutcome =
           InitialAuthorizationCodeGrantOutcomes.failure;
         sinon.stub(webex.credentials, 'buildLogoutUrl').returns(logoutUrl);
 

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -14,11 +14,7 @@ import {base64, patterns} from '@webex/common';
 import {merge, times} from 'lodash';
 import CryptoJS from 'crypto-js';
 import Authorization from '@webex/plugin-authorization-browser-first-party';
-import {
-  config as authorizationConfig,
-  Events,
-  InitialAuthorizationCodeGrantOutcomes,
-} from '../../../src';
+import {Events, InitialAuthorizationCodeGrantOutcomes} from '../../../src';
 
 // Necessary to require lodash this way in order to stub the method
 const lodash = require('lodash');
@@ -140,9 +136,7 @@ describe('plugin-authorization-browser-first-party', () => {
     describe('#initialize()', () => {
       describe('when there is a code in the url', () => {
         it('exchanges it for an access token and sets ready', () => {
-          const webex = makeWebex('http://example.com/?code=5', undefined, undefined, {
-            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
-          });
+          const webex = makeWebex('http://example.com/?code=5');
 
           assert.isFalse(webex.authorization.ready);
           assert.isFalse(webex.credentials.canAuthorize);
@@ -161,18 +155,15 @@ describe('plugin-authorization-browser-first-party', () => {
           });
         });
 
-        it('does not retain the exchange outcome when tracking is disabled by default', async () => {
+        it('retains the initialization exchange outcome after logout', async () => {
           const webex = makeWebex('http://example.com/?code=5');
 
-          assert.isFalse(
-            authorizationConfig.credentials.enableInitialAuthorizationCodeGrantOutcomeTracking
-          );
           await webex.authorization.when('change:ready');
+          webex.authorization.logout({noRedirect: true});
 
-          assert.isTrue(webex.credentials.canAuthorize);
           assert.equal(
             webex.authorization.initialAuthorizationCodeGrantOutcome,
-            InitialAuthorizationCodeGrantOutcomes.notAttempted
+            InitialAuthorizationCodeGrantOutcomes.success
           );
         });
 
@@ -307,9 +298,7 @@ describe('plugin-authorization-browser-first-party', () => {
             .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
             .throws(error);
 
-          const webex = makeWebex(`http://example.com?code=${code}`, undefined, undefined, {
-            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
-          });
+          const webex = makeWebex(`http://example.com?code=${code}`);
 
           return webex.authorization.when('change:ready').then(() => {
             assert.calledOnce(requestAuthorizationCodeGrantStub);
@@ -332,9 +321,7 @@ describe('plugin-authorization-browser-first-party', () => {
 
           sinon.stub(Authorization.prototype, 'requestAuthorizationCodeGrant').rejects(error);
 
-          const webex = makeWebex('http://example.com?code=5', undefined, undefined, {
-            credentials: {enableInitialAuthorizationCodeGrantOutcomeTracking: true},
-          });
+          const webex = makeWebex('http://example.com?code=5');
 
           await webex.authorization.when('change:ready');
 
@@ -369,6 +356,17 @@ describe('plugin-authorization-browser-first-party', () => {
 
           assert.isTrue(webex.authorization.ready);
           assert.isFalse(webex.credentials.canAuthorize);
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
+        });
+
+        it('does not treat a later authorization-code grant as the initialization exchange', async () => {
+          const webex = makeWebex('http://example.com');
+
+          await webex.authorization.requestAuthorizationCodeGrant({code: 'later-code'});
+
           assert.equal(
             webex.authorization.initialAuthorizationCodeGrantOutcome,
             InitialAuthorizationCodeGrantOutcomes.notAttempted

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -14,7 +14,7 @@ import {base64, patterns} from '@webex/common';
 import {merge, times} from 'lodash';
 import CryptoJS from 'crypto-js';
 import Authorization from '@webex/plugin-authorization-browser-first-party';
-import {Events} from '../../../src';
+import {Events, InitialAuthorizationCodeGrantOutcomes} from '../../../src';
 
 // Necessary to require lodash this way in order to stub the method
 const lodash = require('lodash');
@@ -119,7 +119,42 @@ describe('plugin-authorization-browser-first-party', () => {
             assert.calledTwice(webex.request);
             assert.isTrue(webex.authorization.ready);
             assert.isTrue(webex.credentials.canAuthorize);
+            assert.equal(
+              webex.authorization.initialAuthorizationCodeGrantOutcome,
+              InitialAuthorizationCodeGrantOutcomes.success
+            );
           });
+        });
+
+        it('retains pending until the automatic exchange settles', async () => {
+          let resolveGrant;
+          const grantPromise = new Promise((resolve) => {
+            resolveGrant = resolve;
+          });
+          const requestAuthorizationCodeGrantStub = sinon
+            .stub(Authorization.prototype, 'requestAuthorizationCodeGrant')
+            .returns(grantPromise);
+          const webex = makeWebex('http://example.com/?code=5');
+
+          await webex.authorization.when('change:initialAuthorizationCodeGrantOutcome');
+
+          assert.calledOnceWithExactly(requestAuthorizationCodeGrantStub, {
+            code: '5',
+            codeVerifier: undefined,
+          });
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.pending
+          );
+          assert.isFalse(webex.authorization.ready);
+
+          resolveGrant();
+          await webex.authorization.when('change:ready');
+
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.success
+          );
         });
 
         it('validates the csrf token', () => {
@@ -264,7 +299,31 @@ describe('plugin-authorization-browser-first-party', () => {
               'authorization: failed initial authorization code grant request',
               error
             );
+            assert.equal(
+              webex.authorization.initialAuthorizationCodeGrantOutcome,
+              InitialAuthorizationCodeGrantOutcomes.failure
+            );
           });
+        });
+
+        it('retains failure when the automatic exchange promise rejects', async () => {
+          const error = new Error('exchange rejected');
+
+          sinon.stub(Authorization.prototype, 'requestAuthorizationCodeGrant').rejects(error);
+
+          const webex = makeWebex('http://example.com?code=5');
+
+          await webex.authorization.when('change:ready');
+
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.failure
+          );
+          assert.calledOnceWithExactly(
+            webex.logger.warn,
+            'authorization: failed initial authorization code grant request',
+            error
+          );
         });
       });
       describe('when the url contains an error', () => {
@@ -287,6 +346,10 @@ describe('plugin-authorization-browser-first-party', () => {
 
           assert.isTrue(webex.authorization.ready);
           assert.isFalse(webex.credentials.canAuthorize);
+          assert.equal(
+            webex.authorization.initialAuthorizationCodeGrantOutcome,
+            InitialAuthorizationCodeGrantOutcomes.notAttempted
+          );
         });
       });
 


### PR DESCRIPTION
# COMPLETES N/A

## This pull request addresses

Consumers of the browser first-party authorization plugin need to distinguish the outcome of the automatic authorization-code exchange performed during SDK initialization from credentials that may already be available for another reason.

`authorization.ready` cannot provide that distinction because it becomes `true` after startup processing for both successful and failed exchanges. Inferring the result from credentials is also ambiguous because credentials may be hydrated from storage without a new authorization-code exchange.

## by making the following changes

- Export `InitialAuthorizationCodeGrantOutcomes` with three bounded values:
  - `not_attempted`
  - `success`
  - `failure`
- Add the read-only, in-memory `authorization.initialAuthorizationCodeGrantOutcome` property, defaulting to `not_attempted`.
- Set the property to `success` when the automatic `requestAuthorizationCodeGrant()` call made by `initialize()` fulfills, or `failure` when it throws or rejects.
- Set the terminal outcome before `authorization.ready` becomes `true`, preserving the existing ready and error-handling behavior.
- Leave the outcome as `not_attempted` when initialization does not invoke the exchange.
- Re-export the outcome constants from the package entry point so consumers do not need to duplicate string values.
- Document the contract in the public getter JSDoc and package README.

### Scope of this property

This property reports only the automatic authorization-code exchange performed during this authorization plugin instance's initialization. Read it after authorization readiness.

It is a historical initialization result retained for the lifetime of the SDK instance. It does not represent current authorization state and is not reset by logout.

The property intentionally does not report:

- credentials hydrated from storage;
- guest or device authentication;
- token refreshes;
- callback failures that occur before `requestAuthorizationCodeGrant()` is invoked; or
- authorization-code exchanges requested later on the same SDK instance, including login after a non-redirecting logout.

This is intentionally not a per-attempt authorization lifecycle API. A later redirect-based login is represented by the newly initialized SDK instance.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/plugin-authorization-browser-first-party build:src` completed successfully.
- `yarn workspace @webex/plugin-authorization-browser-first-party test:unit --targets authorization.js` — 67 tests passed.
- The property is read-only and defaults to `not_attempted`.
- A successful automatic initialization exchange retains `success` before readiness.
- Synchronous throws and asynchronous rejections retain `failure` while preserving existing readiness and warning behavior.
- Initialization without an authorization code retains `not_attempted`.
- Logout does not change the retained initialization result.
- A later direct `requestAuthorizationCodeGrant()` call does not change the initialization result.
- Targeted formatting and commit-time lint checks passed for the changed files.

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
  - Cisco GAI Coding Policy and Copyright Annotation Best Practices were followed.
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - OpenAI Codex
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

---
> ⚠️ AI Assisted Content 🤖