### PR TITLE
fix(internal-plugin-voicea): persist voiceaChannel across LLM reconne…

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea-plugin.ts
@@ -13,16 +13,16 @@ export class VoiceaPlugin extends WebexPlugin {
   namespace = VOICEA;
 
   /**
-   * Creates a VoiceaChannel bound to the given LLMChannel.
+   * Creates a VoiceaChannel, optionally bound to an LLMChannel.
    *
    * Note: VoiceaChannel does not take ownership of the LLMChannel.
    * The caller retains ownership and is responsible for the LLMChannel's
    * lifecycle (connection, disconnection, cleanup).
    *
-   * @param {LLMChannel} llmChannel - The LLM channel to use for voicea
+   * @param {LLMChannel} [llmChannel] - The LLM channel to use for voicea (optional)
    * @returns {VoiceaChannel} A new VoiceaChannel instance
    */
-  public createChannel(llmChannel: LLMChannel): VoiceaChannel {
+  public createChannel(llmChannel?: LLMChannel): VoiceaChannel {
     // @ts-ignore - webex is available on WebexPlugin
     const channel = new VoiceaChannel(llmChannel, this.webex.request.bind(this.webex));
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -164,6 +164,13 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @returns {Promise<void>}
    */
   public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
+    // Skip if already on this channel - prevents duplicate HTTP requests when
+    // multiple callers (e.g., cleanupPSDataChannel and updateLLMConnection) both
+    // try to switch to the same channel concurrently.
+    if (this.llmChannel === newLLMChannel) {
+      return;
+    }
+
     // Save current state
     const captionsWereOn = this.keepTranscriptionSubscribed;
     const spokenLanguage = this.currentSpokenLanguage;
@@ -193,11 +200,16 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     this.captionServiceId = undefined;
     this.areCaptionsEnabled = false;
 
-    // Re-announce and re-enable captions if they were on
+    // Re-announce and re-enable captions if they were on.
+    // Caption restoration is fire-and-forget: errors are logged but don't propagate,
+    // ensuring cleanup operations (e.g., cleanupPSDataChannel) complete even if
+    // caption restoration fails.
     if (captionsWereOn) {
       if (this.isLLMConnected()) {
         // Channel is already connected, restore captions immediately
-        await this.turnOnCaptions(spokenLanguage);
+        this.turnOnCaptions(spokenLanguage).catch(() => {
+          // Best-effort restoration - if it fails, captions were already in a bad state
+        });
       } else {
         // Channel not yet connected - defer caption restoration until 'online' event.
         // This handles the race where switchLLMChannel is called while the main channel

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -31,7 +31,7 @@ import {millisToMinutesAndSeconds} from './utils';
  */
 export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   private request: (options: {method: string; url: string; body?: object}) => Promise<any>;
-  private llmChannel: LLMChannel;
+  private llmChannel?: LLMChannel;
 
   private seqNum: number;
   private areCaptionsEnabled: boolean;
@@ -48,12 +48,13 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   private currentCaptionLanguage?: string;
 
   /**
-   * Creates a VoiceaChannel bound to the given LLMChannel
-   * @param {LLMChannel} llmChannel - The LLM channel to use
+   * Creates a VoiceaChannel, optionally bound to an LLMChannel.
+   * If no llmChannel is provided, call switchLLMChannel() later to attach one.
+   * @param {LLMChannel} [llmChannel] - The LLM channel to use (optional)
    * @param {Function} request - The request function for making API calls (typically webex.request bound to webex)
    */
   constructor(
-    llmChannel: LLMChannel,
+    llmChannel: LLMChannel | undefined,
     request: (options: {method: string; url: string; body?: object}) => Promise<any>
   ) {
     super();
@@ -70,9 +71,25 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     this.currentCaptionLanguage = undefined;
     this.keepTranscriptionSubscribed = false;
 
-    // Subscribe to relay events from the LLM channel
-    this.llmChannel.on('event:relay.event', this.eventProcessor);
-    this.hasSubscribedToEvents = true;
+    // Subscribe to relay events from the LLM channel if provided
+    if (this.llmChannel) {
+      this.llmChannel.on('event:relay.event', this.eventProcessor);
+      this.hasSubscribedToEvents = true;
+    }
+  }
+
+  /**
+   * Returns the LLM channel, throwing if not available.
+   * @private
+   * @returns {LLMChannel}
+   * @throws {Error} If LLM channel is not available
+   */
+  private requireLLMChannel(): LLMChannel {
+    if (!this.llmChannel) {
+      throw new Error('VoiceaChannel: LLM channel not available');
+    }
+
+    return this.llmChannel;
   }
 
   /**
@@ -116,7 +133,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     this.keepTranscriptionSubscribed = false;
     this.captionServiceId = undefined;
 
-    if (this.hasSubscribedToEvents) {
+    if (this.hasSubscribedToEvents && this.llmChannel) {
       this.llmChannel.off('event:relay.event', this.eventProcessor);
       this.hasSubscribedToEvents = false;
     }
@@ -290,7 +307,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * Indicates whether the LLM channel is connected.
    * @returns {boolean}
    */
-  public isLLMConnected = (): boolean => this.llmChannel.isConnected();
+  public isLLMConnected = (): boolean => this.llmChannel?.isConnected() ?? false;
 
   public getKeepTranscriptionSubscribed = (): boolean => this.keepTranscriptionSubscribed;
 
@@ -299,9 +316,10 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @returns {void}
    */
   public sendAnnouncement = (): void => {
+    const llm = this.requireLLMChannel();
     this.announceStatus = ANNOUNCE_STATUS.JOINING;
-    const socket = this.llmChannel.getSocket();
-    const binding = this.llmChannel.getBinding();
+    const socket = llm.getSocket();
+    const binding = llm.getBinding();
 
     const payload = {
       id: `${this.seqNum}`,
@@ -338,7 +356,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   ): Promise<void> =>
     this.request({
       method: 'PUT',
-      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      url: `${this.requireLLMChannel().getLocusUrl()}/controls/`,
       body: {
         transcribe: {
           spokenLanguage: languageCode,
@@ -359,8 +377,9 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
       return;
     }
 
-    const socket = this.llmChannel.getSocket();
-    const binding = this.llmChannel.getBinding();
+    const llm = this.requireLLMChannel();
+    const socket = llm.getSocket();
+    const binding = llm.getBinding();
 
     socket.send({
       id: `${this.seqNum}`,
@@ -405,8 +424,9 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
       return;
     }
 
-    const socket = this.llmChannel.getSocket();
-    const binding = this.llmChannel.getBinding();
+    const llm = this.requireLLMChannel();
+    const socket = llm.getSocket();
+    const binding = llm.getBinding();
 
     socket?.send({
       id: `${this.seqNum}`,
@@ -449,7 +469,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   private requestTurnOnCaptions = (languageCode?: string): undefined | Promise<void> => {
     this.captionStatus = TURN_ON_CAPTION_STATUS.SENDING;
 
-    const locusUrl = this.llmChannel.getLocusUrl();
+    const locusUrl = this.requireLLMChannel().getLocusUrl();
 
     const body = {
       transcribe: {caption: true},
@@ -536,7 +556,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   ): undefined | Promise<void> => {
     return this.request({
       method: 'PUT',
-      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      url: `${this.requireLLMChannel().getLocusUrl()}/controls/`,
       body: {
         transcribe: {
           transcribing: activate,
@@ -564,7 +584,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
 
     return this.request({
       method: 'PUT',
-      url: `${this.llmChannel.getLocusUrl()}/controls/`,
+      url: `${this.requireLLMChannel().getLocusUrl()}/controls/`,
       body: {
         manualCaption: {
           enable,
@@ -638,11 +658,12 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   } = {}): Promise<void> => {
     if (!this.isLLMConnected()) return;
 
-    const isDataChannelTokenEnabled = await this.llmChannel.isDataChannelTokenEnabled();
+    const llm = this.requireLLMChannel();
+    const isDataChannelTokenEnabled = await llm.isDataChannelTokenEnabled();
     if (!isDataChannelTokenEnabled) return;
 
-    const socket = this.llmChannel.getSocket();
-    const datachannelUrl = this.llmChannel.getDatachannelUrl();
+    const socket = llm.getSocket();
+    const datachannelUrl = llm.getDatachannelUrl();
 
     socket.send({
       id: `${this.seqNum}`,

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -47,8 +47,12 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   private spokenLanguages: string[] = [];
   private currentCaptionLanguage?: string;
 
-  // Pending listener for deferred caption restoration when switching to a not-yet-connected channel
-  private _pendingCaptionRestoreListener?: () => void;
+  // Target channel for reconciler pattern - the channel voicea WANTS to be bound to
+  private targetLLMChannel?: LLMChannel;
+  // Single pending 'online' listener for deferred reconciliation
+  private _pendingOnlineListener?: () => void;
+  // Tracks whether caption restoration is pending (set on switch, cleared on restore)
+  private _pendingCaptionRestore = false;
 
   /**
    * Creates a VoiceaChannel, optionally bound to an LLMChannel.
@@ -135,12 +139,11 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     this.areCaptionsEnabled = false;
     this.keepTranscriptionSubscribed = false;
     this.captionServiceId = undefined;
+    this.targetLLMChannel = undefined;
+    this._pendingCaptionRestore = false;
 
-    // Remove any pending caption restore listener
-    if (this._pendingCaptionRestoreListener && this.llmChannel) {
-      this.llmChannel.off('online', this._pendingCaptionRestoreListener);
-      this._pendingCaptionRestoreListener = undefined;
-    }
+    // Remove any pending online listener
+    this.detachPendingOnline();
 
     if (this.hasSubscribedToEvents && this.llmChannel) {
       this.llmChannel.off('event:relay.event', this.eventProcessor);
@@ -155,74 +158,94 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   }
 
   /**
-   * Switch to a different LLM channel while preserving caption state.
-   * Used when transitioning between main meeting and practice session.
-   * - Preserves keepTranscriptionSubscribed and spokenLanguage state
-   * - Unsubscribes from old channel, subscribes to new channel
-   * - Re-announces and re-enables captions if they were on
-   * @param {LLMChannel} newLLMChannel - The new LLM channel to switch to
-   * @returns {Promise<void>}
+   * Attach a pending 'online' listener to a channel for deferred reconciliation.
+   * Detaches any existing listener first.
+   * @param {LLMChannel} channel - The channel to attach to
+   * @param {Function} callback - The callback to run when 'online' fires
+   * @private
+   * @returns {void}
    */
-  public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
-    // Skip if already on this channel - prevents duplicate HTTP requests when
-    // multiple callers (e.g., cleanupPSDataChannel and updateLLMConnection) both
-    // try to switch to the same channel concurrently.
-    if (this.llmChannel === newLLMChannel) {
-      return;
+  private attachPendingOnline(channel: LLMChannel, callback: () => void): void {
+    this.detachPendingOnline();
+    this._pendingOnlineListener = callback;
+    channel.once('online', this._pendingOnlineListener);
+  }
+
+  /**
+   * Detach any pending 'online' listener.
+   * @private
+   * @returns {void}
+   */
+  private detachPendingOnline(): void {
+    if (this._pendingOnlineListener && this.llmChannel) {
+      this.llmChannel.off('online', this._pendingOnlineListener);
     }
+    this._pendingOnlineListener = undefined;
+  }
 
-    // Save current state
-    const captionsWereOn = this.keepTranscriptionSubscribed;
-    const spokenLanguage = this.currentSpokenLanguage;
-
-    // Remove any pending caption restore listener from old channel
-    if (this._pendingCaptionRestoreListener && this.llmChannel) {
-      this.llmChannel.off('online', this._pendingCaptionRestoreListener);
-      this._pendingCaptionRestoreListener = undefined;
-    }
-
-    // Unsubscribe from old channel
-    if (this.hasSubscribedToEvents && this.llmChannel) {
-      this.llmChannel.off('event:relay.event', this.eventProcessor);
-      this.hasSubscribedToEvents = false;
-    }
-
-    // Switch to new channel
-    this.llmChannel = newLLMChannel;
-
-    // Subscribe to new channel
-    this.llmChannel.on('event:relay.event', this.eventProcessor);
-    this.hasSubscribedToEvents = true;
-
-    // Reset announcement state for new connection
+  /**
+   * Reset announcement state for a new connection.
+   * @private
+   * @returns {void}
+   */
+  private resetAnnounceState(): void {
     this.announceStatus = ANNOUNCE_STATUS.IDLE;
     this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
     this.captionServiceId = undefined;
     this.areCaptionsEnabled = false;
+  }
 
-    // Re-announce and re-enable captions if they were on.
-    // Caption restoration is fire-and-forget: errors are logged but don't propagate,
-    // ensuring cleanup operations (e.g., cleanupPSDataChannel) complete even if
-    // caption restoration fails.
-    if (captionsWereOn) {
-      if (this.isLLMConnected()) {
-        // Channel is already connected, restore captions immediately
-        this.turnOnCaptions(spokenLanguage).catch(() => {
-          // Best-effort restoration - if it fails, captions were already in a bad state
-        });
-      } else {
-        // Channel not yet connected - defer caption restoration until 'online' event.
-        // This handles the race where switchLLMChannel is called while the main channel
-        // is still reconnecting (e.g., concurrent updateLLMConnection and updatePSDataChannel).
-        this._pendingCaptionRestoreListener = () => {
-          this._pendingCaptionRestoreListener = undefined;
-          this.turnOnCaptions(spokenLanguage).catch(() => {
-            // Best-effort restoration - if it fails, captions were already in a bad state
-          });
-        };
-        this.llmChannel.once('online', this._pendingCaptionRestoreListener);
+  /**
+   * Reconcile voicea binding and caption state to match the desired target.
+   * This is idempotent - always re-reads targetLLMChannel and current state.
+   * A deferred 'online' callback that fires late self-corrects automatically.
+   * @private
+   * @returns {void}
+   */
+  private reconcile(): void {
+    const target = this.targetLLMChannel;
+    if (!target) return;
+
+    // 1. Rebind relay-event subscription if actual != desired
+    if (this.llmChannel !== target) {
+      if (this.hasSubscribedToEvents && this.llmChannel) {
+        this.llmChannel.off('event:relay.event', this.eventProcessor);
       }
+      this.detachPendingOnline();
+      this.llmChannel = target;
+      this.llmChannel.on('event:relay.event', this.eventProcessor);
+      this.hasSubscribedToEvents = true;
+      this.resetAnnounceState();
+      // Mark caption restoration as pending if captions were subscribed
+      this._pendingCaptionRestore = this.keepTranscriptionSubscribed;
     }
+
+    // 2. Restore captions if pending
+    if (!this._pendingCaptionRestore) return;
+
+    if (this.isLLMConnected()) {
+      // Channel is connected, restore captions immediately
+      this._pendingCaptionRestore = false;
+      this.turnOnCaptions(this.currentSpokenLanguage).catch(() => {
+        // Best-effort restoration
+      });
+    } else {
+      // Channel not yet connected - defer until 'online' then re-reconcile.
+      // If target changes meanwhile, reconcile() self-corrects.
+      this.attachPendingOnline(target, () => this.reconcile());
+    }
+  }
+
+  /**
+   * Switch to a different LLM channel while preserving caption state.
+   * Used when transitioning between main meeting and practice session.
+   * This is a thin intent-setter - actual binding happens in reconcile().
+   * @param {LLMChannel} newLLMChannel - The new LLM channel to switch to
+   * @returns {Promise<void>}
+   */
+  public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
+    this.targetLLMChannel = newLLMChannel;
+    this.reconcile();
   }
 
   /**
@@ -530,7 +553,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
         this.announce();
         this.updateSubchannelSubscriptionsAndSyncCaptionState({subscribe: ['transcription']}, true);
       })
-      .catch((error) => {
+      .catch(() => {
         this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
         throw new Error('turn on captions fail');
       });

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -47,6 +47,9 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
   private spokenLanguages: string[] = [];
   private currentCaptionLanguage?: string;
 
+  // Pending listener for deferred caption restoration when switching to a not-yet-connected channel
+  private _pendingCaptionRestoreListener?: () => void;
+
   /**
    * Creates a VoiceaChannel, optionally bound to an LLMChannel.
    * If no llmChannel is provided, call switchLLMChannel() later to attach one.
@@ -133,6 +136,12 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     this.keepTranscriptionSubscribed = false;
     this.captionServiceId = undefined;
 
+    // Remove any pending caption restore listener
+    if (this._pendingCaptionRestoreListener && this.llmChannel) {
+      this.llmChannel.off('online', this._pendingCaptionRestoreListener);
+      this._pendingCaptionRestoreListener = undefined;
+    }
+
     if (this.hasSubscribedToEvents && this.llmChannel) {
       this.llmChannel.off('event:relay.event', this.eventProcessor);
       this.hasSubscribedToEvents = false;
@@ -159,6 +168,12 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     const captionsWereOn = this.keepTranscriptionSubscribed;
     const spokenLanguage = this.currentSpokenLanguage;
 
+    // Remove any pending caption restore listener from old channel
+    if (this._pendingCaptionRestoreListener && this.llmChannel) {
+      this.llmChannel.off('online', this._pendingCaptionRestoreListener);
+      this._pendingCaptionRestoreListener = undefined;
+    }
+
     // Unsubscribe from old channel
     if (this.hasSubscribedToEvents && this.llmChannel) {
       this.llmChannel.off('event:relay.event', this.eventProcessor);
@@ -180,7 +195,21 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
 
     // Re-announce and re-enable captions if they were on
     if (captionsWereOn) {
-      await this.turnOnCaptions(spokenLanguage);
+      if (this.isLLMConnected()) {
+        // Channel is already connected, restore captions immediately
+        await this.turnOnCaptions(spokenLanguage);
+      } else {
+        // Channel not yet connected - defer caption restoration until 'online' event.
+        // This handles the race where switchLLMChannel is called while the main channel
+        // is still reconnecting (e.g., concurrent updateLLMConnection and updatePSDataChannel).
+        this._pendingCaptionRestoreListener = () => {
+          this._pendingCaptionRestoreListener = undefined;
+          this.turnOnCaptions(spokenLanguage).catch(() => {
+            // Best-effort restoration - if it fails, captions were already in a bad state
+          });
+        };
+        this.llmChannel.once('online', this._pendingCaptionRestoreListener);
+      }
     }
   }
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -145,8 +145,8 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     // Remove any pending online listener
     this.detachPendingOnline();
 
-    if (this.hasSubscribedToEvents && this.llmChannel) {
-      this.llmChannel.off('event:relay.event', this.eventProcessor);
+    if (this.hasSubscribedToEvents) {
+      this.llmChannel?.off('event:relay.event', this.eventProcessor);
       this.hasSubscribedToEvents = false;
     }
 
@@ -200,11 +200,11 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * This is idempotent - always re-reads targetLLMChannel and current state.
    * A deferred 'online' callback that fires late self-corrects automatically.
    * @private
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  private reconcile(): void {
+  private reconcile(): Promise<void> {
     const target = this.targetLLMChannel;
-    if (!target) return;
+    if (!target) return Promise.resolve();
 
     // 1. Rebind relay-event subscription if actual != desired
     if (this.llmChannel !== target) {
@@ -221,19 +221,25 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
     }
 
     // 2. Restore captions if pending
-    if (!this._pendingCaptionRestore) return;
+    if (!this._pendingCaptionRestore) return Promise.resolve();
 
     if (this.isLLMConnected()) {
       // Channel is connected, restore captions immediately
       this._pendingCaptionRestore = false;
-      this.turnOnCaptions(this.currentSpokenLanguage).catch(() => {
-        // Best-effort restoration
-      });
-    } else {
-      // Channel not yet connected - defer until 'online' then re-reconcile.
-      // If target changes meanwhile, reconcile() self-corrects.
-      this.attachPendingOnline(target, () => this.reconcile());
+
+      return this.turnOnCaptions(this.currentSpokenLanguage)
+        .then(() => undefined)
+        .catch(() => {
+          // Best-effort restoration
+        });
     }
+    // Channel not yet connected - defer until 'online' then re-reconcile.
+    // If target changes meanwhile, reconcile() self-corrects.
+    this.attachPendingOnline(target, () => {
+      this.reconcile();
+    });
+
+    return Promise.resolve();
   }
 
   /**
@@ -243,9 +249,10 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @param {LLMChannel} newLLMChannel - The new LLM channel to switch to
    * @returns {Promise<void>}
    */
-  public async switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
+  public switchLLMChannel(newLLMChannel: LLMChannel): Promise<void> {
     this.targetLLMChannel = newLLMChannel;
-    this.reconcile();
+
+    return this.reconcile();
   }
 
   /**
@@ -553,9 +560,9 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
         this.announce();
         this.updateSubchannelSubscriptionsAndSyncCaptionState({subscribe: ['transcription']}, true);
       })
-      .catch(() => {
+      .catch((error) => {
         this.captionStatus = TURN_ON_CAPTION_STATUS.IDLE;
-        throw new Error('turn on captions fail');
+        throw new Error('turn on captions fail', {cause: error});
       });
   };
 
@@ -599,7 +606,7 @@ export class VoiceaChannel extends EventEmitter implements IVoiceaChannel {
    * @returns {Promise}
    */
   public turnOnCaptions = async (spokenLanguage?: string): Promise<void | undefined> => {
-    if (this.captionStatus === TURN_ON_CAPTION_STATUS.SENDING) return undefined;
+    if (this.isCaptionProcessing()) return undefined;
 
     if (!this.isLLMConnected()) {
       throw new Error('can not turn on captions before llm connected');

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea-plugin.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea-plugin.js
@@ -51,6 +51,18 @@ describe('plugin-voicea', () => {
         assert.instanceOf(channel, VoiceaChannel);
       });
 
+      it('creates a new VoiceaChannel instance without llmChannel', () => {
+        const channel = plugin.createChannel();
+
+        assert.instanceOf(channel, VoiceaChannel);
+      });
+
+      it('creates a new VoiceaChannel instance with undefined llmChannel', () => {
+        const channel = plugin.createChannel(undefined);
+
+        assert.instanceOf(channel, VoiceaChannel);
+      });
+
       it('creates independent channels for multiple calls', () => {
         const mockLLMChannel1 = createMockLLMChannel();
         const mockLLMChannel2 = createMockLLMChannel();

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -28,6 +28,7 @@ function createMockLLMChannel(options = {}) {
     isDataChannelTokenEnabled: sinon.stub().resolves(true),
     on: sinon.stub(),
     off: sinon.stub(),
+    once: sinon.stub(),
     socket: mockWebSocket,
   };
 }
@@ -1047,6 +1048,102 @@ describe('plugin-voicea', () => {
 
         // isLLMConnected should now return true
         assert.equal(channelWithoutLLM.isLLMConnected(), true);
+      });
+
+      it('defers caption restoration when new channel is not connected', async () => {
+        // Enable captions
+        voiceaChannel.keepTranscriptionSubscribed = true;
+        voiceaChannel.currentSpokenLanguage = 'fr';
+
+        // Create a new channel that is NOT connected yet
+        const newMockLLMChannel = createMockLLMChannel({
+          isConnected: false,
+          locusUrl: 'newLocusUrl',
+        });
+
+        await voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Should have subscribed to new channel events
+        assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+
+        // Should have registered a 'once' listener for 'online' event
+        assert.calledWith(newMockLLMChannel.once, 'online', sinon.match.func);
+
+        // Should NOT have sent any messages yet (waiting for connection)
+        assert.notCalled(newMockLLMChannel.socket.send);
+      });
+
+      it('restores captions when deferred channel comes online', async () => {
+        // Enable captions
+        voiceaChannel.keepTranscriptionSubscribed = true;
+        voiceaChannel.currentSpokenLanguage = 'de';
+
+        // Create a new channel that is NOT connected yet
+        const newMockLLMChannel = createMockLLMChannel({
+          isConnected: false,
+          locusUrl: 'newLocusUrl',
+        });
+
+        await voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Get the 'online' listener that was registered
+        const onlineListener = newMockLLMChannel.once.getCall(0).args[1];
+
+        // Simulate channel coming online
+        newMockLLMChannel.isConnected.returns(true);
+        onlineListener();
+
+        // Wait for async turnOnCaptions to complete
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Now it should have sent messages (announcement + subchannel subscription)
+        assert.calledTwice(newMockLLMChannel.socket.send);
+      });
+
+      it('removes pending online listener when deregisterEvents is called', async () => {
+        // Enable captions
+        voiceaChannel.keepTranscriptionSubscribed = true;
+
+        // Create a new channel that is NOT connected yet
+        const newMockLLMChannel = createMockLLMChannel({
+          isConnected: false,
+          locusUrl: 'newLocusUrl',
+        });
+
+        await voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        // Get the 'online' listener that was registered
+        const onlineListener = newMockLLMChannel.once.getCall(0).args[1];
+
+        // Now deregister events
+        voiceaChannel.deregisterEvents();
+
+        // Should have removed the 'online' listener
+        assert.calledWith(newMockLLMChannel.off, 'online', onlineListener);
+      });
+
+      it('removes old pending online listener when switching channels again', async () => {
+        // Enable captions
+        voiceaChannel.keepTranscriptionSubscribed = true;
+
+        // Create first new channel that is NOT connected
+        const firstNewChannel = createMockLLMChannel({isConnected: false, locusUrl: 'firstUrl'});
+
+        await voiceaChannel.switchLLMChannel(firstNewChannel);
+
+        // Get the 'online' listener registered on first channel
+        const firstOnlineListener = firstNewChannel.once.getCall(0).args[1];
+
+        // Now switch to another channel (also not connected)
+        const secondNewChannel = createMockLLMChannel({isConnected: false, locusUrl: 'secondUrl'});
+
+        await voiceaChannel.switchLLMChannel(secondNewChannel);
+
+        // Should have removed the 'online' listener from first channel
+        assert.calledWith(firstNewChannel.off, 'online', firstOnlineListener);
+
+        // Should have registered a new 'online' listener on second channel
+        assert.calledWith(secondNewChannel.once, 'online', sinon.match.func);
       });
     });
 

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -65,8 +65,14 @@ describe('plugin-voicea', () => {
         assert.equal(voiceaChannel.getCaptionStatus(), 'idle');
       });
 
-      it('should subscribe to relay events', () => {
+      it('should subscribe to relay events when llmChannel is provided', () => {
         assert.calledWith(mockLLMChannel.on, 'event:relay.event', sinon.match.func);
+      });
+
+      it('should not subscribe to events when llmChannel is undefined', () => {
+        const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
+        // No llmChannel means no subscription, just verify it doesn't throw
+        assert.equal(channelWithoutLLM.getAnnounceStatus(), 'idle');
       });
     });
 
@@ -193,9 +199,20 @@ describe('plugin-voicea', () => {
     });
 
     describe('#deregisterEvents', () => {
-
       beforeEach(async () => {
         voiceaChannel.keepTranscriptionSubscribed = true;
+      });
+
+      it('works when llmChannel is undefined', () => {
+        const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
+        channelWithoutLLM.areCaptionsEnabled = true;
+        channelWithoutLLM.keepTranscriptionSubscribed = true;
+
+        // Should not throw
+        channelWithoutLLM.deregisterEvents();
+
+        assert.equal(channelWithoutLLM.areCaptionsEnabled, false);
+        assert.equal(channelWithoutLLM.keepTranscriptionSubscribed, false);
       });
 
       it('deregisters voicea channel and resets state', () => {
@@ -321,6 +338,11 @@ describe('plugin-voicea', () => {
       it('returns false when the LLM channel is not connected', () => {
         mockLLMChannel.isConnected.returns(false);
         assert.equal(voiceaChannel.isLLMConnected(), false);
+      });
+
+      it('returns false when the LLM channel is undefined', () => {
+        const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
+        assert.equal(channelWithoutLLM.isLLMConnected(), false);
       });
     });
 
@@ -1010,6 +1032,37 @@ describe('plugin-voicea', () => {
 
         // Should have subscribed to new channel
         assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+      });
+
+      it('switches from undefined llmChannel to a valid one', async () => {
+        // Create a channel without llmChannel
+        const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+
+        await channelWithoutLLM.switchLLMChannel(newMockLLMChannel);
+
+        // Should have subscribed to new channel
+        assert.calledWith(newMockLLMChannel.on, 'event:relay.event', sinon.match.func);
+
+        // isLLMConnected should now return true
+        assert.equal(channelWithoutLLM.isLLMConnected(), true);
+      });
+    });
+
+    describe('#requireLLMChannel', () => {
+      it('throws when llmChannel is undefined', () => {
+        const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
+
+        assert.throws(
+          () => channelWithoutLLM.sendAnnouncement(),
+          'VoiceaChannel: LLM channel not available'
+        );
+      });
+
+      it('does not throw when llmChannel is defined', () => {
+        // voiceaChannel has a mockLLMChannel, so this should not throw
+        assert.doesNotThrow(() => voiceaChannel.sendAnnouncement());
       });
     });
   });

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -969,6 +969,9 @@ describe('plugin-voicea', () => {
 
         await voiceaChannel.switchLLMChannel(newMockLLMChannel);
 
+        // Wait for fire-and-forget turnOnCaptions to complete
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
         // Should have unsubscribed from old channel
         assert.calledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
 
@@ -996,6 +999,24 @@ describe('plugin-voicea', () => {
           },
           trackingId: sinon.match.string,
         });
+      });
+
+      it('skips switch when already on the same channel', async () => {
+        // Enable captions to verify they are NOT re-enabled on no-op switch
+        voiceaChannel.keepTranscriptionSubscribed = true;
+        voiceaChannel.currentSpokenLanguage = 'es';
+
+        // Switch to the same channel that voiceaChannel is already using
+        await voiceaChannel.switchLLMChannel(mockLLMChannel);
+
+        // Should NOT have unsubscribed (no-op)
+        assert.notCalled(mockLLMChannel.off);
+
+        // Should NOT have re-subscribed
+        // The 'on' was already called in the constructor, but no NEW calls should happen
+        // Since constructor already called 'on', we check it wasn't called again after construction
+        // The mock was created fresh, so we just verify no additional sends
+        assert.notCalled(mockLLMChannel.socket.send);
       });
 
       it('does not turn on captions if they were not on before switching', async () => {
@@ -1144,6 +1165,27 @@ describe('plugin-voicea', () => {
 
         // Should have registered a new 'online' listener on second channel
         assert.calledWith(secondNewChannel.once, 'online', sinon.match.func);
+      });
+
+      it('does not duplicate caption HTTP requests on concurrent same-channel switches', async () => {
+        // Enable captions
+        voiceaChannel.keepTranscriptionSubscribed = true;
+        voiceaChannel.currentSpokenLanguage = 'en';
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+
+        // Simulate concurrent switches to the same channel
+        const switch1 = voiceaChannel.switchLLMChannel(newMockLLMChannel);
+        const switch2 = voiceaChannel.switchLLMChannel(newMockLLMChannel);
+
+        await Promise.all([switch1, switch2]);
+
+        // Wait for fire-and-forget turnOnCaptions to complete
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Should only have sent 2 messages total (announcement + subchannel subscription)
+        // NOT 4 messages (which would indicate duplicate switches)
+        assert.calledTwice(newMockLLMChannel.socket.send);
       });
     });
 

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -8,6 +8,8 @@ import Mercury from '@webex/internal-plugin-mercury';
 import {VoiceaChannel} from '../../../src/voicea';
 import {EVENT_TRIGGERS, TOGGLE_MANUAL_CAPTION_STATUS} from '../../../src/constants';
 
+const flushPromises = () => new Promise(setImmediate);
+
 /**
  * Creates a mock LLM channel for testing
  * @param {Object} [options] - Options for the mock channel
@@ -1115,7 +1117,7 @@ describe('plugin-voicea', () => {
         onlineListener();
 
         // Wait for async turnOnCaptions to complete
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await flushPromises();
 
         // Now it should have sent messages (announcement + subchannel subscription)
         assert.calledTwice(newMockLLMChannel.socket.send);

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -210,12 +210,14 @@ describe('plugin-voicea', () => {
         const channelWithoutLLM = new VoiceaChannel(undefined, requestStub);
         channelWithoutLLM.areCaptionsEnabled = true;
         channelWithoutLLM.keepTranscriptionSubscribed = true;
+        channelWithoutLLM.hasSubscribedToEvents = true;
 
         // Should not throw
         channelWithoutLLM.deregisterEvents();
 
         assert.equal(channelWithoutLLM.areCaptionsEnabled, false);
         assert.equal(channelWithoutLLM.keepTranscriptionSubscribed, false);
+        assert.equal(channelWithoutLLM.hasSubscribedToEvents, false);
       });
 
       it('deregisters voicea channel and resets state', () => {
@@ -413,10 +415,25 @@ describe('plugin-voicea', () => {
         assert.equal(result, undefined);
       });
 
-      it('throws error on request failure', async () => {
-        requestStub.rejects(new Error('Request failed'));
+      it('returns undefined when already enabled', async () => {
+        voiceaChannel.captionStatus = 'enabled';
 
-        await assert.isRejected(voiceaChannel.turnOnCaptions(), 'turn on captions fail');
+        const result = await voiceaChannel.turnOnCaptions();
+
+        assert.equal(result, undefined);
+        assert.notCalled(requestStub);
+      });
+
+      it('throws error on request failure', async () => {
+        const requestError = new Error('Request failed');
+        requestStub.rejects(requestError);
+
+        const error = await assert.isRejected(
+          voiceaChannel.turnOnCaptions(),
+          'turn on captions fail'
+        );
+
+        assert.equal(error.cause, requestError);
       });
 
       it('resets caption status to idle on error', async () => {
@@ -971,9 +988,6 @@ describe('plugin-voicea', () => {
 
         await voiceaChannel.switchLLMChannel(newMockLLMChannel);
 
-        // Wait for fire-and-forget turnOnCaptions to complete
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
         // Should have unsubscribed from old channel
         assert.calledWith(mockLLMChannel.off, 'event:relay.event', sinon.match.func);
 
@@ -1001,6 +1015,32 @@ describe('plugin-voicea', () => {
           },
           trackingId: sinon.match.string,
         });
+      });
+
+      it('resolves after caption restoration completes', async () => {
+        let resolveRequest;
+        requestStub.returns(
+          new Promise((resolve) => {
+            resolveRequest = resolve;
+          })
+        );
+        voiceaChannel.keepTranscriptionSubscribed = true;
+
+        const newMockLLMChannel = createMockLLMChannel({locusUrl: 'newLocusUrl'});
+        const switchPromise = voiceaChannel.switchLLMChannel(newMockLLMChannel);
+        let hasSwitchResolved = false;
+        switchPromise.then(() => {
+          hasSwitchResolved = true;
+        });
+
+        await flushPromises();
+
+        assert.isFalse(hasSwitchResolved);
+
+        resolveRequest();
+        await switchPromise;
+
+        assert.isTrue(hasSwitchResolved);
       });
 
       it('skips switch when already on the same channel', async () => {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6954,16 +6954,6 @@ export default class Meeting extends StatelessWebexPlugin {
         );
         this.startLLMHealthCheckTimer();
 
-        // Recreate voiceaChannel if it was destroyed (e.g., by MeetingUtil.cleanUp after
-        // a DESTROY_MEETING event, but user rejoined the same meeting object).
-        if (!this.voiceaChannel) {
-          // @ts-ignore - Fix type
-          this.voiceaChannel = this.webex.internal.voicea.createChannel();
-          LoggerProxy.logger.info(
-            'Meeting:index#updateLLMConnection --> recreated voiceaChannel after rejoin'
-          );
-        }
-
         // Switch voiceaChannel to use the new LLM channel (preserves transcription state).
         // Skip if practice session is active - practice session manages its own voicea binding
         // via updatePSDataChannel, and switching here would break practice session captions.

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -739,6 +739,27 @@ export default class Meeting extends StatelessWebexPlugin {
   turnDiscoverySkippedReason: TurnDiscoverySkipReason;
   turnServerUsed: boolean;
   areVoiceaEventsSetup = false;
+
+  /**
+   * Returns the initial transcription object shape.
+   * Used by constructor and reset paths to ensure consistent initialization.
+   * @private
+   * @returns {Transcription}
+   */
+  private getInitialTranscription(): Transcription {
+    return {
+      captions: [],
+      isListening: false,
+      commandText: '',
+      languageOptions: {currentSpokenLanguage: 'en'},
+      showCaptionBox: false,
+      transcribingRequestStatus: 'INACTIVE',
+      isCaptioning: false,
+      interimCaptions: {} as Map<string, CaptionData>,
+      speakerProxy: {} as Map<string, any>,
+    } as Transcription;
+  }
+
   isMoveToInProgress = false;
   registrationIdStatus: string;
   brbState: BrbState;
@@ -1518,17 +1539,7 @@ export default class Meeting extends StatelessWebexPlugin {
      * @private
      * @memberof Meeting
      */
-    this.transcription = {
-      captions: [],
-      isListening: false,
-      commandText: '',
-      languageOptions: {currentSpokenLanguage: 'en'},
-      showCaptionBox: false,
-      transcribingRequestStatus: 'INACTIVE',
-      isCaptioning: false,
-      interimCaptions: {} as Map<string, CaptionData>,
-      speakerProxy: {} as Map<string, any>,
-    } as Transcription;
+    this.transcription = this.getInitialTranscription();
 
     /**
      * Password status. If it's PASSWORD_STATUS.REQUIRED then verifyPassword() needs to be called
@@ -3056,9 +3067,9 @@ export default class Meeting extends StatelessWebexPlugin {
         // user need to be joined to start the llm and receive transcription
         if (this.isJoined()) {
           // @ts-ignore - config coming from registerPlugin
-          if (transcribing && !this.transcription) {
+          if (transcribing && !this.areVoiceaEventsSetup) {
             this.startTranscription();
-          } else if (!transcribing && this.transcription) {
+          } else if (!transcribing && this.areVoiceaEventsSetup) {
             Trigger.trigger(
               this,
               {
@@ -6703,10 +6714,11 @@ export default class Meeting extends StatelessWebexPlugin {
   private stopListeningForMeetingEvents() {
     this.stopListeningForLLMEvents();
     this.stopListeningForMercuryEvents();
-    if (this.transcription) {
+    if (this.areVoiceaEventsSetup) {
       this.stopTranscription();
-      this.transcription = undefined;
     }
+    // Reset to initial shape instead of null - transcription is always a valid object
+    this.transcription = this.getInitialTranscription();
     this.annotation.deregisterEvents();
   }
 
@@ -6926,6 +6938,16 @@ export default class Meeting extends StatelessWebexPlugin {
         );
         this.startLLMHealthCheckTimer();
 
+        // Recreate voiceaChannel if it was destroyed (e.g., by MeetingUtil.cleanUp after
+        // a DESTROY_MEETING event, but user rejoined the same meeting object).
+        if (!this.voiceaChannel) {
+          // @ts-ignore - Fix type
+          this.voiceaChannel = this.webex.internal.voicea.createChannel();
+          LoggerProxy.logger.info(
+            'Meeting:index#updateLLMConnection --> recreated voiceaChannel after rejoin'
+          );
+        }
+
         // Switch voiceaChannel to use the new LLM channel (preserves transcription state).
         // Skip if practice session is active - practice session manages its own voicea binding
         // via updatePSDataChannel, and switching here would break practice session captions.
@@ -6933,25 +6955,9 @@ export default class Meeting extends StatelessWebexPlugin {
           this.webinar?.isPracticeSessionLLMChannelConnected() ?? false;
 
         if (this.voiceaChannel && !isPracticeSessionActive) {
-          // Reinitialize transcription object if it was cleared during leave() but voiceaChannel
-          // was preserved. switchLLMChannel() will restore captions if they were active,
-          // and the caption event callbacks require this.transcription to exist.
-          if (!this.transcription && this.voiceaChannel.getKeepTranscriptionSubscribed()) {
-            this.transcription = {
-              captions: [],
-              isListening: false,
-              commandText: '',
-              languageOptions: {currentSpokenLanguage: 'en'},
-              showCaptionBox: false,
-              transcribingRequestStatus: 'INACTIVE',
-              isCaptioning: false,
-              interimCaptions: {} as Map<string, CaptionData>,
-              speakerProxy: {} as Map<string, any>,
-            } as Transcription;
-          }
-
-          // @ts-ignore - Fix type
-          // Fire-and-forget: caption restoration shouldn't block LLM connection result
+          // Fire-and-forget: caption restoration shouldn't block LLM connection result.
+          // transcription is always initialized (reset to initial shape, never null),
+          // so no re-init needed here.
           this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
             LoggerProxy.logger.warn(
               'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6933,6 +6933,23 @@ export default class Meeting extends StatelessWebexPlugin {
           this.webinar?.isPracticeSessionLLMChannelConnected() ?? false;
 
         if (this.voiceaChannel && !isPracticeSessionActive) {
+          // Reinitialize transcription object if it was cleared during leave() but voiceaChannel
+          // was preserved. switchLLMChannel() will restore captions if they were active,
+          // and the caption event callbacks require this.transcription to exist.
+          if (!this.transcription && this.voiceaChannel.getKeepTranscriptionSubscribed()) {
+            this.transcription = {
+              captions: [],
+              isListening: false,
+              commandText: '',
+              languageOptions: {currentSpokenLanguage: 'en'},
+              showCaptionBox: false,
+              transcribingRequestStatus: 'INACTIVE',
+              isCaptioning: false,
+              interimCaptions: {} as Map<string, CaptionData>,
+              speakerProxy: {} as Map<string, any>,
+            } as Transcription;
+          }
+
           // @ts-ignore - Fix type
           // Fire-and-forget: caption restoration shouldn't block LLM connection result
           this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6924,16 +6924,21 @@ export default class Meeting extends StatelessWebexPlugin {
         );
         this.startLLMHealthCheckTimer();
 
+        // Recreate voiceaChannel if it was cleared (e.g., after leave() + rejoin).
+        // This ensures startTranscription() works for the meeting object's entire lifetime.
+        if (!this.voiceaChannel) {
+          // @ts-ignore - Fix type
+          this.voiceaChannel = this.webex.internal.voicea.createChannel();
+        }
+
         // Switch voiceaChannel to use the new LLM channel (preserves transcription state)
         // Fire-and-forget: caption restoration shouldn't block LLM connection result
-        if (this.voiceaChannel) {
-          this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
-            LoggerProxy.logger.warn(
-              'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
-              error
-            );
-          });
-        }
+        this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
+          LoggerProxy.logger.warn(
+            'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
+            error
+          );
+        });
 
         if (registerAndConnectResult) {
           if (isInitialJoinPhase) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6745,6 +6745,10 @@ export default class Meeting extends StatelessWebexPlugin {
       }
     } finally {
       this.stopListeningForLLMEvents();
+      // Permanent cleanup: deregister voiceaChannel since meeting is being destroyed
+      // (transient reconnects preserve voiceaChannel via switchLLMChannel instead)
+      this.voiceaChannel?.deregisterEvents();
+      this.voiceaChannel = undefined;
       this.llmChannel = undefined;
     }
   };

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6728,6 +6728,14 @@ export default class Meeting extends StatelessWebexPlugin {
     // Always clear the timer, even if there's no channel
     this.clearLLMHealthCheckTimer();
 
+    // Permanent cleanup must deregister voiceaChannel regardless of LLM presence.
+    // When a transient reconnect fails (LLM registration error), llmChannel is undefined
+    // but voiceaChannel may still exist with listeners attached to the old emitter.
+    if (!preserveVoiceaChannel) {
+      this.voiceaChannel?.deregisterEvents();
+      this.voiceaChannel = undefined;
+    }
+
     if (!this.llmChannel) {
       return;
     }
@@ -6748,12 +6756,6 @@ export default class Meeting extends StatelessWebexPlugin {
       }
     } finally {
       this.stopListeningForLLMEvents();
-      // Only destroy voiceaChannel on permanent cleanup (meeting end/leave).
-      // Transient reconnects preserve it so switchLLMChannel() can restore subscriptions.
-      if (!preserveVoiceaChannel) {
-        this.voiceaChannel?.deregisterEvents();
-        this.voiceaChannel = undefined;
-      }
       this.llmChannel = undefined;
     }
   };
@@ -6924,11 +6926,27 @@ export default class Meeting extends StatelessWebexPlugin {
         );
         this.startLLMHealthCheckTimer();
 
-        // Recreate voiceaChannel if it was cleared (e.g., after leave() + rejoin).
-        // This ensures startTranscription() works for the meeting object's entire lifetime.
+        // Recreate voiceaChannel and transcription state if cleared (e.g., after leave() + rejoin).
+        // Both must be reinitialized together: voiceaListenerCallbacks reference this.transcription,
+        // so startTranscription() would throw if only voiceaChannel is recreated.
         if (!this.voiceaChannel) {
           // @ts-ignore - Fix type
           this.voiceaChannel = this.webex.internal.voicea.createChannel();
+
+          // Reinitialize transcription state (cleared by stopListeningForMeetingEvents during leave)
+          if (!this.transcription) {
+            this.transcription = {
+              captions: [],
+              isListening: false,
+              commandText: '',
+              languageOptions: {currentSpokenLanguage: 'en'},
+              showCaptionBox: false,
+              transcribingRequestStatus: 'INACTIVE',
+              isCaptioning: false,
+              interimCaptions: {} as Map<string, CaptionData>,
+              speakerProxy: {} as Map<string, any>,
+            } as Transcription;
+          }
         }
 
         // Switch voiceaChannel to use the new LLM channel (preserves transcription state)

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6715,12 +6715,15 @@ export default class Meeting extends StatelessWebexPlugin {
    *
    * @param {Object} options
    * @param {boolean} [options.throwOnError=true] rethrows disconnect errors when true
+   * @param {boolean} [options.preserveVoiceaChannel=false] when true, keeps voiceaChannel for switchLLMChannel() during reconnects
    * @returns {Promise<void>}
    */
   private cleanupLLMConneciton = async ({
     throwOnError = true,
+    preserveVoiceaChannel = false,
   }: {
     throwOnError?: boolean;
+    preserveVoiceaChannel?: boolean;
   } = {}): Promise<void> => {
     // Always clear the timer, even if there's no channel
     this.clearLLMHealthCheckTimer();
@@ -6745,10 +6748,12 @@ export default class Meeting extends StatelessWebexPlugin {
       }
     } finally {
       this.stopListeningForLLMEvents();
-      // Permanent cleanup: deregister voiceaChannel since meeting is being destroyed
-      // (transient reconnects preserve voiceaChannel via switchLLMChannel instead)
-      this.voiceaChannel?.deregisterEvents();
-      this.voiceaChannel = undefined;
+      // Only destroy voiceaChannel on permanent cleanup (meeting end/leave).
+      // Transient reconnects preserve it so switchLLMChannel() can restore subscriptions.
+      if (!preserveVoiceaChannel) {
+        this.voiceaChannel?.deregisterEvents();
+        this.voiceaChannel = undefined;
+      }
       this.llmChannel = undefined;
     }
   };
@@ -6868,7 +6873,7 @@ export default class Meeting extends StatelessWebexPlugin {
       }
 
       // URLs changed or not joined, disconnect existing channel
-      await this.cleanupLLMConneciton();
+      await this.cleanupLLMConneciton({preserveVoiceaChannel: true});
     }
 
     if (!isJoined) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -739,6 +739,8 @@ export default class Meeting extends StatelessWebexPlugin {
   turnDiscoverySkippedReason: TurnDiscoverySkipReason;
   turnServerUsed: boolean;
   areVoiceaEventsSetup = false;
+  // Tracks if transcription should start once LLM connects (deferred from CONTROLS_MEETING_TRANSCRIBE_UPDATED)
+  private _pendingTranscriptionStart = false;
 
   /**
    * Returns the initial transcription object shape.
@@ -3068,6 +3070,13 @@ export default class Meeting extends StatelessWebexPlugin {
         if (this.isJoined()) {
           // @ts-ignore - config coming from registerPlugin
           if (transcribing && !this.areVoiceaEventsSetup) {
+            // Defer transcription start if LLM not yet connected - voiceaChannel exists from
+            // constructor but can't make HTTP requests until switchLLMChannel binds an LLM.
+            if (!this.voiceaChannel?.isLLMConnected()) {
+              this._pendingTranscriptionStart = true;
+
+              return;
+            }
             this.startTranscription();
           } else if (!transcribing && this.areVoiceaEventsSetup) {
             Trigger.trigger(
@@ -6328,6 +6337,7 @@ export default class Meeting extends StatelessWebexPlugin {
     this.voiceaChannel?.deregisterEvents();
 
     this.areVoiceaEventsSetup = false;
+    this._pendingTranscriptionStart = false;
     this.triggerStopReceivingTranscriptionEvent();
   }
 
@@ -6964,6 +6974,13 @@ export default class Meeting extends StatelessWebexPlugin {
               error
             );
           });
+
+          // Start transcription if it was deferred while waiting for LLM to connect.
+          // This handles the race where CONTROLS_MEETING_TRANSCRIBE_UPDATED arrived before LLM was ready.
+          if (this._pendingTranscriptionStart && !this.areVoiceaEventsSetup) {
+            this._pendingTranscriptionStart = false;
+            this.startTranscription();
+          }
         }
 
         if (registerAndConnectResult) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6926,37 +6926,22 @@ export default class Meeting extends StatelessWebexPlugin {
         );
         this.startLLMHealthCheckTimer();
 
-        // Recreate voiceaChannel and transcription state if cleared (e.g., after leave() + rejoin).
-        // Both must be reinitialized together: voiceaListenerCallbacks reference this.transcription,
-        // so startTranscription() would throw if only voiceaChannel is recreated.
-        if (!this.voiceaChannel) {
+        // Switch voiceaChannel to use the new LLM channel (preserves transcription state).
+        // Skip if practice session is active - practice session manages its own voicea binding
+        // via updatePSDataChannel, and switching here would break practice session captions.
+        const isPracticeSessionActive =
+          this.webinar?.isPracticeSessionLLMChannelConnected() ?? false;
+
+        if (this.voiceaChannel && !isPracticeSessionActive) {
           // @ts-ignore - Fix type
-          this.voiceaChannel = this.webex.internal.voicea.createChannel();
-
-          // Reinitialize transcription state (cleared by stopListeningForMeetingEvents during leave)
-          if (!this.transcription) {
-            this.transcription = {
-              captions: [],
-              isListening: false,
-              commandText: '',
-              languageOptions: {currentSpokenLanguage: 'en'},
-              showCaptionBox: false,
-              transcribingRequestStatus: 'INACTIVE',
-              isCaptioning: false,
-              interimCaptions: {} as Map<string, CaptionData>,
-              speakerProxy: {} as Map<string, any>,
-            } as Transcription;
-          }
+          // Fire-and-forget: caption restoration shouldn't block LLM connection result
+          this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
+            LoggerProxy.logger.warn(
+              'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
+              error
+            );
+          });
         }
-
-        // Switch voiceaChannel to use the new LLM channel (preserves transcription state)
-        // Fire-and-forget: caption restoration shouldn't block LLM connection result
-        this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
-          LoggerProxy.logger.warn(
-            'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
-            error
-          );
-        });
 
         if (registerAndConnectResult) {
           if (isInitialJoinPhase) {
@@ -10485,8 +10470,11 @@ export default class Meeting extends StatelessWebexPlugin {
     // stopListeningForMeetingEvents() before /leave and /end so events
     // received mid-teardown do not trigger Locus syncs.
     // Token cleanup happens automatically when cleanupLLMConneciton destroys the channel.
+    // Preserve voiceaChannel because it's created in the constructor and should only
+    // be destroyed when the meeting object is destroyed (in MeetingUtil.cleanUp).
+    // On rejoin, switchLLMChannel() will rebind it to the new LLM channel.
 
-    await this.cleanupLLMConneciton({throwOnError: false});
+    await this.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: true});
   };
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -986,6 +986,16 @@ export default class Meeting extends StatelessWebexPlugin {
     // @ts-ignore
     this.webinar = new Webinar({meetingId: this.id}, {parent: this.webex});
     /**
+     * VoiceaChannel for transcription/captions. Created without llmChannel;
+     * switchLLMChannel() is called in updateLLMConnection() when LLM connects.
+     * @instance
+     * @type {VoiceaChannel}
+     * @public
+     * @memberof Meeting
+     */
+    // @ts-ignore - Fix type
+    this.voiceaChannel = this.webex.internal.voicea.createChannel();
+    /**
      * helper class for managing receive slots (for multistream media connections)
      */
     this.receiveSlotManager = new ReceiveSlotManager(
@@ -6670,8 +6680,7 @@ export default class Meeting extends StatelessWebexPlugin {
     this.llmChannel?.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
     this.llmChannel?.off('online', this.handleLLMOnline);
     this.breakouts?.unregisterLLMChannel();
-    this.voiceaChannel?.deregisterEvents();
-    this.voiceaChannel = undefined;
+    // voiceaChannel persists across LLM reconnects; switchLLMChannel() handles re-subscribing
     this.clearLLMHealthCheckTimer();
   }
 
@@ -6901,13 +6910,21 @@ export default class Meeting extends StatelessWebexPlugin {
         // Register breakouts channel
         this.breakouts.registerLLMChannel(this.llmChannel);
 
-        // Create VoiceaChannel for this meeting
-        // @ts-ignore - Fix type
-        this.voiceaChannel = this.webex.internal.voicea.createChannel(this.llmChannel);
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
         );
         this.startLLMHealthCheckTimer();
+
+        // Switch voiceaChannel to use the new LLM channel (preserves transcription state)
+        // Fire-and-forget: caption restoration shouldn't block LLM connection result
+        if (this.voiceaChannel) {
+          this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
+            LoggerProxy.logger.warn(
+              'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
+              error
+            );
+          });
+        }
 
         if (registerAndConnectResult) {
           if (isInitialJoinPhase) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3078,16 +3078,22 @@ export default class Meeting extends StatelessWebexPlugin {
               return;
             }
             this.startTranscription();
-          } else if (!transcribing && this.areVoiceaEventsSetup) {
-            Trigger.trigger(
-              this,
-              {
-                file: 'meeting/index',
-                function: 'setupLocusControlsListener',
-              },
-              EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION,
-              {caption, transcribing}
-            );
+          } else if (!transcribing) {
+            // Always clear pending flag when transcription turns off - prevents stale deferred
+            // starts if transcribing flipped false before LLM connected.
+            this._pendingTranscriptionStart = false;
+
+            if (this.areVoiceaEventsSetup) {
+              Trigger.trigger(
+                this,
+                {
+                  file: 'meeting/index',
+                  function: 'setupLocusControlsListener',
+                },
+                EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION,
+                {caption, transcribing}
+              );
+            }
           }
         }
       }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -739,9 +739,6 @@ export default class Meeting extends StatelessWebexPlugin {
   turnDiscoverySkippedReason: TurnDiscoverySkipReason;
   turnServerUsed: boolean;
   areVoiceaEventsSetup = false;
-  // Tracks if transcription should start once LLM connects (deferred from CONTROLS_MEETING_TRANSCRIBE_UPDATED)
-  private _pendingTranscriptionStart = false;
-
   /**
    * Returns the initial transcription object shape.
    * Used by constructor and reset paths to ensure consistent initialization.
@@ -3070,19 +3067,10 @@ export default class Meeting extends StatelessWebexPlugin {
         if (this.isJoined()) {
           // @ts-ignore - config coming from registerPlugin
           if (transcribing && !this.areVoiceaEventsSetup) {
-            // Defer transcription start if LLM not yet connected - voiceaChannel exists from
-            // constructor but can't make HTTP requests until switchLLMChannel binds an LLM.
-            if (!this.voiceaChannel?.isLLMConnected()) {
-              this._pendingTranscriptionStart = true;
-
-              return;
+            if (this.voiceaChannel?.isLLMConnected()) {
+              this.startTranscription();
             }
-            this.startTranscription();
           } else if (!transcribing) {
-            // Always clear pending flag when transcription turns off - prevents stale deferred
-            // starts if transcribing flipped false before LLM connected.
-            this._pendingTranscriptionStart = false;
-
             if (this.areVoiceaEventsSetup) {
               Trigger.trigger(
                 this,
@@ -6204,6 +6192,21 @@ export default class Meeting extends StatelessWebexPlugin {
     }
   }
 
+  /**
+   * Starts transcription when requested by the current Locus controls and an
+   * active LLM channel is ready.
+   * @returns {void}
+   */
+  public startTranscriptionIfNeeded(): void {
+    if (
+      this.locusInfo.controls?.transcribe?.transcribing &&
+      !this.areVoiceaEventsSetup &&
+      this.voiceaChannel?.isLLMConnected()
+    ) {
+      this.startTranscription();
+    }
+  }
+
   /** Handles Locus LLM events
    *
    * @param {LocusLLMEvent} event - The Locus LLM event to process
@@ -6343,7 +6346,6 @@ export default class Meeting extends StatelessWebexPlugin {
     this.voiceaChannel?.deregisterEvents();
 
     this.areVoiceaEventsSetup = false;
-    this._pendingTranscriptionStart = false;
     this.triggerStopReceivingTranscriptionEvent();
   }
 
@@ -6960,23 +6962,26 @@ export default class Meeting extends StatelessWebexPlugin {
         const isPracticeSessionActive =
           this.webinar?.isPracticeSessionLLMChannelConnected() ?? false;
 
-        if (this.voiceaChannel && !isPracticeSessionActive) {
+        if (!this.voiceaChannel) {
+          // @ts-ignore - Fix type
+          this.voiceaChannel = this.webex.internal.voicea.createChannel();
+        }
+
+        if (!isPracticeSessionActive) {
           // Fire-and-forget: caption restoration shouldn't block LLM connection result.
           // transcription is always initialized (reset to initial shape, never null),
           // so no re-init needed here.
-          this.voiceaChannel.switchLLMChannel(this.llmChannel).catch((error) => {
-            LoggerProxy.logger.warn(
-              'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
-              error
-            );
-          });
-
-          // Start transcription if it was deferred while waiting for LLM to connect.
-          // This handles the race where CONTROLS_MEETING_TRANSCRIBE_UPDATED arrived before LLM was ready.
-          if (this._pendingTranscriptionStart && !this.areVoiceaEventsSetup) {
-            this._pendingTranscriptionStart = false;
-            this.startTranscription();
-          }
+          this.voiceaChannel
+            .switchLLMChannel(this.llmChannel)
+            .then(() => {
+              this.startTranscriptionIfNeeded();
+            })
+            .catch((error) => {
+              LoggerProxy.logger.warn(
+                'Meeting:index#updateLLMConnection --> failed to switch voicea channel:',
+                error
+              );
+            });
         }
 
         if (registerAndConnectResult) {
@@ -10506,11 +10511,10 @@ export default class Meeting extends StatelessWebexPlugin {
     // stopListeningForMeetingEvents() before /leave and /end so events
     // received mid-teardown do not trigger Locus syncs.
     // Token cleanup happens automatically when cleanupLLMConneciton destroys the channel.
-    // Preserve voiceaChannel because it's created in the constructor and should only
-    // be destroyed when the meeting object is destroyed (in MeetingUtil.cleanUp).
-    // On rejoin, switchLLMChannel() will rebind it to the new LLM channel.
+    // A new voiceaChannel is created on the next join. In-session LLM reconnects and
+    // practice-session transitions use their own cleanup paths and preserve the channel.
 
-    await this.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: true});
+    await this.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: false});
   };
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6195,6 +6195,7 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Starts transcription when requested by the current Locus controls and an
    * active LLM channel is ready.
+   * @internal
    * @returns {void}
    */
   public startTranscriptionIfNeeded(): void {

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -396,7 +396,7 @@ const MeetingUtil = {
       .then(() => meeting.stopKeepAlive())
       .then(() => {
         if (meeting.config?.enableAutomaticLLM) {
-          return meeting.cleanupLLMConneciton({throwOnError: false});
+          return meeting.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: true});
         }
 
         return undefined;

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -365,7 +365,7 @@ const MeetingUtil = {
       });
   },
 
-  cleanUp: (meeting) => {
+  cleanUp: (meeting, {preserveVoiceaChannel = true}: {preserveVoiceaChannel?: boolean} = {}) => {
     meeting.getWebexObject().internal.device.meetingEnded();
     meeting.stopPeriodicLogUpload();
 
@@ -396,7 +396,7 @@ const MeetingUtil = {
       .then(() => meeting.stopKeepAlive())
       .then(() => {
         if (meeting.config?.enableAutomaticLLM) {
-          return meeting.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: true});
+          return meeting.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel});
         }
 
         return undefined;

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1485,7 +1485,7 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   private destroy(meeting: Meeting, reason: object) {
-    MeetingUtil.cleanUp(meeting);
+    MeetingUtil.cleanUp(meeting, {preserveVoiceaChannel: false});
     // keep some basic info about the deleted meeting forever
     this.deletedMeetings.set(meeting.id, {
       id: meeting.id,

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -226,15 +226,16 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    // Track whether we switched voicea before disconnecting.
-    // If we skip the switch now (main not connected), we must recheck after disconnect.
+    // Track which main channel we switched voicea to before disconnecting.
+    // If main channel changes during disconnect (concurrent updateLLMConnection),
+    // we need to switch again even if we already switched once.
     const meeting = this.getValidatedWebinarMeeting();
-    let switchedVoiceaBeforeDisconnect = false;
+    let switchedToChannel: LLMChannel | undefined;
 
     // Switch voicea back to main meeting LLM channel before disconnecting PS channel.
-    // Only switch if the main channel is actually connected - if it's reconnecting
-    // (due to concurrent updateLLMConnection), we'll recheck after disconnect completes.
-    if (meeting?.voiceaChannel && meeting?.llmChannel?.isConnected()) {
+    // switchLLMChannel handles the case where the channel is still connecting by
+    // deferring caption restoration until the 'online' event fires.
+    if (meeting?.voiceaChannel && meeting?.llmChannel) {
       // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
       if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
         meeting.transcription = {
@@ -249,8 +250,8 @@ const Webinar = WebexPlugin.extend({
           speakerProxy: {},
         };
       }
+      switchedToChannel = meeting.llmChannel;
       await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
-      switchedVoiceaBeforeDisconnect = true;
     }
 
     if (!this._practiceSessionLLMChannel) {
@@ -282,15 +283,17 @@ const Webinar = WebexPlugin.extend({
       }
       this._practiceSessionLLMChannel = undefined;
 
-      // Recheck: if we skipped the voicea switch earlier (main wasn't connected),
-      // but main is now connected (reconnect completed during our disconnect wait),
-      // switch voicea now. This prevents voicea from being orphaned on the disconnected
-      // practice channel when updateLLMConnection saw practice as still active and skipped its switch.
-      if (
-        !switchedVoiceaBeforeDisconnect &&
-        meeting?.voiceaChannel &&
-        meeting?.llmChannel?.isConnected()
-      ) {
+      // Always recheck the current main channel after disconnect completes.
+      // Even if we switched voicea earlier, the main channel may have been replaced
+      // by a concurrent updateLLMConnection during our disconnect wait. In that case,
+      // updateLLMConnection skipped its voicea switch (saw practice still active),
+      // so we must switch to the new channel now. We don't require the channel to be
+      // connected — switchLLMChannel defers caption restoration if still connecting.
+      const currentMainChannel = meeting?.llmChannel;
+      const needsSwitch =
+        meeting?.voiceaChannel && currentMainChannel && currentMainChannel !== switchedToChannel;
+
+      if (needsSwitch) {
         // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
         if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
           meeting.transcription = {
@@ -305,7 +308,7 @@ const Webinar = WebexPlugin.extend({
             speakerProxy: {},
           };
         }
-        await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+        await meeting.voiceaChannel.switchLLMChannel(currentMainChannel);
       }
     }
   },

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -235,6 +235,20 @@ const Webinar = WebexPlugin.extend({
     // Only switch if the main channel is actually connected - if it's reconnecting
     // (due to concurrent updateLLMConnection), we'll recheck after disconnect completes.
     if (meeting?.voiceaChannel && meeting?.llmChannel?.isConnected()) {
+      // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
+      if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
+        meeting.transcription = {
+          captions: [],
+          isListening: false,
+          commandText: '',
+          languageOptions: {currentSpokenLanguage: 'en'},
+          showCaptionBox: false,
+          transcribingRequestStatus: 'INACTIVE',
+          isCaptioning: false,
+          interimCaptions: {},
+          speakerProxy: {},
+        };
+      }
       await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
       switchedVoiceaBeforeDisconnect = true;
     }
@@ -277,6 +291,20 @@ const Webinar = WebexPlugin.extend({
         meeting?.voiceaChannel &&
         meeting?.llmChannel?.isConnected()
       ) {
+        // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
+        if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
+          meeting.transcription = {
+            captions: [],
+            isListening: false,
+            commandText: '',
+            languageOptions: {currentSpokenLanguage: 'en'},
+            showCaptionBox: false,
+            transcribingRequestStatus: 'INACTIVE',
+            isCaptioning: false,
+            interimCaptions: {},
+            speakerProxy: {},
+          };
+        }
         await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
       }
     }
@@ -464,6 +492,21 @@ const Webinar = WebexPlugin.extend({
         // Switch meeting's voicea channel to use the PS LLM connection
         // This preserves caption state and re-announces automatically
         if (meeting.voiceaChannel) {
+          // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
+          // switchLLMChannel() will restore captions if active, and callbacks need transcription.
+          if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
+            meeting.transcription = {
+              captions: [],
+              isListening: false,
+              commandText: '',
+              languageOptions: {currentSpokenLanguage: 'en'},
+              showCaptionBox: false,
+              transcribingRequestStatus: 'INACTIVE',
+              isCaptioning: false,
+              interimCaptions: {},
+              speakerProxy: {},
+            };
+          }
           await meeting.voiceaChannel.switchLLMChannel(psChannel);
         }
 

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -226,13 +226,17 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
+    // Track whether we switched voicea before disconnecting.
+    // If we skip the switch now (main not connected), we must recheck after disconnect.
+    const meeting = this.getValidatedWebinarMeeting();
+    let switchedVoiceaBeforeDisconnect = false;
+
     // Switch voicea back to main meeting LLM channel before disconnecting PS channel.
     // Only switch if the main channel is actually connected - if it's reconnecting
-    // (due to concurrent updateLLMConnection), skip the switch here and let
-    // updateLLMConnection handle voicea restoration when it completes.
-    const meeting = this.getValidatedWebinarMeeting();
+    // (due to concurrent updateLLMConnection), we'll recheck after disconnect completes.
     if (meeting?.voiceaChannel && meeting?.llmChannel?.isConnected()) {
       await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+      switchedVoiceaBeforeDisconnect = true;
     }
 
     if (!this._practiceSessionLLMChannel) {
@@ -263,6 +267,18 @@ const Webinar = WebexPlugin.extend({
         }
       }
       this._practiceSessionLLMChannel = undefined;
+
+      // Recheck: if we skipped the voicea switch earlier (main wasn't connected),
+      // but main is now connected (reconnect completed during our disconnect wait),
+      // switch voicea now. This prevents voicea from being orphaned on the disconnected
+      // practice channel when updateLLMConnection saw practice as still active and skipped its switch.
+      if (
+        !switchedVoiceaBeforeDisconnect &&
+        meeting?.voiceaChannel &&
+        meeting?.llmChannel?.isConnected()
+      ) {
+        await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+      }
     }
   },
 

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -226,35 +226,14 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    // Track which main channel we switched voicea to before disconnecting.
-    // If main channel changes during disconnect (concurrent updateLLMConnection),
-    // we need to switch again even if we already switched once.
     const meeting = this.getValidatedWebinarMeeting();
-    let switchedToChannel: LLMChannel | undefined;
-
-    // Switch voicea back to main meeting LLM channel before disconnecting PS channel.
-    // switchLLMChannel handles the case where the channel is still connecting by
-    // deferring caption restoration until the 'online' event fires.
-    if (meeting?.voiceaChannel && meeting?.llmChannel) {
-      // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
-      if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
-        meeting.transcription = {
-          captions: [],
-          isListening: false,
-          commandText: '',
-          languageOptions: {currentSpokenLanguage: 'en'},
-          showCaptionBox: false,
-          transcribingRequestStatus: 'INACTIVE',
-          isCaptioning: false,
-          interimCaptions: {},
-          speakerProxy: {},
-        };
-      }
-      switchedToChannel = meeting.llmChannel;
-      await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
-    }
 
     if (!this._practiceSessionLLMChannel) {
+      // Even without PS channel, ensure voicea is bound to main channel
+      if (meeting?.voiceaChannel && meeting?.llmChannel) {
+        await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+      }
+
       return;
     }
 
@@ -283,32 +262,14 @@ const Webinar = WebexPlugin.extend({
       }
       this._practiceSessionLLMChannel = undefined;
 
-      // Always recheck the current main channel after disconnect completes.
-      // Even if we switched voicea earlier, the main channel may have been replaced
-      // by a concurrent updateLLMConnection during our disconnect wait. In that case,
-      // updateLLMConnection skipped its voicea switch (saw practice still active),
-      // so we must switch to the new channel now. We don't require the channel to be
-      // connected — switchLLMChannel defers caption restoration if still connecting.
-      const currentMainChannel = meeting?.llmChannel;
-      const needsSwitch =
-        meeting?.voiceaChannel && currentMainChannel && currentMainChannel !== switchedToChannel;
-
-      if (needsSwitch) {
-        // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
-        if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
-          meeting.transcription = {
-            captions: [],
-            isListening: false,
-            commandText: '',
-            languageOptions: {currentSpokenLanguage: 'en'},
-            showCaptionBox: false,
-            transcribingRequestStatus: 'INACTIVE',
-            isCaptioning: false,
-            interimCaptions: {},
-            speakerProxy: {},
-          };
-        }
-        await meeting.voiceaChannel.switchLLMChannel(currentMainChannel);
+      // Switch voicea to current main channel. The reconciler pattern in switchLLMChannel
+      // handles all timing concerns:
+      // - If main channel was replaced during disconnect (concurrent updateLLMConnection),
+      //   meeting.llmChannel will be the new channel, and reconciler binds to it
+      // - If channel is still connecting, reconciler defers caption restoration until 'online'
+      // - If same channel, reconciler is a no-op for rebind but still reconciles captions
+      if (meeting?.voiceaChannel && meeting?.llmChannel) {
+        await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
       }
     }
   },
@@ -492,24 +453,10 @@ const Webinar = WebexPlugin.extend({
         // Switch annotation to practice session channel
         meeting.annotation.registerChannel(psChannel);
 
-        // Switch meeting's voicea channel to use the PS LLM connection
-        // This preserves caption state and re-announces automatically
+        // Switch meeting's voicea channel to use the PS LLM connection.
+        // The reconciler pattern preserves caption state and handles all timing.
+        // transcription is always initialized (reset to initial shape, never null).
         if (meeting.voiceaChannel) {
-          // Reinitialize transcription if it was cleared but voiceaChannel was preserved.
-          // switchLLMChannel() will restore captions if active, and callbacks need transcription.
-          if (!meeting.transcription && meeting.voiceaChannel.getKeepTranscriptionSubscribed()) {
-            meeting.transcription = {
-              captions: [],
-              isListening: false,
-              commandText: '',
-              languageOptions: {currentSpokenLanguage: 'en'},
-              showCaptionBox: false,
-              transcribingRequestStatus: 'INACTIVE',
-              isCaptioning: false,
-              interimCaptions: {},
-              speakerProxy: {},
-            };
-          }
           await meeting.voiceaChannel.switchLLMChannel(psChannel);
         }
 

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -226,9 +226,12 @@ const Webinar = WebexPlugin.extend({
       this._pendingOnlineListener = null;
     }
 
-    // Switch voicea back to main meeting LLM channel before disconnecting PS channel
+    // Switch voicea back to main meeting LLM channel before disconnecting PS channel.
+    // Only switch if the main channel is actually connected - if it's reconnecting
+    // (due to concurrent updateLLMConnection), skip the switch here and let
+    // updateLLMConnection handle voicea restoration when it completes.
     const meeting = this.getValidatedWebinarMeeting();
-    if (meeting?.voiceaChannel && meeting?.llmChannel) {
+    if (meeting?.voiceaChannel && meeting?.llmChannel?.isConnected()) {
       await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
     }
 

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -232,6 +232,7 @@ const Webinar = WebexPlugin.extend({
       // Even without PS channel, ensure voicea is bound to main channel
       if (meeting?.voiceaChannel && meeting?.llmChannel) {
         await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+        meeting.startTranscriptionIfNeeded();
       }
 
       return;

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -262,14 +262,13 @@ const Webinar = WebexPlugin.extend({
       }
       this._practiceSessionLLMChannel = undefined;
 
-      // Switch voicea to current main channel. The reconciler pattern in switchLLMChannel
-      // handles all timing concerns:
+      // Switch voicea to current main channel. Switching after disconnect ensures:
       // - If main channel was replaced during disconnect (concurrent updateLLMConnection),
-      //   meeting.llmChannel will be the new channel, and reconciler binds to it
-      // - If channel is still connecting, reconciler defers caption restoration until 'online'
-      // - If same channel, reconciler is a no-op for rebind but still reconciles captions
+      //   meeting.llmChannel will be the new channel
+      // - If the channel is still connecting, switchLLMChannel waits for it to come online
       if (meeting?.voiceaChannel && meeting?.llmChannel) {
         await meeting.voiceaChannel.switchLLMChannel(meeting.llmChannel);
+        meeting.startTranscriptionIfNeeded();
       }
     }
   },
@@ -458,6 +457,7 @@ const Webinar = WebexPlugin.extend({
         // transcription is always initialized (reset to initial shape, never null).
         if (meeting.voiceaChannel) {
           await meeting.voiceaChannel.switchLLMChannel(psChannel);
+          meeting.startTranscriptionIfNeeded();
         }
 
         LoggerProxy.logger.info(

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15433,6 +15433,59 @@ describe('plugin-meetings', () => {
           assert.equal(result, 'something');
         });
 
+        it('starts pending transcription after LLM connects when _pendingTranscriptionStart is true', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting._pendingTranscriptionStart = true;
+          meeting.areVoiceaEventsSetup = false;
+          meeting.startTranscription = sinon.stub().resolves();
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          // Should call startTranscription for the pending request
+          assert.calledOnce(meeting.startTranscription);
+          // Should clear the pending flag
+          assert.equal(meeting._pendingTranscriptionStart, false);
+        });
+
+        it('does not start transcription when _pendingTranscriptionStart is false', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting._pendingTranscriptionStart = false;
+          meeting.areVoiceaEventsSetup = false;
+          meeting.startTranscription = sinon.stub().resolves();
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          // Should NOT call startTranscription
+          assert.notCalled(meeting.startTranscription);
+        });
+
+        it('does not start transcription when areVoiceaEventsSetup is already true', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting._pendingTranscriptionStart = true;
+          meeting.areVoiceaEventsSetup = true;
+          meeting.startTranscription = sinon.stub().resolves();
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          // Should NOT call startTranscription (already setup)
+          assert.notCalled(meeting.startTranscription);
+        });
+
         it('registers annotation channel when not in practice session', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15082,6 +15082,7 @@ describe('plugin-meetings', () => {
             getIsCaptionBoxOn: sinon.stub().returns(false),
             updateSubchannelSubscriptions: sinon.stub(),
             switchLLMChannel: sinon.stub().resolves(),
+            getKeepTranscriptionSubscribed: sinon.stub().returns(false),
           };
 
           webex.internal.llm.createChannel = sinon.stub().returns(mockChannel);
@@ -15392,6 +15393,43 @@ describe('plugin-meetings', () => {
           await meeting.updateLLMConnection();
 
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
+        });
+
+        it('reinitializes transcription before switchLLMChannel when transcription is undefined and captions were active', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+          meeting.transcription = undefined;
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
+
+          await meeting.updateLLMConnection();
+
+          // Transcription should be reinitialized before switching
+          assert.isDefined(meeting.transcription);
+          assert.deepEqual(meeting.transcription.captions, []);
+          assert.equal(meeting.transcription.isCaptioning, false);
+          // And voicea should still be switched
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
+        });
+
+        it('does not reinitialize transcription when it already exists', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+          const existingTranscription = {captions: ['existing'], isCaptioning: true};
+          meeting.transcription = existingTranscription;
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
+
+          await meeting.updateLLMConnection();
+
+          // Transcription should remain unchanged
+          assert.strictEqual(meeting.transcription, existingTranscription);
         });
 
         it('skips switchLLMChannel when practice session is active', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15394,7 +15394,7 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
         });
 
-        it('does not call switchLLMChannel when voiceaChannel is undefined', async () => {
+        it('recreates voiceaChannel and calls switchLLMChannel when voiceaChannel is undefined', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.voiceaChannel = undefined;
           meeting.locusInfo = {
@@ -15403,8 +15403,14 @@ describe('plugin-meetings', () => {
             info: {datachannelUrl: 'a datachannel url'},
           };
 
-          // Should not throw
           await meeting.updateLLMConnection();
+
+          // voiceaChannel should be recreated via createChannel()
+          assert.calledOnce(webex.internal.voicea.createChannel);
+          // switchLLMChannel should be called on the newly created channel
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
+          // The meeting should now have the recreated voiceaChannel
+          assert.strictEqual(meeting.voiceaChannel, mockVoiceaChannel);
         });
 
         it('logs warning when switchLLMChannel fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15213,6 +15213,7 @@ describe('plugin-meetings', () => {
             off: sinon.stub(),
           };
           meeting.llmChannel = existingChannel;
+          const originalVoiceaChannel = meeting.voiceaChannel;
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -15233,6 +15234,9 @@ describe('plugin-meetings', () => {
             'a datachannel url',
             undefined
           );
+          // voiceaChannel should be preserved during transient reconnect
+          assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
+          assert.notCalled(mockVoiceaChannel.deregisterEvents);
         });
 
         it('disconnects and reconnects when datachannel URL changes', async () => {
@@ -15248,6 +15252,7 @@ describe('plugin-meetings', () => {
             off: sinon.stub(),
           };
           meeting.llmChannel = existingChannel;
+          const originalVoiceaChannel = meeting.voiceaChannel;
 
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -15268,6 +15273,9 @@ describe('plugin-meetings', () => {
             'a different datachannel url',
             undefined
           );
+          // voiceaChannel should be preserved during transient reconnect
+          assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
+          assert.notCalled(mockVoiceaChannel.deregisterEvents);
         });
 
         it('disconnects when state changes to not joined', async () => {
@@ -15519,6 +15527,75 @@ describe('plugin-meetings', () => {
             // Should not throw
             await meeting.clearMeetingData();
 
+            assert.called(meeting.clearLLMHealthCheckTimer);
+          });
+        });
+
+        describe('#cleanupLLMConneciton', () => {
+          let existingChannel;
+
+          beforeEach(() => {
+            existingChannel = {
+              isConnected: sinon.stub().returns(true),
+              disconnect: sinon.stub().resolves(),
+              off: sinon.stub(),
+            };
+            meeting.llmChannel = existingChannel;
+
+            meeting.annotation.deregisterEvents = sinon.stub();
+            meeting.clearLLMHealthCheckTimer = sinon.stub();
+          });
+
+          it('destroys voiceaChannel when preserveVoiceaChannel is false (default)', async () => {
+            await meeting.cleanupLLMConneciton();
+
+            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
+            assert.isUndefined(meeting.voiceaChannel);
+            assert.isUndefined(meeting.llmChannel);
+          });
+
+          it('destroys voiceaChannel when preserveVoiceaChannel is explicitly false', async () => {
+            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: false});
+
+            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
+            assert.isUndefined(meeting.voiceaChannel);
+            assert.isUndefined(meeting.llmChannel);
+          });
+
+          it('preserves voiceaChannel when preserveVoiceaChannel is true', async () => {
+            const originalVoiceaChannel = meeting.voiceaChannel;
+
+            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: true});
+
+            assert.notCalled(mockVoiceaChannel.deregisterEvents);
+            assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
+            assert.isUndefined(meeting.llmChannel);
+          });
+
+          it('passes throwOnError alongside preserveVoiceaChannel', async () => {
+            existingChannel.disconnect.rejects(new Error('disconnect failed'));
+
+            // Should not throw when throwOnError is false
+            await meeting.cleanupLLMConneciton({throwOnError: false, preserveVoiceaChannel: true});
+
+            assert.notCalled(mockVoiceaChannel.deregisterEvents);
+            assert.isDefined(meeting.voiceaChannel);
+          });
+
+          it('cleans up LLM event listeners regardless of preserveVoiceaChannel', async () => {
+            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: true});
+
+            assert.calledWithExactly(existingChannel.off, 'online', meeting.handleLLMOnline);
+            assert.calledWithExactly(
+              existingChannel.off,
+              'event:relay.event',
+              meeting.processRelayEvent
+            );
+            assert.calledWithExactly(
+              existingChannel.off,
+              'event:locus.state_message',
+              meeting.processLocusLLMEvent
+            );
             assert.called(meeting.clearLLMHealthCheckTimer);
           });
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15394,10 +15394,9 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
         });
 
-        it('recreates voiceaChannel and transcription when both are undefined after leave+rejoin', async () => {
+        it('skips switchLLMChannel when practice session is active', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          meeting.voiceaChannel = undefined;
-          meeting.transcription = undefined; // Cleared by stopListeningForMeetingEvents during leave
+          meeting.webinar.isPracticeSessionLLMChannelConnected = sinon.stub().returns(true);
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
@@ -15406,17 +15405,9 @@ describe('plugin-meetings', () => {
 
           await meeting.updateLLMConnection();
 
-          // voiceaChannel should be recreated via createChannel()
-          assert.calledOnce(webex.internal.voicea.createChannel);
-          // switchLLMChannel should be called on the newly created channel
-          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
-          // The meeting should now have the recreated voiceaChannel
-          assert.strictEqual(meeting.voiceaChannel, mockVoiceaChannel);
-          // transcription state should be reinitialized (so voiceaListenerCallbacks don't throw)
-          assert.isDefined(meeting.transcription);
-          assert.deepEqual(meeting.transcription.captions, []);
-          assert.strictEqual(meeting.transcription.isListening, false);
-          assert.strictEqual(meeting.transcription.isCaptioning, false);
+          // switchLLMChannel should NOT be called when practice session is active
+          // because practice session manages its own voicea binding
+          assert.notCalled(mockVoiceaChannel.switchLLMChannel);
         });
 
         it('logs warning when switchLLMChannel fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8217,6 +8217,7 @@ describe('plugin-meetings', () => {
         it('stops listening for LLM/Mercury and tears down transcription and annotation before calling Locus /leave', async () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
+          meeting.areVoiceaEventsSetup = true;
 
           // Set up llmChannel with mock off function
           meeting.llmChannel = {
@@ -8253,12 +8254,16 @@ describe('plugin-meetings', () => {
           assert.isUndefined(meeting.mercuryOfflineHandler);
           assert.calledOnceWithExactly(meeting.stopTranscription);
           assert.calledOnceWithExactly(meeting.annotation.deregisterEvents);
-          assert.isUndefined(meeting.transcription);
+          // Transcription is reset to initial state (not undefined)
+          assert.isDefined(meeting.transcription);
+          assert.deepEqual(meeting.transcription.captions, []);
+          assert.equal(meeting.transcription.isCaptioning, false);
         });
 
         it('tears down llm/mercury/transcription/annotation even when /leave rejects', async () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
+          meeting.areVoiceaEventsSetup = true;
           meeting.meetingRequest.leaveMeeting = sinon
             .stub()
             .returns(Promise.reject(new Error('leave failed')));
@@ -10371,6 +10376,7 @@ describe('plugin-meetings', () => {
         it('stops listening for LLM/Mercury and tears down transcription and annotation before calling Locus /end', async () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
+          meeting.areVoiceaEventsSetup = true;
 
           // Set up llmChannel with mock off function
           meeting.llmChannel = {
@@ -10412,6 +10418,7 @@ describe('plugin-meetings', () => {
         it('tears down llm/mercury/transcription/annotation even when /end rejects', async () => {
           const onlineHandler = meeting.mercuryOnlineHandler;
           const offlineHandler = meeting.mercuryOfflineHandler;
+          meeting.areVoiceaEventsSetup = true;
           meeting.meetingRequest.endMeetingForAll = sinon
             .stub()
             .returns(Promise.reject(new Error('end failed')));
@@ -15393,43 +15400,6 @@ describe('plugin-meetings', () => {
           await meeting.updateLLMConnection();
 
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
-        });
-
-        it('reinitializes transcription before switchLLMChannel when transcription is undefined and captions were active', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
-          meeting.transcription = undefined;
-          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
-
-          await meeting.updateLLMConnection();
-
-          // Transcription should be reinitialized before switching
-          assert.isDefined(meeting.transcription);
-          assert.deepEqual(meeting.transcription.captions, []);
-          assert.equal(meeting.transcription.isCaptioning, false);
-          // And voicea should still be switched
-          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
-        });
-
-        it('does not reinitialize transcription when it already exists', async () => {
-          meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {
-            syncAllHashTreeDatasets: sinon.stub().resolves(),
-            url: 'a url',
-            info: {datachannelUrl: 'a datachannel url'},
-          };
-          const existingTranscription = {captions: ['existing'], isCaptioning: true};
-          meeting.transcription = existingTranscription;
-          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
-
-          await meeting.updateLLMConnection();
-
-          // Transcription should remain unchanged
-          assert.strictEqual(meeting.transcription, existingTranscription);
         });
 
         it('skips switchLLMChannel when practice session is active', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15394,9 +15394,10 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
         });
 
-        it('recreates voiceaChannel and calls switchLLMChannel when voiceaChannel is undefined', async () => {
+        it('recreates voiceaChannel and transcription when both are undefined after leave+rejoin', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.voiceaChannel = undefined;
+          meeting.transcription = undefined; // Cleared by stopListeningForMeetingEvents during leave
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
@@ -15411,6 +15412,11 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
           // The meeting should now have the recreated voiceaChannel
           assert.strictEqual(meeting.voiceaChannel, mockVoiceaChannel);
+          // transcription state should be reinitialized (so voiceaListenerCallbacks don't throw)
+          assert.isDefined(meeting.transcription);
+          assert.deepEqual(meeting.transcription.captions, []);
+          assert.strictEqual(meeting.transcription.isListening, false);
+          assert.strictEqual(meeting.transcription.isCaptioning, false);
         });
 
         it('logs warning when switchLLMChannel fails', async () => {
@@ -15603,6 +15609,31 @@ describe('plugin-meetings', () => {
               meeting.processLocusLLMEvent
             );
             assert.called(meeting.clearLLMHealthCheckTimer);
+          });
+
+          it('cleans up voiceaChannel even when llmChannel is undefined (failed transient reconnect scenario)', async () => {
+            // Simulate failed transient reconnect: llmChannel is undefined but voiceaChannel exists
+            meeting.llmChannel = undefined;
+            const originalVoiceaChannel = meeting.voiceaChannel;
+
+            assert.isDefined(originalVoiceaChannel);
+
+            // Permanent cleanup should still deregister voiceaChannel
+            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: false});
+
+            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
+            assert.isUndefined(meeting.voiceaChannel);
+          });
+
+          it('preserves voiceaChannel when llmChannel is undefined and preserveVoiceaChannel is true', async () => {
+            // Another transient reconnect scenario
+            meeting.llmChannel = undefined;
+            const originalVoiceaChannel = meeting.voiceaChannel;
+
+            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: true});
+
+            assert.notCalled(mockVoiceaChannel.deregisterEvents);
+            assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15389,7 +15389,7 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.startLLMHealthCheckTimer);
         });
 
-        it('calls switchLLMChannel on voiceaChannel after successful connection', async () => {
+        it('reuses voiceaChannel after successful connection', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
@@ -15399,6 +15399,8 @@ describe('plugin-meetings', () => {
 
           await meeting.updateLLMConnection();
 
+          assert.notCalled(webex.internal.voicea.createChannel);
+          assert.strictEqual(meeting.voiceaChannel, mockVoiceaChannel);
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15549,31 +15549,62 @@ describe('plugin-meetings', () => {
             meeting.clearLLMHealthCheckTimer = sinon.stub();
           });
 
-          it('destroys voiceaChannel when preserveVoiceaChannel is false (default)', async () => {
-            await meeting.cleanupLLMConneciton();
+          forEach(
+            [
+              {
+                description: 'destroys voiceaChannel when preserveVoiceaChannel is false (default)',
+                llmChannelDefined: true,
+                options: undefined,
+                expectedVoiceaPreserved: false,
+              },
+              {
+                description:
+                  'destroys voiceaChannel when preserveVoiceaChannel is explicitly false',
+                llmChannelDefined: true,
+                options: {preserveVoiceaChannel: false},
+                expectedVoiceaPreserved: false,
+              },
+              {
+                description: 'preserves voiceaChannel when preserveVoiceaChannel is true',
+                llmChannelDefined: true,
+                options: {preserveVoiceaChannel: true},
+                expectedVoiceaPreserved: true,
+              },
+              {
+                description:
+                  'cleans up voiceaChannel even when llmChannel is undefined (failed transient reconnect)',
+                llmChannelDefined: false,
+                options: {preserveVoiceaChannel: false},
+                expectedVoiceaPreserved: false,
+              },
+              {
+                description:
+                  'preserves voiceaChannel when llmChannel is undefined and preserveVoiceaChannel is true',
+                llmChannelDefined: false,
+                options: {preserveVoiceaChannel: true},
+                expectedVoiceaPreserved: true,
+              },
+            ],
+            ({description, llmChannelDefined, options, expectedVoiceaPreserved}) => {
+              it(description, async () => {
+                if (!llmChannelDefined) {
+                  meeting.llmChannel = undefined;
+                }
+                const originalVoiceaChannel = meeting.voiceaChannel;
 
-            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
-            assert.isUndefined(meeting.voiceaChannel);
-            assert.isUndefined(meeting.llmChannel);
-          });
+                await meeting.cleanupLLMConneciton(options);
 
-          it('destroys voiceaChannel when preserveVoiceaChannel is explicitly false', async () => {
-            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: false});
-
-            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
-            assert.isUndefined(meeting.voiceaChannel);
-            assert.isUndefined(meeting.llmChannel);
-          });
-
-          it('preserves voiceaChannel when preserveVoiceaChannel is true', async () => {
-            const originalVoiceaChannel = meeting.voiceaChannel;
-
-            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: true});
-
-            assert.notCalled(mockVoiceaChannel.deregisterEvents);
-            assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
-            assert.isUndefined(meeting.llmChannel);
-          });
+                if (expectedVoiceaPreserved) {
+                  assert.notCalled(mockVoiceaChannel.deregisterEvents);
+                  assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
+                } else {
+                  assert.calledOnce(mockVoiceaChannel.deregisterEvents);
+                  assert.isUndefined(meeting.voiceaChannel);
+                }
+                assert.isUndefined(meeting.llmChannel);
+              });
+            }
+          );
 
           it('passes throwOnError alongside preserveVoiceaChannel', async () => {
             existingChannel.disconnect.rejects(new Error('disconnect failed'));
@@ -15600,31 +15631,6 @@ describe('plugin-meetings', () => {
               meeting.processLocusLLMEvent
             );
             assert.called(meeting.clearLLMHealthCheckTimer);
-          });
-
-          it('cleans up voiceaChannel even when llmChannel is undefined (failed transient reconnect scenario)', async () => {
-            // Simulate failed transient reconnect: llmChannel is undefined but voiceaChannel exists
-            meeting.llmChannel = undefined;
-            const originalVoiceaChannel = meeting.voiceaChannel;
-
-            assert.isDefined(originalVoiceaChannel);
-
-            // Permanent cleanup should still deregister voiceaChannel
-            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: false});
-
-            assert.calledOnce(mockVoiceaChannel.deregisterEvents);
-            assert.isUndefined(meeting.voiceaChannel);
-          });
-
-          it('preserves voiceaChannel when llmChannel is undefined and preserveVoiceaChannel is true', async () => {
-            // Another transient reconnect scenario
-            meeting.llmChannel = undefined;
-            const originalVoiceaChannel = meeting.voiceaChannel;
-
-            await meeting.cleanupLLMConneciton({preserveVoiceaChannel: true});
-
-            assert.notCalled(mockVoiceaChannel.deregisterEvents);
-            assert.strictEqual(meeting.voiceaChannel, originalVoiceaChannel);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -315,6 +315,7 @@ describe('plugin-meetings', () => {
       deregisterEvents: sinon.stub(),
       getIsCaptionBoxOn: sinon.stub().returns(false),
       updateSubchannelSubscriptions: sinon.stub(),
+      switchLLMChannel: sinon.stub().resolves(),
     }));
     webex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
       {},
@@ -573,6 +574,11 @@ describe('plugin-meetings', () => {
           localWebex.internal.llm.isDataChannelTokenEnabled = sinon.stub().resolves(false);
           localWebex.internal.llm.on = sinon.stub();
           localWebex.internal.voicea.announce = sinon.stub();
+          localWebex.internal.voicea.createChannel = sinon.stub().returns({
+            on: sinon.stub(),
+            off: sinon.stub(),
+            switchLLMChannel: sinon.stub().resolves(),
+          });
           localWebex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
             {},
             {parent: localWebex}
@@ -15075,10 +15081,14 @@ describe('plugin-meetings', () => {
             deregisterEvents: sinon.stub(),
             getIsCaptionBoxOn: sinon.stub().returns(false),
             updateSubchannelSubscriptions: sinon.stub(),
+            switchLLMChannel: sinon.stub().resolves(),
           };
 
           webex.internal.llm.createChannel = sinon.stub().returns(mockChannel);
           webex.internal.voicea.createChannel = sinon.stub().returns(mockVoiceaChannel);
+
+          // voiceaChannel is created in the Meeting constructor
+          meeting.voiceaChannel = mockVoiceaChannel;
 
           meeting.processRelayEvent = sinon.stub();
           meeting.processLocusLLMEvent = sinon.stub();
@@ -15361,6 +15371,47 @@ describe('plugin-meetings', () => {
           await meeting.updateLLMConnection();
 
           assert.calledOnce(meeting.startLLMHealthCheckTimer);
+        });
+
+        it('calls switchLLMChannel on voiceaChannel after successful connection', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
+        });
+
+        it('does not call switchLLMChannel when voiceaChannel is undefined', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.voiceaChannel = undefined;
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          // Should not throw
+          await meeting.updateLLMConnection();
+        });
+
+        it('logs warning when switchLLMChannel fails', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          mockVoiceaChannel.switchLLMChannel.rejects(new Error('switch failed'));
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          // Should not throw - fire-and-forget behavior
+          const result = await meeting.updateLLMConnection();
+
+          assert.equal(result, 'something');
         });
 
         it('registers annotation channel when not in practice session', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -15089,6 +15089,7 @@ describe('plugin-meetings', () => {
             getIsCaptionBoxOn: sinon.stub().returns(false),
             updateSubchannelSubscriptions: sinon.stub(),
             switchLLMChannel: sinon.stub().resolves(),
+            isLLMConnected: sinon.stub().returns(true),
             getKeepTranscriptionSubscribed: sinon.stub().returns(false),
           };
 
@@ -15404,6 +15405,22 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
         });
 
+        it('creates and binds a voiceaChannel after the previous channel was cleaned up', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          meeting.voiceaChannel = undefined;
+          meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
+            url: 'a url',
+            info: {datachannelUrl: 'a datachannel url'},
+          };
+
+          await meeting.updateLLMConnection();
+
+          assert.calledOnceWithExactly(webex.internal.voicea.createChannel);
+          assert.strictEqual(meeting.voiceaChannel, mockVoiceaChannel);
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockChannel);
+        });
+
         it('skips switchLLMChannel when practice session is active', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.webinar.isPracticeSessionLLMChannelConnected = sinon.stub().returns(true);
@@ -15435,58 +15452,79 @@ describe('plugin-meetings', () => {
           assert.equal(result, 'something');
         });
 
-        it('starts pending transcription after LLM connects when _pendingTranscriptionStart is true', async () => {
+        it('starts transcription after LLM connects when Locus transcription is active', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          meeting._pendingTranscriptionStart = true;
           meeting.areVoiceaEventsSetup = false;
           meeting.startTranscription = sinon.stub().resolves();
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
+            controls: {transcribe: {transcribing: true}},
           };
 
           await meeting.updateLLMConnection();
+          await mockVoiceaChannel.switchLLMChannel.firstCall.returnValue;
 
-          // Should call startTranscription for the pending request
           assert.calledOnce(meeting.startTranscription);
-          // Should clear the pending flag
-          assert.equal(meeting._pendingTranscriptionStart, false);
         });
 
-        it('does not start transcription when _pendingTranscriptionStart is false', async () => {
+        it('does not start transcription after LLM connects when Locus transcription is inactive', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          meeting._pendingTranscriptionStart = false;
           meeting.areVoiceaEventsSetup = false;
           meeting.startTranscription = sinon.stub().resolves();
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
+            controls: {transcribe: {transcribing: false}},
           };
 
           await meeting.updateLLMConnection();
 
-          // Should NOT call startTranscription
           assert.notCalled(meeting.startTranscription);
         });
 
         it('does not start transcription when areVoiceaEventsSetup is already true', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          meeting._pendingTranscriptionStart = true;
           meeting.areVoiceaEventsSetup = true;
           meeting.startTranscription = sinon.stub().resolves();
           meeting.locusInfo = {
             syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
+            controls: {transcribe: {transcribing: true}},
           };
 
           await meeting.updateLLMConnection();
 
-          // Should NOT call startTranscription (already setup)
           assert.notCalled(meeting.startTranscription);
         });
+
+        forEach(
+          [
+            {
+              description: 'does not start transcription when voiceaChannel is disconnected',
+              voiceaChannel: {isLLMConnected: sinon.stub().returns(false)},
+            },
+            {
+              description: 'does not start transcription when voiceaChannel is unavailable',
+              voiceaChannel: undefined,
+            },
+          ],
+          ({description, voiceaChannel}) => {
+            it(description, () => {
+              meeting.areVoiceaEventsSetup = false;
+              meeting.locusInfo = {controls: {transcribe: {transcribing: true}}};
+              meeting.startTranscription = sinon.stub().resolves();
+              meeting.voiceaChannel = voiceaChannel;
+
+              meeting.startTranscriptionIfNeeded();
+
+              assert.notCalled(meeting.startTranscription);
+            });
+          }
+        );
 
         it('registers annotation channel when not in practice session', async () => {
           meeting.joinedWith = {state: 'JOINED'};

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -75,7 +75,7 @@ describe('plugin-meetings', () => {
     });
 
     describe('#cleanup', () => {
-      it('do clean up on meeting object with LLM enabled', async () => {
+      it('cleans up an LLM-enabled meeting while preserving Voicea by default', async () => {
         meeting.config = {enableAutomaticLLM: true};
         await MeetingUtil.cleanUp(meeting);
         assert.calledOnce(meeting.cleanupLocalStreams);
@@ -87,7 +87,10 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.unsetPeerConnections);
         assert.calledOnce(meeting.reconnectionManager.cleanUp);
         assert.calledOnce(meeting.stopKeepAlive);
-        assert.calledOnceWithExactly(meeting.cleanupLLMConneciton, {throwOnError: false});
+        assert.calledOnceWithExactly(meeting.cleanupLLMConneciton, {
+          throwOnError: false,
+          preserveVoiceaChannel: true,
+        });
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
         assert.calledOnce(meeting.locusInfo.cleanUp);
@@ -96,6 +99,17 @@ describe('plugin-meetings', () => {
           meeting.webex.internal.newMetrics.callDiagnosticMetrics.clearEventLimitsForCorrelationId,
           meeting.correlationId
         );
+      });
+
+      it('cleans up an LLM-enabled meeting without preserving Voicea when requested', async () => {
+        meeting.config = {enableAutomaticLLM: true};
+
+        await MeetingUtil.cleanUp(meeting, {preserveVoiceaChannel: false});
+
+        assert.calledOnceWithExactly(meeting.cleanupLLMConneciton, {
+          throwOnError: false,
+          preserveVoiceaChannel: false,
+        });
       });
 
       it('do clean up on meeting object with LLM disabled', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -142,6 +142,7 @@ describe('plugin-meetings', () => {
 
       Object.assign(webex.internal, {
         llm: {on: sinon.stub()},
+        voicea: {createChannel: sinon.stub().returns({})},
         device: {
           deviceType: 'FAKE_DEVICE',
           register: sinon.stub().returns(Promise.resolve()),

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -240,6 +240,10 @@ describe('plugin-meetings', () => {
 
         webex.meetings.destroy(meeting, test1);
 
+        assert.calledOnceWithExactly(MeetingUtil.cleanUp, meeting, {
+          preserveVoiceaChannel: false,
+        });
+
         // and it should still return the information after the meeting is destroyed
         assert.equal(
           webex.meetings.getBasicMeetingInformation(meetingIds.meetingId).id,

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -438,6 +438,7 @@ describe('plugin-meetings', () => {
           webinar._practiceSessionLLMChannel = mockPSChannel;
           mockVoiceaChannel = {
             switchLLMChannel: sinon.stub().resolves(),
+            getKeepTranscriptionSubscribed: sinon.stub().returns(false),
           };
           meeting = {
             id: 'meeting-id',
@@ -449,6 +450,7 @@ describe('plugin-meetings', () => {
             voiceaChannel: mockVoiceaChannel,
             annotation: {registerChannel: sinon.stub()},
             trigger: sinon.stub(),
+            transcription: {captions: []},
           };
           webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
         });
@@ -566,6 +568,33 @@ describe('plugin-meetings', () => {
           // Should not throw - cleanup should continue without voicea switch
           assert.calledOnce(mockPSChannel.disconnect);
         });
+
+        it('reinitializes transcription before switching voicea when transcription is undefined and captions were active', async () => {
+          meeting.llmChannel.isConnected.returns(true);
+          meeting.transcription = undefined;
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
+
+          await webinar.cleanupPSDataChannel();
+
+          // Transcription should be reinitialized
+          assert.isDefined(meeting.transcription);
+          assert.deepEqual(meeting.transcription.captions, []);
+          assert.equal(meeting.transcription.isCaptioning, false);
+          // And voicea should still be switched
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+        });
+
+        it('does not reinitialize transcription when it already exists', async () => {
+          meeting.llmChannel.isConnected.returns(true);
+          const existingTranscription = {captions: ['existing'], isCaptioning: true};
+          meeting.transcription = existingTranscription;
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
+
+          await webinar.cleanupPSDataChannel();
+
+          // Transcription should remain unchanged
+          assert.strictEqual(meeting.transcription, existingTranscription);
+        });
       });
 
       describe('#updatePSDataChannel', () => {
@@ -586,6 +615,7 @@ describe('plugin-meetings', () => {
           });
           mockVoiceaChannel = {
             switchLLMChannel: sinon.stub().resolves(),
+            getKeepTranscriptionSubscribed: sinon.stub().returns(false),
           };
 
           // Default session channel on the meeting
@@ -615,6 +645,7 @@ describe('plugin-meetings', () => {
             }),
             voiceaListenerCallbacks: {},
             trigger: sinon.stub(),
+            transcription: {captions: []},
           };
 
           webex.meetings.getMeetingByType = sinon.stub().returns(meeting);
@@ -770,6 +801,20 @@ describe('plugin-meetings', () => {
         it('switches voicea channel to practice session LLM channel after connect', async () => {
           await webinar.updatePSDataChannel();
 
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
+        });
+
+        it('reinitializes transcription before switching voicea when transcription is undefined and captions were active', async () => {
+          meeting.transcription = undefined;
+          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
+
+          await webinar.updatePSDataChannel();
+
+          // Transcription should be reinitialized before switching
+          assert.isDefined(meeting.transcription);
+          assert.deepEqual(meeting.transcription.captions, []);
+          assert.equal(meeting.transcription.isCaptioning, false);
+          // And voicea should still be switched
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -546,11 +546,10 @@ describe('plugin-meetings', () => {
           assert.calledOnce(mockPSChannel.disconnect);
         });
 
-        it('switches voicea after disconnect when main channel was replaced during practice disconnect', async () => {
+        it('switches voicea to final main channel after disconnect when main channel was replaced during practice disconnect', async () => {
           // Main channel connected initially
           meeting.llmChannel.isConnected.returns(true);
 
-          const originalLLMChannel = meeting.llmChannel;
           const newLLMChannel = {
             isConnected: sinon.stub().returns(true),
             on: sinon.stub(),
@@ -564,10 +563,10 @@ describe('plugin-meetings', () => {
 
           await webinar.cleanupPSDataChannel();
 
-          // Should switch voicea twice: once before disconnect (to original), once after (to new)
-          assert.calledTwice(mockVoiceaChannel.switchLLMChannel);
-          assert.calledWith(mockVoiceaChannel.switchLLMChannel.firstCall, originalLLMChannel);
-          assert.calledWith(mockVoiceaChannel.switchLLMChannel.secondCall, newLLMChannel);
+          // With reconciler pattern: single switch point after disconnect picks up the new channel
+          // (reconciler handles the actual rebinding internally)
+          assert.calledOnce(mockVoiceaChannel.switchLLMChannel);
+          assert.calledWith(mockVoiceaChannel.switchLLMChannel, newLLMChannel);
         });
 
         it('does not switch voicea channel when meeting has no voiceaChannel', async () => {
@@ -577,33 +576,6 @@ describe('plugin-meetings', () => {
 
           // Should not throw - cleanup should continue without voicea switch
           assert.calledOnce(mockPSChannel.disconnect);
-        });
-
-        it('reinitializes transcription before switching voicea when transcription is undefined and captions were active', async () => {
-          meeting.llmChannel.isConnected.returns(true);
-          meeting.transcription = undefined;
-          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
-
-          await webinar.cleanupPSDataChannel();
-
-          // Transcription should be reinitialized
-          assert.isDefined(meeting.transcription);
-          assert.deepEqual(meeting.transcription.captions, []);
-          assert.equal(meeting.transcription.isCaptioning, false);
-          // And voicea should still be switched
-          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
-        });
-
-        it('does not reinitialize transcription when it already exists', async () => {
-          meeting.llmChannel.isConnected.returns(true);
-          const existingTranscription = {captions: ['existing'], isCaptioning: true};
-          meeting.transcription = existingTranscription;
-          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
-
-          await webinar.cleanupPSDataChannel();
-
-          // Transcription should remain unchanged
-          assert.strictEqual(meeting.transcription, existingTranscription);
         });
       });
 
@@ -811,20 +783,6 @@ describe('plugin-meetings', () => {
         it('switches voicea channel to practice session LLM channel after connect', async () => {
           await webinar.updatePSDataChannel();
 
-          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
-        });
-
-        it('reinitializes transcription before switching voicea when transcription is undefined and captions were active', async () => {
-          meeting.transcription = undefined;
-          mockVoiceaChannel.getKeepTranscriptionSubscribed.returns(true);
-
-          await webinar.updatePSDataChannel();
-
-          // Transcription should be reinitialized before switching
-          assert.isDefined(meeting.transcription);
-          assert.deepEqual(meeting.transcription.captions, []);
-          assert.equal(meeting.transcription.isCaptioning, false);
-          // And voicea should still be switched
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -534,30 +534,40 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
         });
 
-        it('skips voicea switch when main channel is not connected before or after disconnect', async () => {
+        it('switches voicea to main channel even when not connected (defers caption restoration)', async () => {
           meeting.llmChannel.isConnected.returns(false);
 
           await webinar.cleanupPSDataChannel();
 
-          // Should not call switchLLMChannel - main channel never became available
-          assert.notCalled(mockVoiceaChannel.switchLLMChannel);
-          // But should still disconnect the practice session channel
+          // Should still switch voicea to main channel - switchLLMChannel handles
+          // the deferred case by registering an 'online' listener
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+          // Should still disconnect the practice session channel
           assert.calledOnce(mockPSChannel.disconnect);
         });
 
-        it('switches voicea after disconnect when main channel becomes connected during practice disconnect', async () => {
-          // Main channel not connected initially
-          meeting.llmChannel.isConnected.returns(false);
+        it('switches voicea after disconnect when main channel was replaced during practice disconnect', async () => {
+          // Main channel connected initially
+          meeting.llmChannel.isConnected.returns(true);
 
-          // Simulate main channel becoming connected during practice disconnect
+          const originalLLMChannel = meeting.llmChannel;
+          const newLLMChannel = {
+            isConnected: sinon.stub().returns(true),
+            on: sinon.stub(),
+            off: sinon.stub(),
+          };
+
+          // Simulate main channel being replaced during practice disconnect
           mockPSChannel.disconnect.callsFake(async () => {
-            meeting.llmChannel.isConnected.returns(true);
+            meeting.llmChannel = newLLMChannel;
           });
 
           await webinar.cleanupPSDataChannel();
 
-          // Should switch voicea after disconnect completes (recheck found main now connected)
-          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+          // Should switch voicea twice: once before disconnect (to original), once after (to new)
+          assert.calledTwice(mockVoiceaChannel.switchLLMChannel);
+          assert.calledWith(mockVoiceaChannel.switchLLMChannel.firstCall, originalLLMChannel);
+          assert.calledWith(mockVoiceaChannel.switchLLMChannel.secondCall, newLLMChannel);
         });
 
         it('does not switch voicea channel when meeting has no voiceaChannel', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -524,10 +524,23 @@ describe('plugin-meetings', () => {
           assert.notCalled(mockPSChannel.disconnect);
         });
 
-        it('switches voicea channel back to main meeting LLM channel', async () => {
+        it('switches voicea channel back to main meeting LLM channel when main channel is connected', async () => {
+          meeting.llmChannel.isConnected.returns(true);
+
           await webinar.cleanupPSDataChannel();
 
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+        });
+
+        it('skips voicea switch when main meeting LLM channel is not connected', async () => {
+          meeting.llmChannel.isConnected.returns(false);
+
+          await webinar.cleanupPSDataChannel();
+
+          // Should not call switchLLMChannel - let updateLLMConnection handle it when main channel reconnects
+          assert.notCalled(mockVoiceaChannel.switchLLMChannel);
+          // But should still disconnect the practice session channel
+          assert.calledOnce(mockPSChannel.disconnect);
         });
 
         it('does not switch voicea channel when meeting has no voiceaChannel', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -532,15 +532,30 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
         });
 
-        it('skips voicea switch when main meeting LLM channel is not connected', async () => {
+        it('skips voicea switch when main channel is not connected before or after disconnect', async () => {
           meeting.llmChannel.isConnected.returns(false);
 
           await webinar.cleanupPSDataChannel();
 
-          // Should not call switchLLMChannel - let updateLLMConnection handle it when main channel reconnects
+          // Should not call switchLLMChannel - main channel never became available
           assert.notCalled(mockVoiceaChannel.switchLLMChannel);
           // But should still disconnect the practice session channel
           assert.calledOnce(mockPSChannel.disconnect);
+        });
+
+        it('switches voicea after disconnect when main channel becomes connected during practice disconnect', async () => {
+          // Main channel not connected initially
+          meeting.llmChannel.isConnected.returns(false);
+
+          // Simulate main channel becoming connected during practice disconnect
+          mockPSChannel.disconnect.callsFake(async () => {
+            meeting.llmChannel.isConnected.returns(true);
+          });
+
+          await webinar.cleanupPSDataChannel();
+
+          // Should switch voicea after disconnect completes (recheck found main now connected)
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
         });
 
         it('does not switch voicea channel when meeting has no voiceaChannel', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -448,6 +448,7 @@ describe('plugin-meetings', () => {
             handleLLMOnline: sinon.stub(),
             llmChannel: createMockLLMChannel(),
             voiceaChannel: mockVoiceaChannel,
+            startTranscriptionIfNeeded: sinon.stub(),
             annotation: {registerChannel: sinon.stub()},
             trigger: sinon.stub(),
             transcription: {captions: []},
@@ -532,6 +533,7 @@ describe('plugin-meetings', () => {
           await webinar.cleanupPSDataChannel();
 
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+          assert.calledOnceWithExactly(meeting.startTranscriptionIfNeeded);
         });
 
         it('switches voicea to main channel even when not connected (defers caption restoration)', async () => {
@@ -612,6 +614,7 @@ describe('plugin-meetings', () => {
             processRelayEvent: sinon.stub(),
             processLocusLLMEvent: sinon.stub(),
             handleLLMOnline: sinon.stub(),
+            startTranscriptionIfNeeded: sinon.stub(),
             llmChannel: mockDefaultChannel,
             voiceaChannel: mockVoiceaChannel,
             annotation: {registerChannel: sinon.stub()},
@@ -784,6 +787,7 @@ describe('plugin-meetings', () => {
           await webinar.updatePSDataChannel();
 
           assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, mockPSChannel);
+          assert.calledOnceWithExactly(meeting.startTranscriptionIfNeeded);
         });
 
         it('does not call switchLLMChannel when meeting has no voiceaChannel', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -523,8 +523,9 @@ describe('plugin-meetings', () => {
 
           await webinar.cleanupPSDataChannel();
 
-          // Should not throw and should complete successfully
           assert.notCalled(mockPSChannel.disconnect);
+          assert.calledOnceWithExactly(mockVoiceaChannel.switchLLMChannel, meeting.llmChannel);
+          assert.calledOnceWithExactly(meeting.startTranscriptionIfNeeded);
         });
 
         it('switches voicea channel back to main meeting LLM channel when main channel is connected', async () => {


### PR DESCRIPTION
…cts to preserve caption state

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-851151
## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

1. [voicea.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) - VoiceaChannel class

[llmChannel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is now optional ([LLMChannel | undefined](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Constructor only subscribes to events if [llmChannel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is provided
Added [requireLLMChannel()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper that throws if LLM channel not available
Methods that use [this.llmChannel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now use the helper for explicit error handling
[isLLMConnected()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns false if no llmChannel (instead of crash)
[deregisterEvents()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) guards against missing llmChannel
2. [voicea-plugin.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Factory

[createChannel(llmChannel?)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now accepts optional llmChannel
3. meeting/index.ts - Meeting class

Constructor: Creates [voiceaChannel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) early (without llmChannel)
stopListeningForLLMEvents: No longer destroys voiceaChannel — just a comment explaining it persists
updateLLMConnection: Calls [voiceaChannel.switchLLMChannel(this.llmChannel)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of creating a new channel

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
