### PR TITLE
SPARK-845583: Validate untrusted inputs at Contact Center trust boundaries

### DIFF
--- a/packages/@webex/contact-center/ai-docs/contact-center-spec.md
+++ b/packages/@webex/contact-center/ai-docs/contact-center-spec.md
@@ -102,6 +102,8 @@ Compatibility notes:
 
 Direct data/configuration and user-preference operations return authenticated REST responses. Enabled agent/task AQM operations, including preview-campaign accept/skip/remove, send authenticated HTTP requests but resolve or reject only after a matching WebSocket notification. Before delegating preview skip/remove, ContactCenter checks the task's campaign-disable flags and throws locally when the corresponding flag is `'true'`. TaskManager converts backend task events into Task instances and typed state-machine events. ContactCenter maps package-facing events through WebexPlugin `trigger` or its internal EventEmitter according to the published contract.
 
+Inbound primary-WebSocket messages are mapped through `handleWebsocketMessage`, which emits only event names on the typed `CC_EVENTS`/`AGENT_EVENTS` allow-list. A server-controlled `eventData.data.type` that is not a known allow-listed constant is ignored and never emitted as an application event name.
+
 Durable agent, task, and configuration records remain remote-system owned. The package owns only in-memory profile/task/listener/cache/connection state.
 
 ### wxApp Better Together (WXCC-6026)
@@ -291,6 +293,7 @@ ContactCenter retains in-memory `agentConfig`, collaborator references, event li
 - Collaborators are initialized after host READY and before their use; `register()` must not be documented as their constructor boundary. Evidence: `src/cc.ts`.
 - AQM promises complete only from correlated WebSocket success/failure or timeout, not from HTTP acknowledgement. Evidence: `src/services/core/aqm-reqs.ts`.
 - `skipPreviewContact` checks `campaignPreviewSkipDisabled` and `removePreviewContact` checks `campaignPreviewRemoveDisabled` on the matching task. When the applicable value is `'true'`, ContactCenter throws before initiating an HTTP or WebSocket-correlated AQM operation; `acceptPreviewContact` has no equivalent pre-guard. Evidence: `src/cc.ts`.
