### PR TITLE
fix(plugin-meetings): enrich unmute event payload with modifiedBy

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -2866,6 +2866,7 @@ export default class LocusInfo extends EventsScope {
           {
             muted: parsedSelves.current.remoteMuted,
             unmuteAllowed: parsedSelves.current.unmuteAllowed,
+            modifiedBy: parsedSelves.current.modifiedBy ?? null,
           }
         );
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2448,6 +2448,7 @@ describe('plugin-meetings', () => {
 
         selfWithLocalUnmuteRequired.controls.audio.muted = false;
         selfWithLocalUnmuteRequired.controls.audio.localAudioUnmuteRequired = true;
+        selfWithLocalUnmuteRequired.controls.audio.meta = {modifiedBy: 'host-uuid-123'};
 
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithLocalUnmuteRequired);
@@ -2462,6 +2463,33 @@ describe('plugin-meetings', () => {
           {
             muted: false,
             unmuteAllowed: true,
+            modifiedBy: 'host-uuid-123',
+          }
+        );
+      });
+
+      it('should set modifiedBy to null on LOCAL_UNMUTE_REQUIRED when it is unavailable', () => {
+        locusInfo.webex.internal.device.url = self.deviceUrl;
+        locusInfo.updateSelf(self);
+        const selfWithLocalUnmuteRequired = cloneDeep(self);
+
+        selfWithLocalUnmuteRequired.controls.audio.muted = false;
+        selfWithLocalUnmuteRequired.controls.audio.localAudioUnmuteRequired = true;
+
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateSelf(selfWithLocalUnmuteRequired);
+
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED,
+          {
+            muted: false,
+            unmuteAllowed: true,
+            modifiedBy: null,
           }
         );
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-844907](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-844907)>

## This pull request addresses
fix: missing modifiedBy in the locusInfo update

## by making the following changes

Adds [modifiedBy](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the [LOCAL_UNMUTE_REQUIRED](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) event payload so the web client can identify who initiated a forced unmute and suppress incorrect self-initiated notifications. The field is null when Locus omits [meta.modifiedBy](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), preserving compatibility with legacy or system-initiated scenarios.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Local web client manual testing via SDK linking and unit. 

webinar with moderated unmute mode:
host or cohost who clicks the unmute panelists button:
<img width="407" height="63" alt="You&#39;ve unmuted all panelists" src="https://github.com/user-attachments/assets/05da14a3-ecb3-4673-ac31-0991a8ec602c" />
others:
<img width="399" height="63" alt="The host or cohost has unmuted you" src="https://github.com/user-attachments/assets/ab4af2d2-4a39-40cb-93a8-f001df6cf95f" />

meeting with moderated unmute mode:
host or cohost who clicks the unmute all button:
<img width="408" height="76" alt="You&#39;ve unmuted all attendees" src="https://github.com/user-attachments/assets/bd4f2175-2463-4c1b-9003-3337871c93ff" />
others:
<img width="412" height="74" alt="The host or cohost has unmuted you" src="https://github.com/user-attachments/assets/17f22b29-91fc-4ddf-ae55-7def2a8b16dd" />

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
