### PR TITLE
fix: cover the watchdog missing case

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1947,10 +1947,13 @@ class HashTreeParser {
 
     const dataSetsNeedingWatchdog = pendingDataSetNames
       .map((name) => this.dataSets[name])
-      .filter(
-        (dataSet): dataSet is InternalDataSet =>
-          Boolean(dataSet?.hashTree) && !dataSet?.heartbeatWatchdogTimer
-      );
+      .filter((dataSet): dataSet is InternalDataSet => {
+        if (!dataSet?.hashTree || dataSet.heartbeatWatchdogTimer) {
+          return false;
+        }
+
+        return this.isVisibleDataSet(dataSet.name);
+      });
 
     if (dataSetsNeedingWatchdog.length > 0) {
       LoggerProxy.logger.info(

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -177,6 +177,9 @@ class HashTreeParser {
   private syncQueueProcessingPromise: Promise<void> = Promise.resolve();
   // top-level heartbeat interval from the most recent message, used as fallback when dataset-level value is missing
   private topLevelHeartbeatIntervalMs?: number;
+  // LLM data sets that were received while LLM was not expected, so their heartbeat watchdog was
+  // skipped; reevaluateLlmWatchdogs() arms these once LLM becomes expected and then clears this set
+  private pendingLlmWatchdogDataSetNames: Set<string> = new Set();
   /**
    * Constructor for HashTreeParser
    * @param {Object} options
@@ -1891,6 +1894,8 @@ class HashTreeParser {
           `HashTreeParser#resetHeartbeatWatchdogs --> ${this.debugId} skipping heartbeat watchdog timer for data set "${dataSet.name}" because LLM is disconnected`
         );
 
+        // remember it so reevaluateLlmWatchdogs() can arm the watchdog once LLM becomes expected
+        this.pendingLlmWatchdogDataSetNames.add(dataSet.name);
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -1915,6 +1920,47 @@ class HashTreeParser {
         this.enqueueSyncForDataset(dataSet.name, `heartbeat watchdog expired`);
         this.resetHeartbeatWatchdogs([dataSet]);
       }, delay);
+    }
+  }
+
+  /**
+   * Re-evaluates heartbeat watchdog timers for LLM data sets. While LLM is not expected,
+   * resetHeartbeatWatchdogs skips setting watchdog timers for LLM data sets and records them in
+   * pendingLlmWatchdogDataSetNames. This must be called when LLM transitions to expected (e.g. self
+   * reports JOINED) to arm the watchdogs for those pending data sets (avoids a timing issue where
+   * the "main"/"atd-active"/"atd-unmuted" data set arrives before the self update). The pending set
+   * is consumed and cleared here.
+   * @returns {void}
+   */
+  reevaluateLlmWatchdogs(): void {
+    if (this.state === 'stopped') {
+      return;
+    }
+
+    if (this.pendingLlmWatchdogDataSetNames.size === 0) {
+      return;
+    }
+
+    // consume the pending set - these LLM data sets were received while LLM was not expected
+    const pendingDataSetNames = [...this.pendingLlmWatchdogDataSetNames];
+    this.pendingLlmWatchdogDataSetNames.clear();
+
+    const dataSetsNeedingWatchdog = pendingDataSetNames
+      .map((name) => this.dataSets[name])
+      .filter(
+        (dataSet): dataSet is InternalDataSet =>
+          Boolean(dataSet?.hashTree) && !dataSet?.heartbeatWatchdogTimer
+      );
+
+    if (dataSetsNeedingWatchdog.length > 0) {
+      LoggerProxy.logger.info(
+        `HashTreeParser#reevaluateLlmWatchdogs --> ${
+          this.debugId
+        } LLM became expected, setting heartbeat watchdog timers for data sets: ${dataSetsNeedingWatchdog
+          .map((ds) => ds.name)
+          .join(', ')}`
+      );
+      this.resetHeartbeatWatchdogs(dataSetsNeedingWatchdog);
     }
   }
 
@@ -1950,6 +1996,7 @@ class HashTreeParser {
     this.topLevelHeartbeatIntervalMs = undefined;
     this.syncAllBackoffType = SyncAllBackoffType.NONE;
     this.dataSetsSyncedDuringBackoff = new Set();
+    this.pendingLlmWatchdogDataSetNames = new Set();
     Object.values(this.dataSets).forEach((dataSet) => {
       dataSet.syncAbortController?.abort();
       dataSet.syncAbortController = undefined;

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -539,6 +539,15 @@ export default class LocusInfo extends EventsScope {
   }
 
   /**
+   * Whether we expect to receive updates over the LLM connection. This is used by hash tree parsers
+   * to decide whether to arm heartbeat watchdog timers for LLM data sets.
+   * @returns {boolean}
+   */
+  private isLlmExpected(): boolean {
+    return this.parsedLocus.self?.joinedWith?.state === 'JOINED';
+  }
+
+  /**
    * Creates a HashTreeParser instance for a given locusUrl and stores it in the map.
    * @param {Object} params
    * @param {string} params.locusUrl - the locus URL used as the map key
@@ -568,7 +577,7 @@ export default class LocusInfo extends EventsScope {
       callbacks: {
         locusInfoUpdateCallback: this.updateFromHashTree.bind(this, locusUrl),
         syncLatencyTracker: this.callbacks.syncLatencyTracker,
-        isLlmExpected: () => this.parsedLocus.self?.joinedWith?.state === 'JOINED',
+        isLlmExpected: () => this.isLlmExpected(),
         // Reuse webex-core's tracking-id interceptor sequence (exposed publicly via
         // webexTrackingIdSequenceNumbers) so Locus requests share the client's unified
         // ${sessionId}_${sequence} tracking id space instead of minting an unrelated id. Fall
@@ -2714,6 +2723,7 @@ export default class LocusInfo extends EventsScope {
    */
   updateSelf(self: any) {
     if (self) {
+      const wasLlmExpected = this.isLlmExpected();
       // @ts-ignore
       const parsedSelves = SelfUtils.getSelves(
         this.parsedLocus.self,
@@ -2993,6 +3003,15 @@ export default class LocusInfo extends EventsScope {
       this.parsedLocus.self = parsedSelves.current;
       // @ts-ignore
       this.self = self;
+
+      // If LLM just became expected (self reported JOINED), some hash tree parsers may have skipped
+      // arming heartbeat watchdog timers for LLM data sets whose messages arrived before this
+      // update. Re-evaluate them now so those watchdogs get armed.
+      if (!wasLlmExpected && this.isLlmExpected()) {
+        this.hashTreeParsers.forEach((entry) => {
+          entry.parser.reevaluateLlmWatchdogs();
+        });
+      }
     } else {
       this.compareAndUpdateFlags.compareHostAndSelf = false;
     }

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -3560,6 +3560,154 @@ describe('HashTreeParser', () => {
         expect(parser.dataSets.self.heartbeatWatchdogTimer).to.not.be.undefined;
       });
 
+      it('arms skipped LLM watchdog timers when reevaluateLlmWatchdogs is called after LLM becomes expected', async () => {
+        let llmExpected = false;
+        const parser = createHashTreeParser(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'meeting-1',
+          undefined,
+          () => llmExpected
+        );
+
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+            {
+              ...createDataSet('self', 1, 2100),
+              url: parser.dataSets.self.url,
+              root: parser.dataSets.self.hashTree.getRootHash(),
+            },
+            {
+              ...createDataSet('atd-unmuted', 16, 3100),
+              url: parser.dataSets['atd-unmuted'].url,
+              root: parser.dataSets['atd-unmuted'].hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+        };
+
+        // LLM data set messages arrive before LLM is expected, so their watchdogs are skipped
+        parser.handleMessage(heartbeatMessage, 'heartbeat before llm expected');
+
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+        const selfTimerBefore = parser.dataSets.self.heartbeatWatchdogTimer;
+        expect(selfTimerBefore).to.not.be.undefined;
+
+        // LLM becomes expected and we re-evaluate the watchdogs
+        llmExpected = true;
+        parser.reevaluateLlmWatchdogs();
+
+        // the previously skipped LLM watchdogs are now armed
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.not.be.undefined;
+        // the self (non-LLM) watchdog timer is left untouched
+        expect(parser.dataSets.self.heartbeatWatchdogTimer).to.equal(selfTimerBefore);
+
+        // the pending set is consumed, so a second call after clearing the timers is a no-op
+        clearTimeout(parser.dataSets.main.heartbeatWatchdogTimer);
+        clearTimeout(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer);
+        parser.dataSets.main.heartbeatWatchdogTimer = undefined;
+        parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer = undefined;
+
+        parser.reevaluateLlmWatchdogs();
+
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+      });
+
+      it('only arms watchdogs for LLM data sets that were actually received in a message', async () => {
+        let llmExpected = false;
+        const parser = createHashTreeParser(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'meeting-1',
+          undefined,
+          () => llmExpected
+        );
+
+        // only 'main' is received in a message (atd-unmuted exists in this.dataSets with a hash
+        // tree but is never received in any message)
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+        };
+
+        parser.handleMessage(heartbeatMessage, 'only main received before llm expected');
+
+        // sanity: atd-unmuted has a hash tree but was never received
+        expect(parser.dataSets['atd-unmuted'].hashTree).to.not.be.undefined;
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+
+        llmExpected = true;
+        parser.reevaluateLlmWatchdogs();
+
+        // 'main' was received, so its watchdog is armed
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        // 'atd-unmuted' was never received, so no watchdog is armed even though it has a hash tree
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+      });
+
+      it('does not re-arm or reset an already active LLM watchdog timer when reevaluateLlmWatchdogs is called', async () => {
+        const parser = createHashTreeParser(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'meeting-1',
+          undefined,
+          () => true
+        );
+
+        parser.handleMessage(
+          createHeartbeatMessage('main', 16, 1100, parser.dataSets.main.hashTree.getRootHash()),
+          'heartbeat with llm expected'
+        );
+
+        const mainTimerBefore = parser.dataSets.main.heartbeatWatchdogTimer;
+        expect(mainTimerBefore).to.not.be.undefined;
+
+        parser.reevaluateLlmWatchdogs();
+
+        // existing active timer must not be cleared/reset (that would extend its deadline)
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.equal(mainTimerBefore);
+      });
+
+      it('does nothing when reevaluateLlmWatchdogs is called on a stopped parser', async () => {
+        const parser = createHashTreeParser(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'meeting-1',
+          undefined,
+          () => true
+        );
+
+        parser.stop();
+
+        parser.reevaluateLlmWatchdogs();
+
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+      });
+
       it('stops all watchdog timers when meeting ends via sentinel message', async () => {
         const parser = createHashTreeParser();
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2055,6 +2055,53 @@ describe('plugin-meetings', () => {
     });
 
     describe('#updateSelf', () => {
+      describe('LLM watchdog re-evaluation', () => {
+        it('re-evaluates LLM watchdogs on all hash tree parsers when self transitions to joined', () => {
+          const parserA = {reevaluateLlmWatchdogs: sinon.stub()};
+          const parserB = {reevaluateLlmWatchdogs: sinon.stub()};
+          locusInfo.hashTreeParsers.set('urlA', {parser: parserA});
+          locusInfo.hashTreeParsers.set('urlB', {parser: parserB});
+
+          // start with LLM not expected (no self yet)
+          locusInfo.parsedLocus.self = undefined;
+          locusInfo.webex.internal.device.url = self.deviceUrl;
+
+          // the self fixture's joined device has state JOINED -> isLlmExpected becomes true
+          locusInfo.updateSelf(cloneDeep(self));
+
+          assert.calledOnceWithExactly(parserA.reevaluateLlmWatchdogs);
+          assert.calledOnceWithExactly(parserB.reevaluateLlmWatchdogs);
+        });
+
+        it('does not re-evaluate LLM watchdogs when LLM was already expected before the update', () => {
+          const parser = {reevaluateLlmWatchdogs: sinon.stub()};
+          locusInfo.hashTreeParsers.set('urlA', {parser});
+          locusInfo.webex.internal.device.url = self.deviceUrl;
+
+          // first update establishes the JOINED state (LLM already expected)
+          locusInfo.updateSelf(cloneDeep(self));
+          parser.reevaluateLlmWatchdogs.resetHistory();
+
+          // second update while already joined must not re-trigger re-evaluation
+          locusInfo.updateSelf(cloneDeep(self));
+
+          assert.notCalled(parser.reevaluateLlmWatchdogs);
+        });
+
+        it('does not re-evaluate LLM watchdogs when the self update does not make LLM expected', () => {
+          const parser = {reevaluateLlmWatchdogs: sinon.stub()};
+          locusInfo.hashTreeParsers.set('urlA', {parser});
+
+          locusInfo.parsedLocus.self = undefined;
+          // device url does not match any of self's devices -> joinedWith is undefined -> not expected
+          locusInfo.webex.internal.device.url = 'https://some-other-device-url.com';
+
+          locusInfo.updateSelf(cloneDeep(self));
+
+          assert.notCalled(parser.reevaluateLlmWatchdogs);
+        });
+      });
+
       it('should trigger SELF_MEETING_BRB_CHANGED when brb state changed', () => {
         locusInfo.self = undefined;
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-852249

## This pull request addresses

Temporary storage, only when LLM not expected & only for LLM datasets: A dataset name is added to the set only inside the LLM-skip branch of resetHeartbeatWatchdogs — i.e. only for LLM_DATASET_NAMES datasets that were received while isLlmExpected() is false and whose watchdog was skipped.
Checked when LLM becomes expected: reevaluateLlmWatchdogs returns early if the pending set is empty; otherwise it proceeds to arm watchdogs for the pending datasets (that still have a hash tree and no active timer).
Consumed and cleared: The set is snapshotted and clear()ed before arming, so it does not linger. A second reevaluateLlmWatchdogs call is a no-op (verified by the added test assertion).

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
