### PR TITLE
fix: get the userId from the token when device is not available

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -386,6 +386,20 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   }
 
   /**
+   * Returns the signed-in user's CI ID derived from credentials tokens.
+   * Used as a fallback when no device is registered.
+   * @returns the userId, or undefined if it can't be determined
+   */
+  private getUserIdFromCredentials(): string | undefined {
+    try {
+      // @ts-ignore
+      return this.webex.credentials.getUserId();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Gather identifier details for call diagnostic payload.
    * @throws Error if initialization fails.
    * @param options
@@ -429,7 +443,6 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       const {device} = this;
       const {installationId} = device?.config || {};
 
-      identifiers.userId = device?.userId || preLoginId;
       identifiers.deviceId = device?.url;
       identifiers.orgId = device?.orgId;
       // @ts-ignore
@@ -439,6 +452,10 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         identifiers.machineId = installationId;
       }
     }
+
+    // Prefer the device's userId, but fall back to the signed-in user's ID from
+    // credentials when no device is registered, then to the pre-login ID.
+    identifiers.userId = this.device?.userId || this.getUserIdFromCredentials() || preLoginId;
 
     if (meeting?.locusInfo?.fullState) {
       identifiers.locusUrl = meeting.locusUrl;

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -841,6 +841,60 @@ describe('internal-plugin-metrics', () => {
           userId: 'preLoginId',
         });
       });