+- `handleWebsocketMessage` only re-emits event names that belong to the typed `CC_EVENTS`/`AGENT_EVENTS` allow-list; an untrusted `eventData.data.type` outside that allow-list is not emitted as an event name. Evidence: `src/cc.ts`.
 - ContactCenter owns automated relogin policy; ConnectionService owns transport-state detection/emission. Evidence: `src/cc.ts`, `src/services/core/websocket/connection-service.ts`.
 - Deregistration does not station-logout the agent. Evidence: `src/cc.ts`.
 - Published methods/types/events remain semver-sensitive through `src/index.ts`.

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -82,6 +82,13 @@ import type {
 } from './types';
 
 /**
+ * Typed allow-list of server-controlled websocket event names this SDK re-emits verbatim.
+ * Guards against emitting an arbitrary/unknown `data.type` supplied by the websocket payload.
+ * @ignore
+ */
+const CC_EVENT_ALLOW_LIST = new Set<string>(Object.values(CC_EVENTS));
+
+/**
  * The main Contact Center plugin class that enables integration with Webex Contact Center.
  *
  * @class ContactCenter
@@ -1314,8 +1321,14 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   private handleWebsocketMessage = (event: string) => {
     const eventData = JSON.parse(event);
-    // Re-emit all the events related to agent except keep-alives
-    if (!eventData.keepalive && eventData.data && eventData.data.type) {
+    // Re-emit all the events related to agent except keep-alives. Only event names present in
+    // the typed CC_EVENTS allow-list are emitted; unknown/server-injected types are ignored.
+    if (
+      !eventData.keepalive &&
+      eventData.data &&
+      eventData.data.type &&
+      CC_EVENT_ALLOW_LIST.has(eventData.data.type)
+    ) {
       // @ts-ignore
       this.emit(eventData.data.type, eventData.data);
     }

--- a/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
@@ -40,6 +40,18 @@ export class ApiAIAssistant {
     this.aiFeature = aiFeature;
   }
 
+  /**
+   * Validates a caller-supplied identifier (agentId/interactionId) before it is used to
+   * construct a request. Accepts a non-empty alphanumeric identifier that may contain
+   * hyphens or underscores.
+   * @param value - the identifier to validate
+   * @returns {boolean} true when the identifier is a non-empty, well-formed string
+   * @private
+   */
+  private isValidTranscriptIdentifier(value: unknown): boolean {
+    return typeof value === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(value);
+  }
+
   private getBaseUrl(): string {
     const wccApiGatewayUrl = this.webex.internal.services.get(WCC_API_GATEWAY) || '';
 
@@ -359,6 +371,18 @@ export class ApiAIAssistant {
     if (!this.aiFeature?.realtimeTranscripts?.enable) {
       const {error: detailedError} = getErrorDetails(
         new Error('REAL_TIME_TRANSCRIPTION_NOT_ENABLED'),
+        METHODS.FETCH_HISTORIC_TRANSCRIPTS,
+        CC_FILE
+      );
+      throw detailedError;
+    }
+
+    if (
+      !this.isValidTranscriptIdentifier(agentId) ||
+      !this.isValidTranscriptIdentifier(interactionId)
+    ) {
+      const {error: detailedError} = getErrorDetails(
+        new Error('INVALID_AGENT_ID_OR_INTERACTION_ID'),
         METHODS.FETCH_HISTORIC_TRANSCRIPTS,
         CC_FILE
       );

--- a/packages/@webex/contact-center/src/services/WebCallingService.ts
+++ b/packages/@webex/contact-center/src/services/WebCallingService.ts
@@ -15,6 +15,7 @@ import {TIMEOUT_DURATION, WEB_CALLING_SERVICE_FILE} from '../constants';
 import LoggerProxy from '../logger-proxy';
 import {
   DEFAULT_RTMS_DOMAIN,
+  ALLOWED_RTMS_DOMAIN,
   POST_AUTH,
   WCC_CALLING_RTMS_DOMAIN,
   DEREGISTER_WEBCALLING_LINE_MSG,
@@ -142,8 +143,23 @@ export default class WebCallingService extends EventEmitter {
 
     try {
       const url = new URL(rtmsURL);
+      const hostname = url.hostname.toLowerCase();
+      const isAllowedHost =
+        hostname === ALLOWED_RTMS_DOMAIN || hostname.endsWith(`.${ALLOWED_RTMS_DOMAIN}`);
 
-      return url.hostname;
+      if (!isAllowedHost) {
+        LoggerProxy.error(
+          `Non-allow-listed RTMS host from u2c catalogue: ${hostname} so falling back to default domain`,
+          {
+            module: WEB_CALLING_SERVICE_FILE,
+            method: METHODS.GET_RTMS_DOMAIN,
+          }
+        );
+
+        return DEFAULT_RTMS_DOMAIN;
+      }
+
+      return hostname;
     } catch (error) {
       LoggerProxy.error(
         `Invalid URL from u2c catalogue: ${rtmsURL} so falling back to default domain`,

--- a/packages/@webex/contact-center/src/services/WebCallingService.ts
+++ b/packages/@webex/contact-center/src/services/WebCallingService.ts
@@ -21,6 +21,7 @@ import {
   DEREGISTER_WEBCALLING_LINE_MSG,
   METHODS,
 } from './constants';
+import {isAllowedUrlHost} from './core/Utils';
 
 /**
  * WebCallingService provides WebRTC calling functionality for Contact Center agents.
@@ -142,12 +143,9 @@ export default class WebCallingService extends EventEmitter {
     const rtmsURL = this.webex.internal.services.get(WCC_CALLING_RTMS_DOMAIN);
 
     try {
-      const url = new URL(rtmsURL);
-      const hostname = url.hostname.toLowerCase();
-      const isAllowedHost =
-        hostname === ALLOWED_RTMS_DOMAIN || hostname.endsWith(`.${ALLOWED_RTMS_DOMAIN}`);
+      const hostname = new URL(rtmsURL).hostname.toLowerCase();
 
-      if (!isAllowedHost) {
+      if (!isAllowedUrlHost(rtmsURL, [ALLOWED_RTMS_DOMAIN])) {
         LoggerProxy.error(
           `Non-allow-listed RTMS host from u2c catalogue: ${hostname} so falling back to default domain`,
           {

--- a/packages/@webex/contact-center/src/services/ai-docs/services-spec.md
+++ b/packages/@webex/contact-center/src/services/ai-docs/services-spec.md
@@ -69,7 +69,7 @@ Each service folder contains its own `ai-docs/` with detailed documentation. **A
 
 **Paginated data services** (AddressBook, Queue, EntryPoint) do not have dedicated ai-docs. Read their source files directly — they follow shared REST/pagination/caching patterns documented in [`ai-docs/patterns/typescript-patterns.md`](../../../ai-docs/patterns/typescript-patterns.md). `UserPreference` is also a direct REST service, but it has CRUD semantics and does not use their PageCache pattern.
 
-**WebCallingService** also has no dedicated ai-docs, but it follows a different pattern: EventEmitter-based call lifecycle orchestration around `@webex/calling` (`createClient`, line registration/deregistration, `ICall` events), `callTaskMap` tracking, and async registration flows with timeout handling. Read [`WebCallingService.ts`](../WebCallingService.ts) directly when changing browser calling behavior.
+**WebCallingService** also has no dedicated ai-docs, but it follows a different pattern: EventEmitter-based call lifecycle orchestration around `@webex/calling` (`createClient`, line registration/deregistration, `ICall` events), `callTaskMap` tracking, and async registration flows with timeout handling. Before registering the calling line it resolves the RTMS domain from the u2c service catalog through `getRTMSDomain()`, which trusts the catalog host only when it is on the `ALLOWED_RTMS_DOMAIN` allow-list and otherwise falls back to `DEFAULT_RTMS_DOMAIN`. Read [`WebCallingService.ts`](../WebCallingService.ts) directly when changing browser calling behavior.
 
 The `ContactCenter` plugin class (`cc.ts`) is the **only public entry point**. It delegates all backend work to the services layer:
 
@@ -211,6 +211,8 @@ Use [`constants.ts`](../constants.ts) as the canonical source for service-level 
 
 - `DEFAULT_RTMS_DOMAIN`, `WCC_CALLING_RTMS_DOMAIN` — RTMS/WebRTC domain constants
 
+- `ALLOWED_RTMS_DOMAIN` — trusted RTMS domain suffix (`rtmsprod.net`); a catalog-provided RTMS host is used only when its hostname equals or is a subdomain of this value, otherwise `DEFAULT_RTMS_DOMAIN` is used
+
 - `METHODS` — method name constants used by `WebCallingService`
 
 ## Key Files (source of truth)
@@ -264,6 +266,8 @@ ContactCenter READY callback
 | SERVICES-R-005 | Inherit authenticated request identity from the host Webex SDK through Core/WebexRequest; Services must not store, parse, or refresh credentials. | One host-owned authentication boundary avoids duplicate token handling and credential leakage across composed services. | `src/services/index.ts`, `src/services/core/WebexRequest.ts` | `test/unit/spec/services/core/WebexRequest.ts` | None; authentication ownership is explicit. | PRESENT |
 | SERVICES-R-006 | Treat Services composition as unconditionally created by the ContactCenter READY callback; Services owns no rollout or feature-flag decision. | Capability flags belong to the consuming config/task/calling collaborators, so the composition root must not silently gate construction. | `src/services/index.ts`, `src/cc.ts` | `test/unit/spec/cc.ts` | None; rollout applicability is explicitly N/A for Services. | PRESENT |
 | SERVICES-R-007 | Existing Queue and EntryPoint list methods must apply inbound, active, telephony, profile/agent-view, and `name,ASC` defaults while retaining their established parameter and full-record response types. Caller-supplied existing filter, sort, or profile inputs override defaults. Queue must also treat `sortOrder` without `sortBy` as a name sort and bypass the simple-page cache. | Defaults on the established methods let thin consumers request lists without a parallel API, while existing parameters preserve specialized behavior for other consumers and full-record types remain truthful because no field projection is requested. | `src/services/Queue.ts`, `src/services/EntryPoint.ts`, `src/types.ts` | `test/unit/spec/services/Queue.ts`, `test/unit/spec/services/EntryPoint.ts`, `test/unit/spec/cc.ts` | The backend honors the view flags and combined CMS sort value. | PRESENT |
+| SERVICES-R-008 | `WebCallingService.getRTMSDomain()` returns a catalog-provided RTMS hostname only when it equals `ALLOWED_RTMS_DOMAIN` (`rtmsprod.net`) or is a subdomain of it; a parseable but non-allow-listed host, or a catalog value that is not a valid URL, falls back to `DEFAULT_RTMS_DOMAIN`. The rejected host is logged as a diagnostic before fallback. | The u2c service catalog is an untrusted input at the calling trust boundary; allow-listing the RTMS host prevents WebRTC registration against an attacker-controlled domain. | `src/services/WebCallingService.ts`, `src/services/constants.ts` | `test/unit/spec/services/WebCallingService.ts` | The `@webex/calling` client accepts the resolved domain string. | PRESENT |
+| SERVICES-R-009 | `ApiAIAssistant.fetchHistoricTranscripts(agentId: string, interactionId: string): Promise<HistoricTranscriptsResponse>` validates both caller-supplied identifiers before building the authenticated request, accepting only non-empty strings matching the identifier format `^[A-Za-z0-9_-]{1,128}$`. Invalid inputs reject with a typed error and no request is sent. | `agentId`/`interactionId` are caller-controlled inputs on an authenticated request boundary; validating them before use rejects malformed identifiers instead of forwarding them to the backend. | `src/services/ApiAiAssistant.ts` | `test/unit/spec/services/ApiAiAssistant.ts` | Real-time transcription feature flag must already be enabled; format validation runs after that gate. | PRESENT |
 
 ## Design Overview
 `Services` is a singleton composition root for transport-facing capabilities only. It constructs two `WebSocketManager` instances (primary Contact Center and RTD), creates `AqmReqs` on the primary manager, then creates config, agent, contact, dialer, and ConnectionService collaborators.
@@ -409,6 +413,7 @@ classDiagram
 - ApiAIAssistant, TaskManager, and UserPreference are READY-time ContactCenter collaborators, not fields constructed by Services.
 - Authentication is inherited from the host SDK through Core/WebexRequest; Services owns no credential lifecycle.
 - Rollout applicability is N/A for the Services composition root: it is created at READY and does not evaluate a feature flag.
+- Untrusted external inputs are validated at the service trust boundary: catalog-provided RTMS hosts must pass the `ALLOWED_RTMS_DOMAIN` allow-list before use, and caller-supplied `agentId`/`interactionId` must match the accepted identifier format before an authenticated transcript request is built.
 
 ## Concurrency & Reactive Flow
 - `getInstance` composition is synchronous in the JavaScript execution turn. Direct REST promises can proceed independently, while each AQM promise remains pending until its matching primary-WebSocket notification, HTTP failure, or timeout.
@@ -481,6 +486,8 @@ Unit tests mirror module paths under `test/unit/spec/services`. Preserve positiv
 | `SERVICES-R-005` | `test/unit/spec/services/core/WebexRequest.ts` | None. |
 | `SERVICES-R-006` | `test/unit/spec/cc.ts` | None. |
 | `SERVICES-R-007` | `test/unit/spec/services/Queue.ts`, `test/unit/spec/services/EntryPoint.ts`, `test/unit/spec/cc.ts` | None. |
+| `SERVICES-R-008` | `test/unit/spec/services/WebCallingService.ts` | Cover allowed host, subdomain, non-allow-listed host, and unparseable catalog value fallback. |
+| `SERVICES-R-009` | `test/unit/spec/services/ApiAiAssistant.ts` | Cover valid identifiers plus empty, over-length, and disallowed-character rejections. |
 
 ## Traceability
 - Repo architecture: `../../../ai-docs/ARCHITECTURE.md` · Registry: `../../../ai-docs/SPEC_INDEX.md`

--- a/packages/@webex/contact-center/src/services/constants.ts
+++ b/packages/@webex/contact-center/src/services/constants.ts
@@ -33,6 +33,16 @@ export const WCC_CALLING_RTMS_DOMAIN = 'wcc-calling-rtms-domain';
 export const DEFAULT_RTMS_DOMAIN = 'rtw.prod-us1.rtmsprod.net';
 
 /**
+ * Trusted domain suffix for RTMS hosts returned by the u2c service catalog. A catalog-provided
+ * RTMS host is only used when its hostname is, or is a subdomain of, this domain; otherwise
+ * `DEFAULT_RTMS_DOMAIN` is used.
+ * @type {string}
+ * @public
+ * @ignore
+ */
+export const ALLOWED_RTMS_DOMAIN = 'rtmsprod.net';
+
+/**
  * Timeout in milliseconds for WebSocket events.
  * @type {number}
  * @public

--- a/packages/@webex/contact-center/src/services/core/Utils.ts
+++ b/packages/@webex/contact-center/src/services/core/Utils.ts
@@ -99,6 +99,30 @@ export const isValidDialNumber = (
   });
 };
 
+/**
+ * Checks whether a URL's hostname is, or is a subdomain of, one of the allowed domains.
+ *
+ * @param url - The candidate URL to validate
+ * @param allowedDomains - Domains (or domain suffixes) the URL's hostname must match
+ * @returns true when the URL parses and its hostname matches an allowed domain, false otherwise
+ */
+export const isAllowedUrlHost = (
+  url: string | undefined | null,
+  allowedDomains: string[]
+): boolean => {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+
+    return allowedDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+  } catch (error) {
+    return false;
+  }
+};
+
 export const getStationLoginErrorData = (failure: Failure, loginOption: LoginOption) => {
   let duplicateLocationMessage = 'This value is already in use';
 

--- a/packages/@webex/contact-center/src/services/core/ai-docs/core-spec.md
+++ b/packages/@webex/contact-center/src/services/core/ai-docs/core-spec.md
@@ -37,13 +37,13 @@ The Core service provides the foundational infrastructure layer that all other s
 
 | Component | File | Description |
 |---|---|---|
-| `WebSocketManager` | [`WebSocketManager.ts`](../websocket/WebSocketManager.ts) | Manages the WebSocket connection lifecycle including initialization, message dispatch, and graceful shutdown. Emits `message` events for incoming data and `socketClose` when the connection drops while reconnect is allowed. |
+| `WebSocketManager` | [`WebSocketManager.ts`](../websocket/WebSocketManager.ts) | Manages the WebSocket connection lifecycle including initialization, message dispatch, and graceful shutdown. Validates the subscribe/register `webSocketUrl` against the RoutingNotifs allow-list before opening a socket. Emits `message` events for incoming data and `socketClose` when the connection drops while reconnect is allowed. |
 | `ConnectionService` | [`connection-service.ts`](../websocket/connection-service.ts) | Orchestrates reconnection logic and keepalive heartbeats on top of `WebSocketManager`. Detects connection loss/recovery and emits `connectionLost` details; ContactCenter owns any `silentRelogin()` policy. |
 | `WebexRequest` | [`WebexRequest.ts`](../WebexRequest.ts) | Singleton HTTP client that forwards service/resource/method/body options to the authenticated host request API and provides `uploadLogs` diagnostics. |
 | `AqmReqs` | [`aqm-reqs.ts`](../aqm-reqs.ts) | Factory for creating request methods that send HTTP requests and wait for correlated WebSocket notifications (success or failure). Used by routing and task services to implement their API methods. |
 | `Utils` | [`Utils.ts`](../Utils.ts) | Shared utility functions including `getErrorDetails()` for standardized error handling, `generateTaskErrorObject()` for task-specific errors, and `createErrDetailsObject()` for constructing error detail objects. |
 | `Err` | [`Err.ts`](../Err.ts) | Error class definitions. `Err.Details` carries structured error metadata (status, type, trackingId) for consistent error propagation. |
-| `constants` | [`constants.ts`](../constants.ts) | Timeout values, interval durations, participant types, interaction states, and method name constants used throughout the core layer. Any new constants for core should be defined here. |
+| `constants` | [`constants.ts`](../constants.ts) | Timeout values, interval durations, participant types, interaction states, method name constants, and the `ALLOWED_ROUTING_NOTIFS_DOMAINS` WebSocket host allow-list used throughout the core layer. Any new constants for core should be defined here. |
 
 ## Purpose / Responsibility
 Own authenticated HTTP, realtime WebSocket lifecycle, AQM request correlation, reconnect/keepalive behavior, and shared error normalization.
@@ -259,13 +259,14 @@ connectionService.on('connectionLost', (details: ConnectionLostDetails) => {
 | CORE-R-004 | ConnectionService must emit transport-state details and retry `initWebSocket({body, resource})`; ContactCenter owns relogin policy. | Separating transport detection from agent recovery prevents Core from mutating package-level session state. | `src/services/core/websocket/connection-service.ts` | `test/unit/spec/services/core/websocket/connection-service.ts` | None; source and test evidence rechecked during the 2026-07-09 remediation; independent document revalidation pending. | PRESENT |
 | CORE-R-005 | The keepalive worker must use the configured 4-second interval and 16-second close-socket timeout; AQM defaults to 20 seconds unless disabled/overridden. | Accurate timing is required for predictable recovery and request failure behavior. | `src/services/core/constants.ts` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | None; source and test evidence rechecked during the 2026-07-09 remediation; independent document revalidation pending. | PRESENT |
 | CORE-R-006 | Treat Core timeout, keepalive, and recovery constants as fixed behavior controls, not rollout flags; Core owns no feature-gate evaluation. | Conflating operational constants with rollout policy could disable transport or correlation paths unexpectedly. | `src/services/core/constants.ts`, `src/services/index.ts` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | None; rollout applicability is explicitly N/A for Core. | PRESENT |
-| CORE-R-007 | When an AQM request sets `redactSensitiveLogs`, routing-failure and timeout logs must omit the request URL, bind key, response, and raw routing payload while preserving settlement and cleanup behavior. | Dynamic request paths and routing messages can contain participant identifiers or phone numbers that must not enter diagnostic logs. | `src/services/core/aqm-reqs.ts`, `src/services/core/types.ts` | `test/unit/spec/services/core/aqm-reqs.ts` | The flag is internal and opt-in; ordinary AQM logging remains backward compatible. | PRESENT |
+| CORE-R-007 | AQM routing-failure logging never emits the raw routing message payload or error verbatim; the failure-bind path logs only a fixed redacted diagnostic regardless of `redactSensitiveLogs`. When an AQM request additionally sets `redactSensitiveLogs`, timeout logs must also omit the request URL, bind key, and response while preserving settlement and cleanup behavior. | Dynamic request paths and routing messages can contain participant identifiers or phone numbers that must not enter diagnostic logs. | `src/services/core/aqm-reqs.ts`, `src/services/core/types.ts` | `test/unit/spec/services/core/aqm-reqs.ts` | The timeout flag is internal and opt-in; ordinary AQM logging remains backward compatible while routing-failure logging is unconditionally redacted. | PRESENT |
+| CORE-R-008 | `WebSocketManager` opens a socket only for a subscribe/register `webSocketUrl` that parses as a `wss` URL whose host equals, or is a subdomain of, an entry in `ALLOWED_ROUTING_NOTIFS_DOMAINS`; a malformed, non-`wss`, or non-allow-listed URL is rejected with an error and no socket is opened. | A server-controlled subscribe response could otherwise direct the realtime connection to an untrusted or non-secure endpoint. | `src/services/core/websocket/WebSocketManager.ts`, `src/services/core/constants.ts` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | The allow-list is a fixed domain set; subdomain matching is exact suffix matching on the parsed hostname. | PRESENT |
 
 ## Design Overview
 Core separates four responsibilities:
 
 1. `WebexRequest` wraps the authenticated host request API and service-catalog routing.
-2. `WebSocketManager` registers a subscription using both `body` and `resource`, connects the socket, owns the keepalive worker, and emits raw messages/socket lifecycle events.
+2. `WebSocketManager` registers a subscription using both `body` and `resource`, validates the returned `webSocketUrl` against the `ALLOWED_ROUTING_NOTIFS_DOMAINS` allow-list before connecting the socket, owns the keepalive worker, and emits raw messages/socket lifecycle events.
 3. `AqmReqs` registers bind matchers on the primary WebSocket, sends HTTP through WebexRequest, and settles requests only from matching notifications, HTTP failure, or timeout.
 4. `ConnectionService` observes message/socket liveness, emits connection-state details, and retries socket initialization. ContactCenter listens to those details and owns optional silent relogin.
 
@@ -294,7 +295,7 @@ const setState = aqmReqs.req((p: {data: Agent.StateChange}) => ({
 await setState({data: stateChangePayload});
 ```
 
-`CLOSE_SOCKET_TIMEOUT` is 16000 ms. `CONNECTIVITY_CHECK_INTERVAL` drives reconnect attempts separately. `TIMEOUT_REQ` is the 20000 ms default AQM timeout; `WEBSOCKET_EVENT_TIMEOUT` is not the active AqmReqs default. A request configuration may set internal `redactSensitiveLogs: true`; this changes only routing-failure and timeout diagnostics, not correlation, errors, timing, or cleanup.
+`CLOSE_SOCKET_TIMEOUT` is 16000 ms. `CONNECTIVITY_CHECK_INTERVAL` drives reconnect attempts separately. `TIMEOUT_REQ` is the 20000 ms default AQM timeout; `WEBSOCKET_EVENT_TIMEOUT` is not the active AqmReqs default. Routing-failure diagnostics are always redacted to a fixed message that omits the raw payload and error. A request configuration may additionally set internal `redactSensitiveLogs: true` to redact timeout diagnostics (request URL, bind key, and response); neither redaction changes correlation, errors, timing, or cleanup.
 
 ## Data Flow
 ```mermaid
@@ -365,12 +366,17 @@ sequenceDiagram
   Caller->>WSM: initWebSocket({body, resource})
   WSM->>Host: register(body, resource)
   Host-->>WSM: WebSocket URL/subscription
-  WSM->>WS: connect()
-  alt welcome
-    WS-->>WSM: Welcome event
-    WSM-->>Caller: WelcomeResponse
-  else register/connect failure
-    WSM-->>Caller: throw error
+  WSM->>WSM: validate webSocketUrl against wss + allow-list
+  alt allow-listed wss URL
+    WSM->>WS: connect()
+    alt welcome
+      WS-->>WSM: Welcome event
+      WSM-->>Caller: WelcomeResponse
+    else connect failure
+      WSM-->>Caller: throw error
+    end
+  else malformed / non-wss / non-allow-listed URL
+    WSM-->>Caller: throw error (no socket opened)
   end
 ```
 
@@ -448,6 +454,8 @@ WebSocketManager owns socket/welcome/worker state. AqmReqs owns pending success/
 
 ## Business Rules & Invariants
 - Core must preserve its typed public/event contracts and must not invent backend states or responses. Enforced in `src/services/core/WebexRequest.ts`.
+- A subscribe/register `webSocketUrl` is trusted only when it is a `wss` URL on the `ALLOWED_ROUTING_NOTIFS_DOMAINS` allow-list; otherwise `WebSocketManager` throws and never opens a socket. Enforced in `src/services/core/websocket/WebSocketManager.ts`.
+- AQM routing-failure logs never contain the raw routing payload or error verbatim. Enforced in `src/services/core/aqm-reqs.ts`.
 - Rollout applicability is N/A for Core: keepalive, timeout, and reconnect constants control behavior, while Services constructs Core without a feature gate.
 
 ## Concurrency & Reactive Flow
@@ -468,7 +476,7 @@ stateDiagram-v2
 ```
 
 ## Protocol / Wire Format
-`WebSocketManager.initWebSocket` accepts `{body: SubscribeRequest, resource: string}`. Subscription uses the host Webex request API; AqmReqs operational HTTP uses the WebexRequest wrapper. AQM request configs carry `host`, `url`, optional `method`/`data`, `notifSuccess.bind`, optional `notifFail.bind`, optional cancel bind, and optional timeout. HTTP acknowledgement never substitutes for the matching WebSocket operation result.
+`WebSocketManager.initWebSocket` accepts `{body: SubscribeRequest, resource: string}`. Subscription uses the host Webex request API; the returned `webSocketUrl` must be a `wss` URL on the `ALLOWED_ROUTING_NOTIFS_DOMAINS` allow-list or the socket is not opened. AqmReqs operational HTTP uses the WebexRequest wrapper. AQM request configs carry `host`, `url`, optional `method`/`data`, `notifSuccess.bind`, optional `notifFail.bind`, optional cancel bind, and optional timeout. HTTP acknowledgement never substitutes for the matching WebSocket operation result.
 
 ## Error Handling & Failure Modes
 | Condition | Signal (error/code/result) | Caller recovery |
@@ -712,7 +720,8 @@ export const generateTaskErrorObject = (
 ## Pitfalls
 - `initWebSocket` requires both `body` and `resource`; omitting `resource` registers against no durable subscription endpoint.
 - AqmReqs installs notification binds before HTTP and never resolves from acknowledgement; duplicate binds, timeout, and cleanup ordering are correctness-critical.
-- Sensitive AQM configurations must use the opt-in redaction flag so dynamic URLs and raw routing messages are not included in timeout/failure logs.
+- AQM routing-failure logs are always redacted; sensitive AQM configurations must also use the opt-in `redactSensitiveLogs` flag so dynamic URLs and responses are not included in timeout logs.
+- Do not open the WebSocket directly from a subscribe/register response; the `webSocketUrl` must first pass `wss` scheme and allow-listed host validation.
 - Keepalive closure (16 seconds), lost-connection detection (8 seconds), reconnect interval (5 seconds), and recovery timeout (50 seconds) are separate controls and must not be conflated.
 
 ## Module Do's / Don'ts
@@ -751,6 +760,7 @@ Unit tests mirror module paths under `test/unit/spec/services/core`. Preserve po
 | `CORE-R-005` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | Keep timer-value assertions synchronized with constants. |
 | `CORE-R-006` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | Feature-gate absence is verified from construction/source rather than a dedicated negative test. |
 | `CORE-R-007` | `test/unit/spec/services/core/aqm-reqs.ts` | None. |
+| `CORE-R-008` | `test/unit/spec/services/core/websocket/WebSocketManager.ts` | None. |
 
 ## Traceability
 - Repo architecture: `../../../../ai-docs/ARCHITECTURE.md` · Registry: `../../../../ai-docs/SPEC_INDEX.md`

--- a/packages/@webex/contact-center/src/services/core/aqm-reqs.ts
+++ b/packages/@webex/contact-center/src/services/core/aqm-reqs.ts
@@ -119,21 +119,12 @@ export default class AqmReqs {
             if ('errId' in notifFail) {
               const error = new Err.Details(notifFail.errId, msg as any);
 
-              if (c.redactSensitiveLogs) {
-                LoggerProxy.log('Routing request failed (sensitive details redacted)', {
-                  module: AQM_REQS_FILE,
-                  method: METHODS.CREATE_PROMISE,
-                });
-              } else {
-                LoggerProxy.log(`Routing request failed: ${JSON.stringify(msg)}`, {
-                  module: AQM_REQS_FILE,
-                  method: METHODS.CREATE_PROMISE,
-                });
-                LoggerProxy.log(`Routing request failed: ${error}`, {
-                  module: AQM_REQS_FILE,
-                  method: METHODS.CREATE_PROMISE,
-                });
-              }
+              // The raw routing-failure payload/error is never logged verbatim; only a
+              // redacted, non-sensitive diagnostic is emitted regardless of redactSensitiveLogs.
+              LoggerProxy.log('Routing request failed (sensitive details redacted)', {
+                module: AQM_REQS_FILE,
+                method: METHODS.CREATE_PROMISE,
+              });
               reject(error);
             } else {
               reject(notifFail.err(msg as any));

--- a/packages/@webex/contact-center/src/services/core/constants.ts
+++ b/packages/@webex/contact-center/src/services/core/constants.ts
@@ -80,6 +80,14 @@ export const PARTICIPANT_TYPES = {
 /** Interaction state for consultation */
 export const STATE_CONSULT = 'consult';
 
+/**
+ * Trusted domains for the RoutingNotifs WebSocket connection. A `webSocketUrl` returned by the
+ * subscribe/register API is only opened when its hostname matches one of these domains exactly
+ * or is a subdomain of one of them.
+ * @ignore
+ */
+export const ALLOWED_ROUTING_NOTIFS_DOMAINS = ['cisco.com', 'ciscoccservice.com'];
+
 // Method names for core services
 export const METHODS = {
   // WebexRequest methods

--- a/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
@@ -5,7 +5,12 @@ import {ConnectionLostDetails} from './types';
 import {CC_EVENTS, SubscribeResponse, WelcomeResponse} from '../../config/types';
 import LoggerProxy from '../../../logger-proxy';
 import workerScript from './keepalive.worker';
-import {KEEPALIVE_WORKER_INTERVAL, CLOSE_SOCKET_TIMEOUT, METHODS} from '../constants';
+import {
+  KEEPALIVE_WORKER_INTERVAL,
+  CLOSE_SOCKET_TIMEOUT,
+  METHODS,
+  ALLOWED_ROUTING_NOTIFS_DOMAINS,
+} from '../constants';
 import {WEB_SOCKET_MANAGER_FILE} from '../../../constants';
 
 /**
@@ -87,6 +92,36 @@ export class WebSocketManager extends EventEmitter {
     this.isConnectionLost = event.isConnectionLost;
   }
 
+  /**
+   * Determines whether a `webSocketUrl` returned by the subscribe/register API is safe to open.
+   * Only a `wss` URL whose hostname is, or is a subdomain of, one of the allow-listed
+   * RoutingNotifs domains is considered trusted.
+   * @param url - the candidate WebSocket URL
+   * @returns {boolean} true when the URL is a valid, allow-listed wss endpoint
+   * @private
+   */
+  private isAllowedWebSocketUrl(url: string | undefined | null): boolean {
+    if (!url) {
+      return false;
+    }
+
+    try {
+      const parsedUrl = new URL(url);
+
+      if (parsedUrl.protocol !== 'wss:') {
+        return false;
+      }
+
+      const hostname = parsedUrl.hostname.toLowerCase();
+
+      return ALLOWED_ROUTING_NOTIFS_DOMAINS.some(
+        (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
   private async register(connectionConfig: SubscribeRequest, resource: string) {
     try {
       // X-ORGANIZATION-ID header is only required for INT environments
@@ -107,7 +142,15 @@ export class WebSocketManager extends EventEmitter {
         body: connectionConfig,
         headers: isIntEnv && orgId ? {'X-ORGANIZATION-ID': orgId} : undefined,
       });
-      this.url = subscribeResponse.body.webSocketUrl;
+      const {webSocketUrl} = subscribeResponse.body;
+
+      if (!this.isAllowedWebSocketUrl(webSocketUrl)) {
+        throw new Error(
+          'Rejected webSocketUrl from RoutingNotifs registration: scheme or host not allow-listed'
+        );
+      }
+
+      this.url = webSocketUrl;
     } catch (e) {
       LoggerProxy.error(
         `Register API Failed, Request to RoutingNotifs websocket registration API failed ${e}`,

--- a/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
@@ -12,6 +12,7 @@ import {
   ALLOWED_ROUTING_NOTIFS_DOMAINS,
 } from '../constants';
 import {WEB_SOCKET_MANAGER_FILE} from '../../../constants';
+import {isAllowedUrlHost} from '../Utils';
 
 /**
  * WebSocketManager handles the WebSocket connection for Contact Center operations.
@@ -106,20 +107,14 @@ export class WebSocketManager extends EventEmitter {
     }
 
     try {
-      const parsedUrl = new URL(url);
-
-      if (parsedUrl.protocol !== 'wss:') {
+      if (new URL(url).protocol !== 'wss:') {
         return false;
       }
-
-      const hostname = parsedUrl.hostname.toLowerCase();
-
-      return ALLOWED_ROUTING_NOTIFS_DOMAINS.some(
-        (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
-      );
     } catch (error) {
       return false;
     }
+
+    return isAllowedUrlHost(url, ALLOWED_ROUTING_NOTIFS_DOMAINS);
   }
 
   private async register(connectionConfig: SubscribeRequest, resource: string) {

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -2930,6 +2930,27 @@ describe('webex.cc', () => {
       });
     });
 
+    it('does not emit an unknown server-controlled event type', () => {
+      const payload = {
+        type: 'UnhandledMessage',
+        data: {foo: 'bar', type: 'MaliciousInjectedType'},
+      };
+
+      messageCallback(JSON.stringify(payload));
+
+      expect(emitSpy).not.toHaveBeenCalledWith('MaliciousInjectedType', expect.anything());
+    });
+
+    it('emits a known agent event type verbatim from data.type', () => {
+      const sample = {foo: 'bar', type: CC_EVENTS.AGENT_STATE_CHANGE_SUCCESS};
+
+      messageCallback(
+        JSON.stringify({type: CC_EVENTS.AGENT_STATE_CHANGE_SUCCESS, data: sample})
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE_SUCCESS, sample);
+    });
+
     it('should call webCallingService.setLoginOption with correct deviceType on AGENT_STATION_LOGIN_SUCCESS', () => {
       const setLoginOptionSpy = jest.spyOn(webex.cc.webCallingService, 'setLoginOption');
       const deviceType = LoginOption.EXTENSION;

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -92,6 +92,39 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual(responseBody as any);
   });
 
+  it('rejects an invalid agentId/interactionId and does not call webex.request', async () => {
+    apiAIAssistant.setAIFeatureFlags({realtimeTranscripts: {enable: true}} as any);
+
+    await expect(
+      apiAIAssistant.fetchHistoricTranscripts('', 'interaction-1')
+    ).rejects.toBeDefined();
+    await expect(
+      apiAIAssistant.fetchHistoricTranscripts('test-agent-id', 'bad id!')
+    ).rejects.toBeDefined();
+
+    expect(mockWebex.request).not.toHaveBeenCalled();
+  });
+
+  it('sends the request for valid agentId/interactionId identifiers', async () => {
+    const responseBody = {interactionId: 'interaction-1', data: []};
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: responseBody});
+    apiAIAssistant.setAIFeatureFlags({realtimeTranscripts: {enable: true}} as any);
+
+    const result = await apiAIAssistant.fetchHistoricTranscripts('test-agent-id', 'interaction-1');
+
+    expect(mockWebex.request).toHaveBeenCalledWith({
+      uri: 'https://api-ai-assistant.produs1.ciscoccservice.com/transcripts/list',
+      method: HTTP_METHODS.POST,
+      addAuthHeader: true,
+      body: {
+        agentId: 'test-agent-id',
+        orgId: 'test-org-id',
+        interactionId: 'interaction-1',
+      },
+    });
+    expect(result).toEqual(responseBody as any);
+  });
+
   it('should request real-time assistance without extra context using sendEvent', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -105,26 +105,6 @@ describe('ApiAIAssistant', () => {
     expect(mockWebex.request).not.toHaveBeenCalled();
   });
 
-  it('sends the request for valid agentId/interactionId identifiers', async () => {
-    const responseBody = {interactionId: 'interaction-1', data: []};
-    (mockWebex.request as jest.Mock).mockResolvedValue({body: responseBody});
-    apiAIAssistant.setAIFeatureFlags({realtimeTranscripts: {enable: true}} as any);
-
-    const result = await apiAIAssistant.fetchHistoricTranscripts('test-agent-id', 'interaction-1');
-
-    expect(mockWebex.request).toHaveBeenCalledWith({
-      uri: 'https://api-ai-assistant.produs1.ciscoccservice.com/transcripts/list',
-      method: HTTP_METHODS.POST,
-      addAuthHeader: true,
-      body: {
-        agentId: 'test-agent-id',
-        orgId: 'test-org-id',
-        interactionId: 'interaction-1',
-      },
-    });
-    expect(result).toEqual(responseBody as any);
-  });
-
   it('should request real-time assistance without extra context using sendEvent', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);

--- a/packages/@webex/contact-center/test/unit/spec/services/WebCallingService.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/WebCallingService.ts
@@ -198,6 +198,44 @@ describe('WebCallingService', () => {
 
     });
 
+    it('should fall back to default domain for a non-allow-listed catalog RTMS host', async () => {
+      webex.internal.services.get.mockReturnValue('wss://evil.attacker.com');
+
+      line = callingClient.getLines().line1 as ILine;
+      const deviceInfo = {
+        mobiusDeviceId: 'device123',
+        status: 'registered',
+        setError: jest.fn(),
+        getError: jest.fn(),
+        type: 'line',
+        id: 'line1',
+      };
+
+      const registeredHandler = jest.fn();
+      const lineOnSpy = jest.spyOn(line, 'on').mockImplementation((event, handler) => {
+        if (event === LINE_EVENTS.REGISTERED) {
+          registeredHandler.mockImplementation(handler);
+          handler(deviceInfo);
+        }
+      });
+      await expect(webRTCCalling.registerWebCallingLine()).resolves.toBeUndefined();
+      expect(createClient).toHaveBeenCalledWith(webex, {
+        logger: {
+          level: 'info',
+        },
+        serviceData: {
+          indicator: 'contactcenter',
+          domain: 'rtw.prod-us1.rtmsprod.net',
+        },
+      });
+      expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
+      expect(line.register).toHaveBeenCalled();
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'Non-allow-listed RTMS host from u2c catalogue: evil.attacker.com so falling back to default domain',
+        {module: WEB_CALLING_SERVICE_FILE, method: 'getRTMSDomain'}
+      );
+    });
+
     it('should reject if registration times out', async () => {
       line = callingClient.getLines().line1 as ILine;
       jest.spyOn(global, 'setTimeout').mockImplementation(((handler: TimerHandler) => {

--- a/packages/@webex/contact-center/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/Utils.ts
@@ -1036,4 +1036,26 @@ describe('Utils', () => {
     });
   });
 
+  describe('isAllowedUrlHost', () => {
+    it('returns true when the hostname exactly matches an allowed domain', () => {
+      expect(Utils.isAllowedUrlHost('wss://cisco.com', ['cisco.com'])).toBe(true);
+    });
+
+    it('returns true when the hostname is a subdomain of an allowed domain', () => {
+      expect(Utils.isAllowedUrlHost('wss://notifs.wxcc-us1.cisco.com', ['cisco.com'])).toBe(true);
+    });
+
+    it('returns false when the hostname is not in the allowed domains list', () => {
+      expect(Utils.isAllowedUrlHost('wss://evil.attacker.com', ['cisco.com'])).toBe(false);
+    });
+
+    it('returns false for an unparsable url', () => {
+      expect(Utils.isAllowedUrlHost('not-a-url', ['cisco.com'])).toBe(false);
+    });
+
+    it('returns false for a null/undefined url', () => {
+      expect(Utils.isAllowedUrlHost(null as any, ['cisco.com'])).toBe(false);
+      expect(Utils.isAllowedUrlHost(undefined as any, ['cisco.com'])).toBe(false);
+    });
+  });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/core/aqm-reqs.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/aqm-reqs.ts
@@ -610,6 +610,35 @@ describe('AqmReqs', () => {
       expect(aqm['pendingRequests']).toEqual({});
     });
 
+    it('never logs the raw routing-failure payload even when redactSensitiveLogs is not set', async () => {
+      const participantId = '+1/plain-failure-secret';
+      webexRequestInstance.request.mockResolvedValueOnce(mockWebexRequestResolvedValue);
+      const conf = {
+        ...participantDropConfig(participantId, 'disabled'),
+        redactSensitiveLogs: false,
+      };
+      const promise = aqm['createPromise'](conf);
+
+      webSocketManagerInstance.emit(
+        'message',
+        JSON.stringify({
+          type: 'RoutingMessage',
+          data: {type: 'ParticipantDropConferenceFailed', participantId},
+        })
+      );
+
+      await expect(promise).rejects.toBeDefined();
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        'Routing request failed (sensitive details redacted)',
+        expect.objectContaining({module: AQM_REQS_FILE})
+      );
+
+      const loggedCalls = JSON.stringify((LoggerProxy.log as jest.Mock).mock.calls);
+      expect(loggedCalls).not.toContain(participantId);
+      expect(loggedCalls).not.toContain('ParticipantDropConferenceFailed');
+      expect(aqm['pendingRequests']).toEqual({});
+    });
+
     it('resolves a correlated participant-left event and clears its binds', async () => {
       jest.useFakeTimers();
       (global.window as any).setTimeout = global.setTimeout;

--- a/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
@@ -94,7 +94,9 @@ describe('WebSocketManager', () => {
     };
 
     global.Worker = jest.fn(() => mockWorker) as any;
-    global.WebSocket = MockWebSocket as any;
+    global.WebSocket = jest.fn(function (this: any, ...args: any[]) {
+      return new MockWebSocket(...(args as []));
+    }) as any;
 
     global.Blob = function (content: any[], options: any) {
       return {content, options};
@@ -119,10 +121,58 @@ describe('WebSocketManager', () => {
     expect(webSocketManager).toBeDefined();
   });
 
+  describe('webSocketUrl validation', () => {
+    it('rejects a non-wss webSocketUrl and does not construct a socket', async () => {
+      const subscribeResponse = {
+        body: {
+          webSocketUrl: 'http://fake-url.cisco.com',
+        },
+      };
+
+      (mockWebex.request as jest.Mock).mockResolvedValueOnce(subscribeResponse);
+
+      await expect(
+        webSocketManager.initWebSocket({body: fakeSubscribeRequest, resource: SUBSCRIBE_API})
+      ).rejects.toBeDefined();
+
+      expect(global.WebSocket).not.toHaveBeenCalled();
+    });
+
+    it('rejects a wss webSocketUrl with a non-allow-listed host and does not construct a socket', async () => {
+      const subscribeResponse = {
+        body: {
+          webSocketUrl: 'wss://evil.attacker.com',
+        },
+      };
+
+      (mockWebex.request as jest.Mock).mockResolvedValueOnce(subscribeResponse);
+
+      await expect(
+        webSocketManager.initWebSocket({body: fakeSubscribeRequest, resource: SUBSCRIBE_API})
+      ).rejects.toBeDefined();
+
+      expect(global.WebSocket).not.toHaveBeenCalled();
+    });
+
+    it('connects for a valid wss allow-listed webSocketUrl', async () => {
+      const subscribeResponse = {
+        body: {
+          webSocketUrl: 'wss://notifs.wxcc-us1.cisco.com',
+        },
+      };
+
+      (mockWebex.request as jest.Mock).mockResolvedValueOnce(subscribeResponse);
+
+      await webSocketManager.initWebSocket({body: fakeSubscribeRequest, resource: SUBSCRIBE_API});
+
+      expect(global.WebSocket).toHaveBeenCalledWith('wss://notifs.wxcc-us1.cisco.com');
+    });
+  });
+
   it('should register and connect to WebSocket with X-ORGANIZATION-ID header for INT environment', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -144,7 +194,7 @@ describe('WebSocketManager', () => {
   it('should connect rtd websocket', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -167,7 +217,7 @@ describe('WebSocketManager', () => {
 it('should register and connect to WebSocket without X-ORGANIZATION-ID header for production environment', async () => {
   const subscribeResponse = {
     body: {
-      webSocketUrl: 'wss://fake-url',
+      webSocketUrl: 'wss://fake-url.cisco.com',
     },
   };
     // Mock production environment (services.isIntegrationEnvironment returns false)
@@ -196,7 +246,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should not send X-ORGANIZATION-ID header when services.isIntegrationEnvironment is not available', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -245,7 +295,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should close WebSocket connection', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -262,7 +312,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket keepalive messages', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -286,7 +336,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket close due to network issue', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -333,7 +383,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket error event', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -353,7 +403,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket message event with AGENT_MULTI_LOGIN', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -376,7 +426,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket message event with Welcome', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -395,7 +445,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket close with forceCloseWebSocketOnTimeout', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -430,7 +480,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket close without reconnect', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 
@@ -460,7 +510,7 @@ it('should register and connect to WebSocket without X-ORGANIZATION-ID header fo
   it('should handle WebSocket close with clean close', async () => {
     const subscribeResponse = {
       body: {
-        webSocketUrl: 'wss://fake-url',
+        webSocketUrl: 'wss://fake-url.cisco.com',
       },
     };
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-845583

## This pull request addresses

[SecScan][contact-center][P0] Remediate 5 high-severity SecScan findings in `packages/@webex/contact-center`. Five untrusted/remote-controlled inputs crossed Contact Center trust boundaries without validation, allow-listing, or redaction:

- An unvalidated subscribe `webSocketUrl` was opened directly as a WebSocket connection.
- A server-controlled websocket `event.data.type` was re-emitted verbatim as an SDK event name.
- A catalog-provided RTMS hostname was trusted without an allow-list.
- Caller-supplied `agentId`/`interactionId` were forwarded into a transcript-fetch request without validation.
- Raw routing-failure payloads/errors were logged verbatim unless the opt-in `redactSensitiveLogs` flag was set.

## by making the following changes

**Root Cause:**
Several Contact Center trust boundaries (WebSocket URL from the subscribe response, websocket event type, catalog RTMS host, caller-supplied identifiers, and routing-failure diagnostics) accepted untrusted or externally-controlled values and used them directly to open sockets, emit events, build requests, or write logs, without validating, allow-listing, or redacting them first.

**Fix:**
- Validate the `wss` scheme and an allow-listed RoutingNotifs host before assigning `WebSocketManager.url` / opening the socket; reject malformed/non-allowed URLs with a typed error and open no socket.
- Gate `ContactCenter.handleWebsocketMessage`'s `emit` on a typed `CC_EVENTS`/`CC_AGENT_EVENTS` allow-list so only known event names are re-emitted.
- Validate `WebCallingService.getRTMSDomain`'s parsed hostname against an RTMS allow-list; fall back to `DEFAULT_RTMS_DOMAIN` for non-allow-listed hosts (parse-failure fallback unchanged).
- Validate `agentId`/`interactionId` in `ApiAiAssistant.fetchHistoricTranscripts` before constructing the request; reject invalid input with a typed error and send no request.
- Remove verbatim payload/error logging in `AqmReqs`'s `notifFail` routing-failure branch so raw routing-failure data is never logged, regardless of `redactSensitiveLogs`; keep a redacted diagnostic log and existing rejection/cleanup semantics.
- Spec Sync: updated `core-spec.md` (CORE-R-007), `services-spec.md`, and `contact-center-spec.md` to document the now-unconditional redaction and the new allow-list/validation behaviors.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- 9 targeted unit tests added (RED) across the 5 affected modules and their existing suites re-run (GREEN + targeted regression): 182 tests passed / 0 failed in the affected suites. See `## Testing` below for full gate status, since Gate 1/Gate 2 were not run by this workflow's canonical verification gates.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [x] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

## Changes

- `packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts` — validate `wss` scheme + allow-listed host before opening the socket
- `packages/@webex/contact-center/src/services/core/constants.ts` — new `ALLOWED_ROUTING_NOTIFS_DOMAINS`
- `packages/@webex/contact-center/src/cc.ts` — typed `CC_EVENTS` allow-list gate on `handleWebsocketMessage` emit
- `packages/@webex/contact-center/src/services/WebCallingService.ts` — RTMS host allow-list in `getRTMSDomain`
- `packages/@webex/contact-center/src/services/constants.ts` — new `ALLOWED_RTMS_DOMAIN`
- `packages/@webex/contact-center/src/services/ApiAiAssistant.ts` — `agentId`/`interactionId` validation in `fetchHistoricTranscripts`
- `packages/@webex/contact-center/src/services/core/aqm-reqs.ts` — unconditional redaction of raw routing-failure logs in `notifFail`
- `packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts`
- `packages/@webex/contact-center/test/unit/spec/cc.ts`
- `packages/@webex/contact-center/test/unit/spec/services/WebCallingService.ts`
- `packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts`
- `packages/@webex/contact-center/test/unit/spec/services/core/aqm-reqs.ts`
- `packages/@webex/contact-center/src/services/core/ai-docs/core-spec.md` — CORE-R-007 Spec Sync
- `packages/@webex/contact-center/src/services/ai-docs/services-spec.md` — Spec Sync
- `packages/@webex/contact-center/ai-docs/contact-center-spec.md` — Spec Sync

## Testing

- Tests added: 9
- Gate 1 verification: SKIPPED — `skipped-missing-command` — Gate 1 was not run because no applicable manifest declares `commands.compile`.
- Gate 2 verification: SKIPPED — `skipped-missing-command` — Gate 2 was not run because no applicable manifest declares `commands.unit-test`.
- Gate 3 verification: not run
- Draft warning: Gate 1 and Gate 2 canonical verification were skipped (`skipped-missing-command`); this PR is left in draft pending human verification of build/test status before merge. Targeted `yarn jest` runs recorded in the Fix step (5 suites, 182 tests passed, 0 failed) are informal Fix-step evidence only and do not substitute for the canonical gates.
- Coverage outcome: skipped because role coverage-check is absent

## Verification limitations

- Gate 1 compile: SKIPPED — skipped-missing-command — Gate 1 was not run because no applicable manifest declares `commands.compile`.
- Gate 2 unit tests: SKIPPED — skipped-missing-command — Gate 2 was not run because no applicable manifest declares `commands.unit-test`.

## Contract Discovery Warnings

- Manifest reference discovery capped at 100 strings

## Acceptance Criteria

| ID | Criterion | Source | JiraToPr status | Evidence |
|---|---|---|---|---|
| AC-1 | The Contact Center WebSocket connection is only opened for a validated subscribe `webSocketUrl` (`wss` scheme and expected/allow-listed host); a malformed or non-allowed URL is rejected with a typed error and no socket is opened. | Jira/Implementation Plan TASK-1 | Not validated — Gate 2 skipped (`skipped-missing-command`) | Fix-step targeted `yarn jest` run reports pass, but canonical Gate 2 did not run; external validation also required (see below). |
| AC-2 | `cc.handleWebsocketMessage` only emits application event names that belong to the typed `CC_EVENTS`/`AGENT_EVENTS` allow-list; a server-controlled `eventData.data.type` that is not a known constant is not emitted as an event name. | Jira/Implementation Plan TASK-2 | Not validated — Gate 2 skipped (`skipped-missing-command`) | Fix-step targeted `yarn jest` run reports pass, but canonical Gate 2 did not run. |
| AC-3 | `WebCallingService.getRTMSDomain` returns a host only when it is on the RTMS domain allow-list; a parseable but non-allow-listed catalog host falls back to `DEFAULT_RTMS_DOMAIN` instead of being trusted. | Jira/Implementation Plan TASK-3 | Not validated — Gate 2 skipped (`skipped-missing-command`) | Fix-step targeted `yarn jest` run reports pass, but canonical Gate 2 did not run; external validation also required (see below). |
| AC-4 | `ApiAiAssistant.fetchHistoricTranscripts` validates caller-supplied `agentId` and `interactionId` (non-empty, expected identifier format) before constructing the authenticated request; invalid inputs are rejected with a typed error and no request is sent. | Jira/Implementation Plan TASK-4 | Not validated — Gate 2 skipped (`skipped-missing-command`) | Fix-step targeted `yarn jest` run reports pass, but canonical Gate 2 did not run. |
| AC-5 | The AQM routing-failure log path never emits the raw routing message payload or raw error verbatim; PII-bearing routing failures are logged only as redacted, non-sensitive diagnostics, and CORE-R-007 is updated to reflect this behavior. | Jira/Implementation Plan TASK-5 | Not validated — Gate 2 skipped (`skipped-missing-command`) | Fix-step targeted `yarn jest` run reports pass, and the CORE-R-007 spec update was applied in the Spec Sync commit; canonical Gate 2 did not run. |

## External Validation Required

- **AC-1 — Contact Center WebSocket connection only opens for a validated subscribe `webSocketUrl`.**
  - Reason: `external-validation-required`
  - Details: Any string returned as `subscribeResponse.body.webSocketUrl` is opened as a WebSocket connection; only a `wss` URL with an expected/allow-listed host should be opened. The allow-listed host set must be confirmed against production RoutingNotifs endpoints — this was not independently validated by JiraToPr.
  - Source: Triage boundary requirement (security-policy, external) — WCC subscribe/RoutingNotifs service (`webSocketUrl`); `packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts`
- **AC-3 — `WebCallingService.getRTMSDomain` returns a host only when allow-listed.**
  - Reason: `external-validation-required`
  - Details: Any parseable catalog URL hostname was previously used as the WebRTC RTMS domain. The allow-list must include the legitimate catalog-provided RTMS domain(s) — this was not independently validated by JiraToPr.
  - Source: Triage boundary requirement (security-policy, external) — u2c service catalog (`WCC_CALLING_RTMS_DOMAIN`); `packages/@webex/contact-center/src/services/WebCallingService.ts`

## AI Assistance

- [x] Code was generated entirely by GAI / GAI-assisted / Manual
- Tool: Other (JiraToPr automation)

---
Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-845583

