### PR TITLE
fix(sdk-meetings): ZD:150348 - Web JS SDK - final-only caption throws in processNewCaptions

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -102,7 +102,7 @@ export const processNewCaptions = ({
 
       interimTranscriptionIds.push(interimId);
     } else {
-      transcriptData.interimCaptions[transcriptId].forEach((innerInterimId) => {
+      (transcriptData.interimCaptions[transcriptId] ?? []).forEach((innerInterimId) => {
         const interimTranscriptIndex = transcriptData.captions.findIndex(
           (transcript) => transcript.id === innerInterimId
         );

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
@@ -150,6 +150,82 @@ describe('plugin-meetings', () => {
         });
 
         describe('processNewCaptions', () => {
+            const processCaptions = () => processNewCaptions({
+                data: fakeVoiceaPayload,
+                meeting: fakeMeeting
+            });
+
+            it('should process a final-only caption without an existing interim caption', () => {
+                const transcriptData = fakeMeeting.transcription;
+                const transcriptId = fakeVoiceaPayload.transcriptId;
+
+                delete transcriptData.interimCaptions[transcriptId];
+
+                assert.doesNotThrow(processCaptions);
+
+                const finalCaption = transcriptData.captions.find(caption => caption.id === transcriptId);
+
+                assert.exists(finalCaption);
+                assert.deepEqual(transcriptData.interimCaptions[transcriptId], []);
+            });
+
+            it('should process an interim caption received after a final caption', () => {
+                const transcriptData = fakeMeeting.transcription;
+                const transcriptId = fakeVoiceaPayload.transcriptId;
+
+                delete transcriptData.interimCaptions[transcriptId];
+
+                assert.doesNotThrow(processCaptions);
+
+                fakeVoiceaPayload.isFinal = false;
+
+                assert.doesNotThrow(processCaptions);
+
+                const speakerId = fakeMeeting.members.membersCollection.members[fakeMemberId].participant.person.id;
+                const interimId = `${transcriptId}_${speakerId}`;
+
+                assert.exists(transcriptData.captions.find(caption => caption.id === transcriptId));
+                assert.exists(transcriptData.captions.find(caption => caption.id === interimId));
+                assert.deepEqual(transcriptData.interimCaptions[transcriptId], [interimId]);
+            });
+
+            it('should process repeated final captions without throwing', () => {
+                const transcriptData = fakeMeeting.transcription;
+                const transcriptId = fakeVoiceaPayload.transcriptId;
+
+                delete transcriptData.interimCaptions[transcriptId];
+
+                assert.doesNotThrow(() => {
+                    processCaptions();
+                    processCaptions();
+                });
+
+                assert.exists(transcriptData.captions.find(caption => caption.id === transcriptId));
+            });
+
+            it('should process final captions from multiple CSIs without throwing', () => {
+                const transcriptData = fakeMeeting.transcription;
+                const transcriptId = fakeVoiceaPayload.transcriptId;
+                const secondCaptionText = 'Caption from a second CSI';
+
+                fakeVoiceaPayload.transcripts.push({
+                    text: secondCaptionText,
+                    csis: [1234867713],
+                    transcript_language_code: 'en'
+                });
+
+                assert.doesNotThrow(processCaptions);
+
+                const finalCaptionTexts = transcriptData.captions
+                    .filter(caption => caption.id === transcriptId)
+                    .map(caption => caption.text);
+
+                assert.deepEqual(finalCaptionTexts, [
+                    fakeVoiceaPayload.transcripts[0].text,
+                    secondCaptionText
+                ]);
+            });
+
             it('should process new final captions correctly', () => {
                 let transcriptData = fakeMeeting.transcription;
                 let transcriptId = fakeVoiceaPayload.transcriptId;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
@@ -203,16 +203,24 @@ describe('plugin-meetings', () => {
                 assert.exists(transcriptData.captions.find(caption => caption.id === transcriptId));
             });
 
-            it('should process final captions from multiple CSIs without throwing', () => {
+            it('should process a final payload containing transcript entries for multiple CSIs without throwing', () => {
                 const transcriptData = fakeMeeting.transcription;
                 const transcriptId = fakeVoiceaPayload.transcriptId;
+                const firstCsi = 1234867712;
+                const secondCsi = 1234867713;
                 const secondCaptionText = 'Caption from a second CSI';
 
-                fakeVoiceaPayload.transcripts.push({
-                    text: secondCaptionText,
-                    csis: [1234867713],
-                    transcript_language_code: 'en'
-                });
+                fakeVoiceaPayload.transcripts = [
+                    {
+                        ...fakeVoiceaPayload.transcripts[0],
+                        csis: [firstCsi]
+                    },
+                    {
+                        text: secondCaptionText,
+                        csis: [secondCsi],
+                        transcript_language_code: 'en'
+                    }
+                ];
 
                 assert.doesNotThrow(processCaptions);
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-849083

## This pull request addresses

SPARK-849083 — Caption processing throws TypeError: Cannot read properties of undefined (reading 'forEach') when a final Voicea caption is received without a previously cached interim caption for the same transcript ID.

## by making the following changes

Treating a missing interimCaptions[transcriptId] entry as an empty array before removing interim captions. This allows final-only captions to be processed without changing existing caption ordering or behavior.

Added a safe fallback for final captions that do not have a cached interim entry.
Preserved the existing interim-caption cleanup and final-caption processing order.
Added regression tests covering:- Final-only captions.
- Interim captions received after a final caption.
- Repeated final captions.
- Final payloads containing multiple CSI/speaker entries.
<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 11 10 18 AM" src="https://github.com/user-attachments/assets/300d7ac0-2b02-4953-9b56-21920af5a2f1" />


<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 11 10 28 AM" src="https://github.com/user-attachments/assets/6df32df8-0411-4a2e-be4b-ea0bcbfb38a7" />
<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 12 55 52 PM" src="https://github.com/user-attachments/assets/a435f7f7-adb1-4619-99c6-453630394ae2" />
<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 12 56 03 PM" src="https://github.com/user-attachments/assets/32dccd8f-8472-4edc-bca3-cf3366f17a9f" />



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [X] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [X] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [X] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [X] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