+
+      it('should use the userId from credentials when no device userId is available', () => {
+        cd.device.userId = undefined;
+        webex.credentials.getUserId = sinon.stub().returns('credentials-user-id');
+
+        const res = cd.getIdentifiers({
+          correlationId: 'correlationId',
+        });
+
+        assert.deepEqual(res, {
+          correlationId: 'correlationId',
+          locusUrl: 'locus-url',
+          deviceId: 'deviceUrl',
+          orgId: 'orgId',
+          userId: 'credentials-user-id',
+        });
+      });
+
+      it('should prefer the device userId over the credentials userId', () => {
+        webex.credentials.getUserId = sinon.stub().returns('credentials-user-id');
+
+        const res = cd.getIdentifiers({
+          correlationId: 'correlationId',
+        });
+
+        assert.equal(res.userId, 'userId');
+        assert.notCalled(webex.credentials.getUserId);
+      });
+
+      it('should fall back to preLoginId when neither the device nor credentials provide a userId', () => {
+        cd.device.userId = undefined;
+        webex.credentials.getUserId = sinon.stub().throws(new Error('no user token available'));
+
+        const res = cd.getIdentifiers({
+          correlationId: 'correlationId',
+          preLoginId: 'preLoginId',
+        });
+
+        assert.equal(res.userId, 'preLoginId');
+      });
+    });
+
+    describe('#getUserIdFromCredentials', () => {
+      it('should return the userId from credentials', () => {
+        webex.credentials.getUserId = sinon.stub().returns('credentials-user-id');
+
+        assert.equal(cd.getUserIdFromCredentials(), 'credentials-user-id');
+      });
+
+      it('should return undefined when credentials cannot provide a userId', () => {
+        webex.credentials.getUserId = sinon.stub().throws(new Error('no user token available'));
+
+        assert.isUndefined(cd.getUserIdFromCredentials());
+      });
     });
 
     it('should prepare diagnostic event successfully', () => {

--- a/packages/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/@webex/webex-core/src/lib/credentials/credentials.js
@@ -213,6 +213,49 @@ const Credentials = WebexPlugin.extend({
   },
 
   /**
+   * Extract the CI user ID [cis_uuid] from a provided token.
+   *
+   * @private
+   * @param {string} token - The access token to extract the user ID from.
+   * @throws {Error} - If the token cannot be parsed or does not contain a user ID.
+   * @returns {string} - The CI user ID.
+   */
+  extractUserIdFromToken(token = '') {
+    // User tokens are JWT-like; the middle section holds a base64-encoded JSON payload.
+    const payload = JSON.parse(base64.decode(token.split('.')[1]));
+
+    if (!payload.cis_uuid) {
+      throw new Error('the provided token does not contain a user ID');
+    }
+
+    return payload.cis_uuid;
+  },
+
+  /**
+   * Get the CI user ID [cis_uuid] of the currently authenticated user.
+   *
+   * Checks the supertoken first, then falls back to any stored user tokens.
+   *
+   * @throws {Error} - If the user ID could not be determined from any token.
+   * @returns {string} - The CI user ID.
+   */
+  getUserId() {
+    const tokens = [this.supertoken, ...this.userTokens.models];
+
+    for (const token of tokens) {
+      if (token && token.access_token) {
+        try {
+          return this.extractUserIdFromToken(token.access_token);
+        } catch {
+          // token wasn't parseable or lacked a user ID; try the next one
+        }
+      }
+    }
+
+    throw new Error('could not extract the user ID from any available token');
+  },
+
+  /**
    * Generates a Third-Party Login URL pointing at IdBroker's
    * `/idb/ThirdPartyLogin` endpoint. Used by the social-provider sign-in
    * flow (Google / Microsoft / Apple / ...).

--- a/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
+++ b/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
@@ -7,7 +7,7 @@ import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import MockWebex from '@webex/test-helper-mock-webex';
 import {Credentials, Token, grantErrors} from '@webex/webex-core';
-import {inBrowser} from '@webex/common';
+import {inBrowser, base64} from '@webex/common';
 import FakeTimers from '@sinonjs/fake-timers';
 import {skipInBrowser} from '@webex/test-helper-mocha';
 import Logger from '@webex/plugin-logger';
@@ -504,6 +504,88 @@ describe('webex-core', () => {
 
       it('should throw when no token is provided', () =>
         expect(() => credentials.extractOrgIdFromUserToken()).toThrow());
+    });
+
+    describe('#extractUserIdFromToken()', () => {
+      let credentials;
+      let webex;
+
+      beforeEach(() => {
+        webex = new MockWebex();
+        credentials = new Credentials(undefined, {parent: webex});
+      });
+
+      const buildToken = (payload) =>
+        `header.${base64.toBase64Url(JSON.stringify(payload))}.signature`;
+
+      it('should return the cis_uuid from the provided token', () => {
+        const token = buildToken({cis_uuid: 'my-user-id'});
+
+        assert.equal(credentials.extractUserIdFromToken(token), 'my-user-id');
+      });
+
+      it('should throw if the token does not contain a cis_uuid', () => {
+        const token = buildToken({foo: 'bar'});
+
+        expect(() => credentials.extractUserIdFromToken(token)).toThrow(
+          'the provided token does not contain a user ID'
+        );
+      });
+
+      it('should throw when provided an unparseable token', () =>
+        expect(() => credentials.extractUserIdFromToken('not-a-valid-token')).toThrow());
+
+      it('should throw when no token is provided', () =>
+        expect(() => credentials.extractUserIdFromToken()).toThrow());
+    });
+
+    describe('#getUserId()', () => {
+      let credentials;
+      let webex;
+
+      const buildToken = (userId) =>
+        `header.${base64.toBase64Url(JSON.stringify({cis_uuid: userId}))}.signature`;
+
+      beforeEach(() => {
+        webex = new MockWebex();
+        credentials = new Credentials(undefined, {parent: webex});
+      });
+
+      it('should return the userId from the supertoken', () => {
+        credentials.supertoken = makeToken(webex, {
+          access_token: buildToken('supertoken-user-id'),
+        });
+
+        assert.equal(credentials.getUserId(), 'supertoken-user-id');
+      });
+
+      it('should fall back to a user token when the supertoken has no userId', () => {
+        credentials.supertoken = makeToken(webex, {access_token: 'AT'});
+        credentials.userTokens.add(
+          makeToken(webex, {access_token: buildToken('user-token-user-id'), scope: 'scope1'})
+        );
+
+        assert.equal(credentials.getUserId(), 'user-token-user-id');
+      });
+
+      it('should prefer the supertoken over the user tokens', () => {
+        credentials.supertoken = makeToken(webex, {
+          access_token: buildToken('supertoken-user-id'),
+        });
+        credentials.userTokens.add(
+          makeToken(webex, {access_token: buildToken('user-token-user-id'), scope: 'scope1'})
+        );
+
+        assert.equal(credentials.getUserId(), 'supertoken-user-id');
+      });
+
+      it('should throw if no available token contains a userId', () => {
+        credentials.supertoken = makeToken(webex, {access_token: 'AT'});
+
+        expect(() => credentials.getUserId()).toThrow(
+          'could not extract the user ID from any available token'
+        );
+      });
     });
 
     describe('#initialize()', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

CA metrics only included userId if there was a device. This misses the messages sent before device registration

## by making the following changes

Derive the active userId from the available tokens

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
