### PR TITLE
feat(internal-plugin-metrics): allow use of metrics before webex ready

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -302,7 +302,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       isSupportedBrowserFamily,
       isOutdatedBrowserVersion,
       // @ts-ignore
-    } = this.webex.meetings.config?.metrics ?? {};
+    } = this.webex.meetings?.config?.metrics ?? {};
 
     if (!this.hasLoggedBrowserSerial) {
       this.logger.log(
@@ -353,7 +353,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
 
       if (meetingId) {
         // @ts-ignore
-        const meeting = this.webex.meetings.getBasicMeetingInformation(meetingId);
+        const meeting = this.webex.meetings?.getBasicMeetingInformation(meetingId);
         if (meeting?.environment) {
           origin.environment = meeting.environment;
         }

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -100,7 +100,12 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   // @ts-ignore
   private preLoginMetricsBatcher: PreLoginMetricsBatcher;
 
-  private logger: any; // to avoid adding @ts-ignore everywhere
+  // lazy getter to avoid @ts-ignore on every call site
+  private get logger(): any {
+    // @ts-ignore
+    return this.webex.logger;
+  }
+
   private hasLoggedBrowserSerial: boolean;
   private device: any;
   private delayedClientEvents: DelayedClientEvent[] = [];
@@ -126,8 +131,6 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    */
   constructor(...args) {
     super(...args);
-    // @ts-ignore
-    this.logger = this.webex.logger;
     // @ts-ignore
     this.callDiagnosticEventsBatcher = new CallDiagnosticEventsBatcher({}, {parent: this.webex});
     // @ts-ignore
@@ -273,12 +276,12 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   getOrigin(options: GetOriginOptions, meetingId?: string) {
     const defaultClientType: ClientType =
       // @ts-ignore
-      this.webex.meetings.config?.metrics?.clientType;
+      this.webex.meetings?.config?.metrics?.clientType;
     const defaultSubClientType: SubClientType =
       // @ts-ignore
-      this.webex.meetings.config?.metrics?.subClientType;
+      this.webex.meetings?.config?.metrics?.subClientType;
     // @ts-ignore
-    const providedClientVersion: string = this.webex.meetings.config?.metrics?.clientVersion;
+    const providedClientVersion: string = this.webex.meetings?.config?.metrics?.clientVersion;
     // @ts-ignore
     const defaultSDKClientVersion = `${CLIENT_NAME}/${this.webex.version}`;
 
@@ -330,12 +333,12 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           ...versionMetadata,
           publicNetworkPrefix:
             // @ts-ignore
-            anonymizeIPAddress(this.webex.meetings.geoHintInfo?.clientAddress) || undefined,
+            anonymizeIPAddress(this.webex.meetings?.geoHintInfo?.clientAddress) || undefined,
           localNetworkPrefix:
             anonymizeIPAddress(
               // @ts-ignore
-              this.webex.meetings.meetingCollection
-                .get(meetingId)
+              this.webex.meetings?.meetingCollection
+                ?.get(meetingId)
                 ?.statsAnalyzer?.getLocalIpAddress()
             ) || undefined,
           osVersion: getOSVersion() || 'unknown',
@@ -500,7 +503,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         sent: 'not_defined_yet',
       },
       // @ts-ignore
-      senderCountryCode: this.webex.meetings.geoHintInfo?.countryCode,
+      senderCountryCode: this.webex.meetings?.geoHintInfo?.countryCode,
       event: eventData,
     };
 
@@ -1465,7 +1468,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       },
       headers: {},
       // @ts-ignore
-      waitForServiceTimeout: this.webex.internal.metrics.config.waitForServiceTimeout,
+      waitForServiceTimeout: this.webex.internal.metrics?.config?.waitForServiceTimeout,
     };
 
     if (options.preLoginId) {

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -80,6 +80,8 @@ class Metrics extends WebexPlugin {
 
     // @ts-ignore
     this.callDiagnosticLatencies = new CallDiagnosticLatencies({}, {parent: this.webex});
+    // @ts-ignore
+    this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
     this.onReady();
   }
 
@@ -89,8 +91,6 @@ class Metrics extends WebexPlugin {
   private onReady() {
     // @ts-ignore
     this.webex.once('ready', () => {
-      // @ts-ignore
-      this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
       this.preLoginMetrics = new PreLoginMetrics(
         // @ts-ignore
         new PreLoginMetricsBatcher({}, {parent: this.webex}),
@@ -333,7 +333,7 @@ class Metrics extends WebexPlugin {
     payload?: RecursivePartial<FeatureEvent['payload']>;
     options: any;
   }) {
-    if (!this.callDiagnosticLatencies || !this.callDiagnosticMetrics) {
+    if (!this.isReady) {
       // @ts-ignore
       this.webex.logger.log(
         `NewMetrics: @submitFeatureEvent. Attempted to submit before webex.ready. Event name: ${name}`
@@ -368,7 +368,7 @@ class Metrics extends WebexPlugin {
     payload?: RecursivePartial<ClientEvent['payload']>;
     options?: SubmitClientEventOptions;
   }): Promise<any> {
-    if (!this.callDiagnosticLatencies || !this.callDiagnosticMetrics) {
+    if (!this.isReady) {
       // @ts-ignore
       this.webex.logger.log(
         `NewMetrics: @submitClientEvent. Attempted to submit before webex.ready. Event name: ${name}`

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -364,6 +364,23 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('should build origin correctly when the meetings plugin is not available (before webex is ready)', () => {
+        // meetings plugin, geoHintInfo and meetingCollection are all absent before webex.ready
+        webex.meetings = undefined;
+
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.equal(res.clientInfo.clientType, 'TEAMS_CLIENT');
+        assert.equal(res.clientInfo.subClientType, 'WEB_APP');
+        assert.isUndefined(res.clientInfo.publicNetworkPrefix);
+        assert.isUndefined(res.clientInfo.localNetworkPrefix);
+        assert.equal(res.name, 'endpoint');
+      });
+
       it('builds origin correctly, when overriding clientVersion', () => {
         webex.meetings.config.metrics.clientVersion = '43.9.0.1234';
 
@@ -4526,6 +4543,30 @@ describe('internal-plugin-metrics', () => {
           fetchOptions.body.metrics[0].eventPayload.event.meetingJoinPhase,
           options.meetingJoinPhase
         );
+      });
+
+      it('builds request options before webex is ready (no meetings plugin or internal metrics config)', async () => {
+        // before webex.ready the meetings plugin and internal metrics config are not available
+        webex.meetings = undefined;
+        webex.internal.metrics = undefined;
+
+        const options = {
+          correlationId: 'myCorrelationId',
+          clientType: 'TEAMS_CLIENT',
+          subClientType: 'WEB_APP',
+        };
+
+        const fetchOptions = await cd.buildClientEventFetchRequestOptions({
+          name: 'client.exit.app',
+          payload: {trigger: 'user-interaction', canProceed: false},
+          options,
+        });
+
+        const eventPayload = fetchOptions.body.metrics[0].eventPayload;
+        assert.equal(eventPayload.event.name, 'client.exit.app');
+        assert.isUndefined(eventPayload.senderCountryCode);
+        assert.isUndefined(fetchOptions.waitForServiceTimeout);
+        assert.equal(fetchOptions.resource, 'clientmetrics');
       });
     });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -73,6 +73,32 @@ describe('internal-plugin-metrics', () => {
 
       assert.instanceOf(webex.internal.newMetrics.callDiagnosticLatencies, CallDiagnosticLatencies);
     });
+
+    it('checks callDiagnosticMetrics is defined before ready emit', () => {
+      const webex = mockWebex();
+
+      assert.isDefined(webex.internal.newMetrics.callDiagnosticMetrics);
+    });
+
+    it('can call buildClientEventFetchRequestOptions before ready', async () => {
+      const webex = mockWebex();
+      const stub = sinon.stub(
+        webex.internal.newMetrics.callDiagnosticMetrics,
+        'buildClientEventFetchRequestOptions'
+      ).resolves({url: 'https://metrics.example.com'});
+
+      const result = await webex.internal.newMetrics.buildClientEventFetchRequestOptions({
+        name: 'client.alert.displayed',
+        options: {correlationId: 'test-id'},
+      });
+
+      assert.calledOnceWithExactly(stub, {
+        name: 'client.alert.displayed',
+        payload: undefined,
+        options: {correlationId: 'test-id'},
+      });
+      assert.deepEqual(result, {url: 'https://metrics.example.com'});
+    });
   });
 
   describe('new-metrics', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Sometimes we might need to use metrics (buildClientEventFetchRequestOptions) before the whole of webex is ready. This is the case when we are using the gated services init and are still waiting for the by-proximity catalog request. If we supply a metrics URL with the discovery catalog, then we should still be able to use metrics.

Note that this change still does not currently allow sending of metrics before webex is ready

## by making the following changes

Move to creating the call diagnostic metrics class in the constructor rather than on ready

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
