### PR TITLE
fix(internal-plugin-mercury): disconnected event

### DIFF
--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -253,15 +253,23 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /**
    * Disconnects the WebSocket and clears all connection state.
    * Overrides Mercury's disconnect to also clear LLM-specific state.
-   * State is cleared BEFORE calling super.disconnect() so that when the
-   * 'disconnected' event fires, handlers see clean state and can safely
-   * call registerAndConnect() without risk of the resumed disconnect()
-   * erasing the new connection's URLs.
+   * Waits for any in-flight connection to settle before clearing state
+   * to prevent race conditions where a stale register() response could
+   * overwrite state after disconnect clears it.
    * @param {object} [options]
    * @returns {Promise<void>}
    */
   public async disconnect(options?: {code: number; reason: string}): Promise<void> {
-    // Clear LLM-specific state first, before Mercury emits 'disconnected'
+    // Wait for any in-flight connection to settle before clearing state
+    if (this.connectingPromise) {
+      try {
+        await this.connectingPromise;
+      } catch {
+        // Ignore errors - we're disconnecting anyway
+      }
+    }
+
+    // Clear LLM-specific state before Mercury emits 'disconnected'
     this.webSocketUrl = undefined;
     this.binding = undefined;
     this.locusUrl = undefined;

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -268,6 +268,7 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
+    this.connectingPromise = undefined;
 
     await super.disconnect(options);
   }

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -147,6 +147,11 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
         const clientLLMDatachannelResponseTime = Math.round(performance.now() - registerStart);
         const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
+        // Check again after async operation - disconnect may have run during the await
+        if (this.connectingPromise !== connectionPromise) {
+          return;
+        }
+
         const connectUrl =
           isDataChannelTokenEnabled && this.webSocketUrl
             ? LLMChannel.buildUrlWithAwareSubchannels(this.webSocketUrl, AWARE_DATA_CHANNEL)

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -264,7 +264,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
-    this.emit('disconnected');
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -253,17 +253,23 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /**
    * Disconnects the WebSocket and clears all connection state.
    * Overrides Mercury's disconnect to also clear LLM-specific state.
+   * State is cleared BEFORE calling super.disconnect() so that when the
+   * 'disconnected' event fires, handlers see clean state and can safely
+   * call registerAndConnect() without risk of the resumed disconnect()
+   * erasing the new connection's URLs.
    * @param {object} [options]
    * @returns {Promise<void>}
    */
   public async disconnect(options?: {code: number; reason: string}): Promise<void> {
-    await super.disconnect(options);
+    // Clear LLM-specific state first, before Mercury emits 'disconnected'
     this.webSocketUrl = undefined;
     this.binding = undefined;
     this.locusUrl = undefined;
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
+
+    await super.disconnect(options);
   }
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -276,7 +276,6 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = undefined;
     this.datachannelToken = undefined;
     this.refreshHandler = undefined;
-    this.connectingPromise = undefined;
 
     await super.disconnect(options);
   }

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -74,9 +74,12 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
    * Register to the websocket
    * @param {string} llmSocketUrl
    * @param {string} datachannelToken
-   * @returns {Promise<void>}
+   * @returns {Promise<object>} Promise resolving to {webSocketUrl, binding}
    */
