### PR TITLE
fix(calling): remove the DefaultLocalId from callId for delete

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -276,9 +276,10 @@ describe('Call Tests', () => {
     expect(parseMediaQualityStatisticsMock).toHaveBeenCalledTimes(1);
     expect(webex.request.mock.calls[0][0].body.metrics).toStrictEqual(disconnectStats);
     expect(webex.request.mock.calls[0][0].body.callId).toBe(
-      call.getCallId().replace(DEFAULT_LOCAL_CALL_ID, '')
+      call.getCallId().replace(`${DEFAULT_LOCAL_CALL_ID}_`, '')
     );
     expect(webex.request.mock.calls[0][0].body.callId).not.toContain(DEFAULT_LOCAL_CALL_ID);
+    expect(webex.request.mock.calls[0][0].body.callId).not.toMatch(/^_/);
     expect(call.getDisconnectReason().code).toBe(DisconnectCode.NORMAL);
     expect(call.getDisconnectReason().cause).toBe(DisconnectCause.NORMAL);
 

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -7,6 +7,7 @@ import {ERROR_TYPE, ERROR_LAYER} from '../../Errors/types';
 import * as Utils from '../../common/Utils';
 import {CALL_EVENT_KEYS, CallEvent, RoapEvent, RoapMessage} from '../../Events/types';
 import {
+  DEFAULT_LOCAL_CALL_ID,
   DEFAULT_SESSION_TIMER,
   ICE_CANDIDATES_TIMEOUT,
   ICE_LITE_CANDIDATES_TIMEOUT,
@@ -274,6 +275,10 @@ describe('Call Tests', () => {
     await waitForMsecs(50); // Need to add a small delay for Promise and callback to finish.
     expect(parseMediaQualityStatisticsMock).toHaveBeenCalledTimes(1);
     expect(webex.request.mock.calls[0][0].body.metrics).toStrictEqual(disconnectStats);
+    expect(webex.request.mock.calls[0][0].body.callId).toBe(
+      call.getCallId().replace(DEFAULT_LOCAL_CALL_ID, '')
+    );
+    expect(webex.request.mock.calls[0][0].body.callId).not.toContain(DEFAULT_LOCAL_CALL_ID);
     expect(call.getDisconnectReason().code).toBe(DisconnectCode.NORMAL);
     expect(call.getDisconnectReason().cause).toBe(DisconnectCause.NORMAL);
 
@@ -309,6 +314,29 @@ describe('Call Tests', () => {
     const response = await call['postMedia']({});
 
     expect(response.body).toStrictEqual(mediaResponse.body);
+  });
+
+  it('delete sends the server-assigned callId unchanged', async () => {
+    const serverCallId = '8a67806f-fc4d-446b-a131-31e71ea5b020';
+
+    webex.request.mockReturnValue({
+      statusCode: 200,
+      body: {
+        device: {
+          deviceId: '8a67806f-fc4d-446b-a131-31e71ea5b010',
+          correlationId: '8a67806f-fc4d-446b-a131-31e71ea5b011',
+        },
+        callId: serverCallId,
+      },
+    });
+
+    const call = callManager.createCall(CallDirection.OUTBOUND, deviceId, mockLineId, dest);
+
+    call.setCallId(serverCallId);
+    call.end();
+    await waitForMsecs(50);
+
+    expect(webex.request.mock.calls[0][0].body.callId).toBe(serverCallId);
   });
 
   it('check whether callerId midcall event is serviced or not', async () => {

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -3100,7 +3100,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           correlationId: this.correlationId,
         },
         callId: this.callId.includes(DEFAULT_LOCAL_CALL_ID)
-          ? this.callId.replace(DEFAULT_LOCAL_CALL_ID, '')
+          ? this.callId.replace(`${DEFAULT_LOCAL_CALL_ID}_`, '')
           : this.callId,
         metrics: disconnectMetrics,
         causecode: this.disconnectReason.code,

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -3099,7 +3099,9 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           deviceId: this.deviceId,
           correlationId: this.correlationId,
         },
-        callId: this.callId,
+        callId: this.callId.includes(DEFAULT_LOCAL_CALL_ID)
+          ? this.callId.replace(DEFAULT_LOCAL_CALL_ID, '')
+          : this.callId,
         metrics: disconnectMetrics,
         causecode: this.disconnectReason.code,
         cause: this.disconnectReason.cause,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-831494](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-831494) >

## This pull request addresses

Removes the DefaultLocalId from the callId while making delete api request

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Unit tests
- Tested manually by making call without registering the device. Getting the same result.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
