### PR TITLE
feat(internal-plugin-metrics): report client model number

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -299,6 +299,9 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     const {
       browser: providedBrowser,
       browserVersion: providedBrowserVersion,
+      os: providedOs,
+      osVersion: providedOsVersion,
+      deviceFormFactor,
       isSupportedBrowserFamily,
       isOutdatedBrowserVersion,
       // @ts-ignore
@@ -341,11 +344,12 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
                 ?.get(meetingId)
                 ?.statsAnalyzer?.getLocalIpAddress()
             ) || undefined,
-          osVersion: getOSVersion() || 'unknown',
+          osVersion: providedOsVersion || getOSVersion() || 'unknown',
           subClientType: options?.subClientType || defaultSubClientType,
-          os: getOSNameInternal(),
+          os: providedOs || getOSNameInternal(),
           browser: providedBrowser || getBrowserName(),
           browserVersion: providedBrowserVersion || getBrowserVersion(),
+          ...(deviceFormFactor === undefined ? {} : {deviceFormFactor}),
           ...(isSupportedBrowserFamily === undefined ? {} : {isSupportedBrowserFamily}),
           ...(isOutdatedBrowserVersion === undefined ? {} : {isOutdatedBrowserVersion}),
         },

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -301,7 +301,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       browserVersion: providedBrowserVersion,
       os: providedOs,
       osVersion: providedOsVersion,
-      deviceFormFactor,
+      modelNumber,
       isSupportedBrowserFamily,
       isOutdatedBrowserVersion,
       // @ts-ignore
@@ -349,7 +349,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           os: providedOs || getOSNameInternal(),
           browser: providedBrowser || getBrowserName(),
           browserVersion: providedBrowserVersion || getBrowserVersion(),
-          ...(deviceFormFactor === undefined ? {} : {deviceFormFactor}),
+          ...(modelNumber === undefined ? {} : {modelNumber}),
           ...(isSupportedBrowserFamily === undefined ? {} : {isSupportedBrowserFamily}),
           ...(isOutdatedBrowserVersion === undefined ? {} : {isOutdatedBrowserVersion}),
         },

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -440,7 +440,7 @@ describe('internal-plugin-metrics', () => {
       it('builds origin with device details provided by the host client', () => {
         webex.meetings.config.metrics.os = 'ios';
         webex.meetings.config.metrics.osVersion = '17.6';
-        webex.meetings.config.metrics.deviceFormFactor = 'tablet';
+        webex.meetings.config.metrics.modelNumber = 'iPad';
 
         //@ts-ignore
         const res = cd.getOrigin(
@@ -450,10 +450,10 @@ describe('internal-plugin-metrics', () => {
 
         assert.equal(res.clientInfo.os, 'ios');
         assert.equal(res.clientInfo.osVersion, '17.6');
-        assert.equal(res.clientInfo.deviceFormFactor, 'tablet');
+        assert.equal(res.clientInfo.modelNumber, 'iPad');
       });
 
-      it('falls back to SDK OS detection and omits device form factor when the host provides nothing', () => {
+      it('falls back to SDK OS detection and omits model number when the host provides nothing', () => {
         //@ts-ignore
         const res = cd.getOrigin(
           {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
@@ -462,7 +462,7 @@ describe('internal-plugin-metrics', () => {
 
         assert.equal(res.clientInfo.os, getOSNameInternal());
         assert.equal(res.clientInfo.osVersion, getOSVersion() || 'unknown');
-        assert.notProperty(res.clientInfo, 'deviceFormFactor');
+        assert.notProperty(res.clientInfo, 'modelNumber');
       });
 
       it('builds origin correctly with the browser support flags from config', () => {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -437,6 +437,34 @@ describe('internal-plugin-metrics', () => {
         assert.equal(res.clientInfo.browserVersion, getBrowserVersion());
       });
 
+      it('builds origin with device details provided by the host client', () => {
+        webex.meetings.config.metrics.os = 'ios';
+        webex.meetings.config.metrics.osVersion = '17.6';
+        webex.meetings.config.metrics.deviceFormFactor = 'tablet';
+
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.equal(res.clientInfo.os, 'ios');
+        assert.equal(res.clientInfo.osVersion, '17.6');
+        assert.equal(res.clientInfo.deviceFormFactor, 'tablet');
+      });
+
+      it('falls back to SDK OS detection and omits device form factor when the host provides nothing', () => {
+        //@ts-ignore
+        const res = cd.getOrigin(
+          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT'},
+          fakeMeeting.id
+        );
+
+        assert.equal(res.clientInfo.os, getOSNameInternal());
+        assert.equal(res.clientInfo.osVersion, getOSVersion() || 'unknown');
+        assert.notProperty(res.clientInfo, 'deviceFormFactor');
+      });
+
       it('builds origin correctly with the browser support flags from config', () => {
         // `false` is the meaningful "unsupported family" signal, so it must survive a truthy check
         webex.meetings.config.metrics.isSupportedBrowserFamily = false;


### PR DESCRIPTION
# COMPLETES #N/A — requested Call Analyzer telemetry enhancement

## This pull request addresses

Web clients can identify tablet hardware, but the SDK does not currently copy host-provided OS and model details into Call Analyzer client information.

## by making the following changes

- Accept host-provided `os`, `osVersion`, and `modelNumber` meeting metrics.
- Copy `modelNumber` into `origin.clientInfo` when supplied by the host.
- Preserve the existing SDK OS detection and omit `modelNumber` for clients that do not provide it.
- Reuse the existing Event Dictionary `ClientInfo.modelNumber` field; no schema change is required.

Consumer: [webex-web-client #11968](https://github.com/WebexServices/webex-web-client/pull/11968).

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/internal-plugin-metrics build:src` — passed.
- `yarn workspace @webex/internal-plugin-metrics test:unit --targets call-diagnostic/call-diagnostic-metrics.ts` — 170 passing, including host-provided `modelNumber` and fallback/omission coverage.
- Package-wide unit run — the changed call-diagnostic tests passed; 14 unrelated local environment failures remain where generic metrics tests access a missing `navigator.language`.
- Cross-repository web-client config tests — 145 passing for standard iPad, desktop-mode iPad, Android tablet, iPhone, and Windows desktop identities.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Codex
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any applicable automated checks
- [ ] All existing and new package tests passed
- [ ] I have updated the documentation accordingly

---
> ⚠️ AI Assisted Content 🤖