-  private register = async (llmSocketUrl: string, datachannelToken?: string): Promise<void> => {
+  private register = async (
+    llmSocketUrl: string,
+    datachannelToken?: string
+  ): Promise<{webSocketUrl: string; binding: string}> => {
     const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
     return this.request({
@@ -88,10 +91,7 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
           ? {'Data-Channel-Auth-Token': datachannelToken}
           : {},
     })
-      .then((res: {body: {webSocketUrl: string; binding: string}}) => {
-        this.webSocketUrl = res.body.webSocketUrl;
-        this.binding = res.body.binding;
-      })
+      .then((res: {body: {webSocketUrl: string; binding: string}}) => res.body)
       .catch((error: any) => {
         this.logger.error(`Error connecting to websocket for : ${error}`);
         throw error;
@@ -131,8 +131,19 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.datachannelUrl = datachannelUrl;
     const registerStart = performance.now();
 
-    this.connectingPromise = this.register(datachannelUrl, datachannelToken)
-      .then(async () => {
+    const connectionPromise: Promise<RegisterAndConnectTiming | void> = this.register(
+      datachannelUrl,
+      datachannelToken
+    )
+      .then(async ({webSocketUrl, binding}) => {
+        // Check if this operation was invalidated by a disconnect
+        if (this.connectingPromise !== connectionPromise) {
+          return;
+        }
+
+        this.webSocketUrl = webSocketUrl;
+        this.binding = binding;
+
         const clientLLMDatachannelResponseTime = Math.round(performance.now() - registerStart);
         const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
@@ -158,8 +169,13 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
         return {clientLLMDatachannelResponseTime, clientLLMWebSocketConnectTime};
       })
       .finally(() => {
-        this.connectingPromise = undefined;
+        // Only clear if this operation is still current
+        if (this.connectingPromise === connectionPromise) {
+          this.connectingPromise = undefined;
+        }
       });
+
+    this.connectingPromise = connectionPromise;
 
     return this.connectingPromise;
   };
@@ -253,21 +269,18 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /**
    * Disconnects the WebSocket and clears all connection state.
    * Overrides Mercury's disconnect to also clear LLM-specific state.
-   * Waits for any in-flight connection to settle before clearing state
-   * to prevent race conditions where a stale register() response could
-   * overwrite state after disconnect clears it.
+   * Clears connectingPromise first to invalidate any in-flight operations,
+   * then clears state before calling super.disconnect(). This ensures:
+   * 1. Stale register() responses won't overwrite state (they check promise identity)
+   * 2. No deadlock with Mercury's _connectWithBackoff() (we don't await connectingPromise)
+   * 3. State is cleared before 'disconnected' event fires
    * @param {object} [options]
    * @returns {Promise<void>}
    */
   public async disconnect(options?: {code: number; reason: string}): Promise<void> {
-    // Wait for any in-flight connection to settle before clearing state
-    if (this.connectingPromise) {
-      try {
-        await this.connectingPromise;
-      } catch {
-        // Ignore errors - we're disconnecting anyway
-      }
-    }
+    // Clear connectingPromise first to invalidate any in-flight operations.
+    // Their promise identity checks will detect they've been superseded.
+    this.connectingPromise = undefined;
 
     // Clear LLM-specific state before Mercury emits 'disconnected'
     this.webSocketUrl = undefined;

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -390,6 +390,33 @@ describe('plugin-llm', () => {
 
         sinon.assert.calledOnce(disconnectedSpy);
       });
+
+      it('clears state before disconnected event fires', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        llmChannel.setDatachannelToken('token123');
+
+        let stateAtEventTime;
+
+        llmChannel.on('disconnected', () => {
+          // Capture state when event fires - should already be cleared
+          stateAtEventTime = {
+            locusUrl: llmChannel.getLocusUrl(),
+            datachannelUrl: llmChannel.getDatachannelUrl(),
+            binding: llmChannel.getBinding(),
+            datachannelToken: llmChannel.getDatachannelToken(),
+          };
+        });
+
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        // State should have been undefined when the event fired
+        assert.deepEqual(stateAtEventTime, {
+          locusUrl: undefined,
+          datachannelUrl: undefined,
+          binding: undefined,
+          datachannelToken: undefined,
+        });
+      });
     });
 
     describe('#setRefreshHandler', () => {

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -420,6 +420,71 @@ describe('plugin-llm', () => {
           isConnecting: false,
         });
       });
+
+      it('waits for in-flight connection to settle before clearing state', async () => {
+        let resolveRequest;
+        llmChannel.request = sinon.stub().returns(
+          new Promise((resolve) => {
+            resolveRequest = resolve;
+          })
+        );
+
+        // Start connection but don't await - request is pending
+        const connectPromise = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        assert.equal(llmChannel.isConnecting(), true);
+
+        // Start disconnect while connection is in-flight
+        const disconnectPromise = llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        // Disconnect should be blocked waiting for connection to settle
+        // Resolve the pending request
+        resolveRequest({
+          headers: {},
+          body: {binding: 'binding', webSocketUrl: 'wss://example.com/socket'},
+        });
+
+        // Now both should complete
+        await connectPromise;
+        await disconnectPromise;
+
+        // State should be cleared after disconnect completes
+        assert.equal(llmChannel.getLocusUrl(), undefined);
+        assert.equal(llmChannel.getBinding(), undefined);
+        assert.equal(llmChannel.isConnecting(), false);
+      });
+
+      it('waits for in-flight connection that fails before clearing state', async () => {
+        let rejectRequest;
+        llmChannel.request = sinon.stub().returns(
+          new Promise((resolve, reject) => {
+            rejectRequest = reject;
+          })
+        );
+
+        // Start connection but don't await - request is pending
+        const connectPromise = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        // Start disconnect while connection is in-flight
+        const disconnectPromise = llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        // Reject the pending request
+        rejectRequest(new Error('Network error'));
+
+        // Connect promise should reject
+        try {
+          await connectPromise;
+        } catch {
+          // expected
+        }
+
+        // Disconnect should still complete successfully
+        await disconnectPromise;
+
+        // State should be cleared
+        assert.equal(llmChannel.getLocusUrl(), undefined);
+        assert.equal(llmChannel.isConnecting(), false);
+      });
     });
 
     describe('#setRefreshHandler', () => {

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -421,7 +421,7 @@ describe('plugin-llm', () => {
         });
       });
 
-      it('waits for in-flight connection to settle before clearing state', async () => {
+      it('invalidates in-flight connection via promise identity', async () => {
         let resolveRequest;
         llmChannel.request = sinon.stub().returns(
           new Promise((resolve) => {
@@ -434,56 +434,79 @@ describe('plugin-llm', () => {
 
         assert.equal(llmChannel.isConnecting(), true);
 
-        // Start disconnect while connection is in-flight
-        const disconnectPromise = llmChannel.disconnect({code: 1000, reason: 'test'});
+        // Disconnect while connection is in-flight - should complete immediately
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
 
-        // Disconnect should be blocked waiting for connection to settle
-        // Resolve the pending request
+        // State should be cleared immediately, not waiting for connection
+        assert.equal(llmChannel.getLocusUrl(), undefined);
+        assert.equal(llmChannel.isConnecting(), false);
+
+        // Now resolve the pending request - stale operation should not overwrite state
         resolveRequest({
           headers: {},
-          body: {binding: 'binding', webSocketUrl: 'wss://example.com/socket'},
+          body: {binding: 'stale-binding', webSocketUrl: 'wss://example.com/stale'},
         });
 
-        // Now both should complete
+        // Wait for the stale promise to settle
         await connectPromise;
-        await disconnectPromise;
 
-        // State should be cleared after disconnect completes
-        assert.equal(llmChannel.getLocusUrl(), undefined);
+        // State should still be undefined - stale operation detected invalidation
         assert.equal(llmChannel.getBinding(), undefined);
         assert.equal(llmChannel.isConnecting(), false);
       });
 
-      it('waits for in-flight connection that fails before clearing state', async () => {
-        let rejectRequest;
+      it('stale operation does not clear new connectingPromise', async () => {
+        let resolveFirstRequest;
+        let resolveSecondRequest;
         llmChannel.request = sinon.stub().returns(
-          new Promise((resolve, reject) => {
-            rejectRequest = reject;
+          new Promise((resolve) => {
+            resolveFirstRequest = resolve;
           })
         );
 
-        // Start connection but don't await - request is pending
-        const connectPromise = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        // Start first connection
+        const firstConnectPromise = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
 
-        // Start disconnect while connection is in-flight
-        const disconnectPromise = llmChannel.disconnect({code: 1000, reason: 'test'});
+        // Disconnect invalidates the first connection
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
 
-        // Reject the pending request
-        rejectRequest(new Error('Network error'));
+        // Start second connection before first resolves
+        llmChannel.request = sinon.stub().returns(
+          new Promise((resolve) => {
+            resolveSecondRequest = resolve;
+          })
+        );
+        const secondConnectPromise = llmChannel.registerAndConnect(
+          'newLocusUrl',
+          'newDatachannelUrl'
+        );
 
-        // Connect promise should reject
-        try {
-          await connectPromise;
-        } catch {
-          // expected
-        }
+        assert.equal(llmChannel.isConnecting(), true);
 
-        // Disconnect should still complete successfully
-        await disconnectPromise;
+        // Resolve the first (stale) request
+        resolveFirstRequest({
+          headers: {},
+          body: {binding: 'stale-binding', webSocketUrl: 'wss://example.com/stale'},
+        });
 
-        // State should be cleared
-        assert.equal(llmChannel.getLocusUrl(), undefined);
+        await firstConnectPromise;
+
+        // isConnecting should still be true because second connection is in progress
+        assert.equal(llmChannel.isConnecting(), true);
+
+        // State should not have been overwritten by stale operation
+        assert.equal(llmChannel.getBinding(), undefined);
+
+        // Complete second connection
+        resolveSecondRequest({
+          headers: {},
+          body: {binding: 'new-binding', webSocketUrl: 'wss://example.com/new'},
+        });
+        await secondConnectPromise;
+
+        // Now isConnecting should be false and state should reflect second connection
         assert.equal(llmChannel.isConnecting(), false);
+        assert.equal(llmChannel.getBinding(), 'new-binding');
       });
     });
 

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -355,6 +355,7 @@ describe('plugin-llm', () => {
         assert.equal(llmChannel.getDatachannelUrl(), undefined);
         assert.equal(llmChannel.getBinding(), undefined);
         assert.equal(llmChannel.getDatachannelToken(), undefined);
+        assert.equal(llmChannel.isConnecting(), false);
       });
 
       it('works without options', async () => {
@@ -404,6 +405,7 @@ describe('plugin-llm', () => {
             datachannelUrl: llmChannel.getDatachannelUrl(),
             binding: llmChannel.getBinding(),
             datachannelToken: llmChannel.getDatachannelToken(),
+            isConnecting: llmChannel.isConnecting(),
           };
         });
 
@@ -415,6 +417,7 @@ describe('plugin-llm', () => {
           datachannelUrl: undefined,
           binding: undefined,
           datachannelToken: undefined,
+          isConnecting: false,
         });
       });
     });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -508,6 +508,50 @@ describe('plugin-llm', () => {
         assert.equal(llmChannel.isConnecting(), false);
         assert.equal(llmChannel.getBinding(), 'new-binding');
       });
+
+      it('does not call connect() if disconnect runs during isDataChannelTokenEnabled await', async () => {
+        let resolveFeatureToggle;
+        const featureTogglePromise = new Promise((resolve) => {
+          resolveFeatureToggle = resolve;
+        });
+
+        // Request resolves immediately
+        llmChannel.request = sinon.stub().resolves({
+          headers: {},
+          body: {binding: 'binding', webSocketUrl: 'wss://example.com/socket'},
+        });
+
+        // Feature toggle will block
+        webex.internal.feature.getFeature = sinon
+          .stub()
+          .onFirstCall()
+          .resolves(true) // First call in register()
+          .onSecondCall()
+          .returns(featureTogglePromise); // Second call blocks
+
+        // Start connection
+        const connectPromise = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        // Wait for register() to complete and state to be set
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // Binding should be set after register() completes
+        assert.equal(llmChannel.getBinding(), 'binding');
+
+        // Disconnect while isDataChannelTokenEnabled() is pending
+        await llmChannel.disconnect({code: 1000, reason: 'test'});
+
+        // State should be cleared
+        assert.equal(llmChannel.getBinding(), undefined);
+
+        // Now resolve the feature toggle - stale operation should NOT call connect()
+        resolveFeatureToggle(true);
+
+        await connectPromise;
+
+        // connect() should NOT have been called - identity check after await should have aborted
+        sinon.assert.notCalled(llmChannel.connect);
+      });
     });
 
     describe('#setRefreshHandler', () => {

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -25,8 +25,16 @@ describe('plugin-llm', () => {
       };
 
       llmChannel = webex.internal.llm;
-      // Stub Mercury's prototype disconnect so super.disconnect() works in tests
-      sinon.stub(Object.getPrototypeOf(Object.getPrototypeOf(llmChannel)), 'disconnect').resolves();
+      // Stub Mercury's prototype disconnect so super.disconnect() works in tests.
+      // The real Mercury emits 'disconnected' after disconnect completes, so we simulate that.
+      sinon
+        .stub(Object.getPrototypeOf(Object.getPrototypeOf(llmChannel)), 'disconnect')
+        .callsFake(function () {
+          this.connected = false;
+          this._emit('disconnected');
+
+          return Promise.resolve();
+        });
       llmChannel.request = sinon.stub().resolves({
         headers: {},
         body: {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -249,12 +249,15 @@ const Mercury = WebexPlugin.extend({
 
       if (this.socket) {
         this.socket.removeAllListeners('message');
-        this.once('offline', resolve);
-        this.socket.close(options || undefined);
+        this.once('offline', () => {
+          this._emit('disconnected');
+          resolve();
+        });
+        this.socket.close(options);
 
         return;
       }
-
+      this._emit('disconnected');
       resolve();
     });
   },

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -690,6 +690,47 @@ describe('plugin-mercury', () => {
             assert.isUndefined(mercury.mockWebSocket, 'Mercury does not have a mockWebSocket');
           }));
 
+      it('emits disconnected event after offline when socket exists', () => {
+        const offlineSpy = sinon.spy();
+        const disconnectedSpy = sinon.spy();
+        let offlineCalledFirst = false;
+
+        return mercury.connect().then(() => {
+          mercury.on('offline', () => {
+            offlineSpy();
+            // At this point, disconnected should not have been called yet
+            offlineCalledFirst = !disconnectedSpy.called;
+          });
+          mercury.on('disconnected', disconnectedSpy);
+
+          const promise = mercury.disconnect();
+
+          mockWebSocket.emit('close', {
+            code: 1000,
+            reason: 'Done',
+          });
+
+          return promise.then(() => {
+            assert.calledOnce(offlineSpy);
+            assert.calledOnce(disconnectedSpy);
+            assert.isTrue(offlineCalledFirst, 'offline was emitted before disconnected');
+          });
+        });
+      });
+
+      it('emits disconnected event when no socket exists', () => {
+        const disconnectedSpy = sinon.spy();
+
+        mercury.on('disconnected', disconnectedSpy);
+
+        // Ensure there's no socket
+        assert.isUndefined(mercury.socket, 'Mercury should not have a socket');
+
+        return mercury.disconnect().then(() => {
+          assert.calledOnce(disconnectedSpy);
+        });
+      });
+
       it('disconnects the WebSocket with code 3050', () =>
         mercury
           .connect()

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -799,20 +799,25 @@ describe('plugin-meetings', () => {
       });
 
       it('re-checks the subscription when the llm emits online', () => {
-        const onlineCall = webex.internal.llm.on
-          .getCalls()
-          .find((c) => c.args[0] === 'online');
+        const onlineCall = webex.internal.llm.on.getCalls().find((c) => c.args[0] === 'online');
         assert.exists(onlineCall, 'expected an online listener to be registered');
         const onlineHandler = onlineCall.args[1];
 
-        webex.internal.llm.isConnected = sinon.stub().returns(true);
-        webex.internal.llm.getLocusUrl = sinon.stub().returns(breakouts.locusUrl);
+        // Set up _llmChannel so listenToBroadcastMessages can subscribe
+        const mockChannel = {
+          isConnected: sinon.stub().returns(true),
+          on: sinon.stub(),
+          off: sinon.stub(),
+        };
+        breakouts._llmChannel = mockChannel;
+
+        const listenToSpy = sinon.spy(breakouts, 'listenTo');
 
         onlineHandler.call(breakouts);
 
-        const call = webex.internal.llm.on
+        const call = listenToSpy
           .getCalls()
-          .find((c) => c.args[0] === 'event:breakout.message');
+          .find((c) => c.args[0] === mockChannel && c.args[1] === 'event:breakout.message');
         assert.exists(call, 'expected broadcast message subscription after online');
         assert.isTrue(breakouts.hasSubscribedToMessage);
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-850929
## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

[register()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns data instead of setting state

Returns [{webSocketUrl, binding}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — caller decides whether to use it
[registerAndConnect()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) uses promise identity checks

Captures [connectionPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) locally before assigning to [this.connectingPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
First check (after [register()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)): Aborts if [this.connectingPromise !== connectionPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Second check (after [isDataChannelTokenEnabled()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)): Prevents [connect(undefined)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) after disconnect clears [webSocketUrl](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[.finally()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) check: Only clears [connectingPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) if still current — prevents stale operation from clearing a new operation's promise
[disconnect()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) invalidates in-flight operations immediately

Clears [connectingPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) first (invalidates ops via identity mismatch)
Clears all LLM-specific state
Calls [super.disconnect()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — no deadlock since we don't await [connectingPromise](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
