### PR TITLE
fix(contact-center): wxApp customer logs at logger.level, enriched me…

### DIFF
--- a/packages/@webex/contact-center/.sdd/manifest.json
+++ b/packages/@webex/contact-center/.sdd/manifest.json
@@ -95,7 +95,8 @@
       "canonical_spec": "src/metrics/ai-docs/metrics-spec.md",
       "contracts": {
         "provides": [
-          "MetricsManager timing, behavioral/operational/business event submission, taxonomy, queues, and tracking-field helpers"
+          "MetricsManager timing, behavioral/operational/business event submission, taxonomy, queues, and tracking-field helpers",
+          "WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING operational/behavioral telemetry event (contract metrics.wxapp-offer-participant-fields-missing; emit site voice/wxAppOfferObservability.ts)"
         ],
         "requires": [
           "Webex internal metrics service; Webex ready lifecycle; LoggerProxy; browser document visibility"

--- a/packages/@webex/contact-center/ai-docs/CONTRACTS.md
+++ b/packages/@webex/contact-center/ai-docs/CONTRACTS.md
@@ -27,6 +27,12 @@
 | `cc.events` | Config/Core | backend CC_EVENTS | consume/map | config/core specs | remote WebSocket delivery; AQM correlation where configured | backend contract | `src/services/config/types.ts` |
 | `rtd.events` | Task | realtime transcription/suggestion | consume then publish per task | task spec | websocket best-effort according to remote service | additive payloads | `src/services/task/TaskManager.ts` |
 
+### Telemetry / Metrics Events
+
+| Contract ID | Owner module | Event constant | Wire name | Payload schema link | Tags | Defined at |
+|---|---|---|---|---|---|---|
+| `metrics.wxapp-offer-participant-fields-missing` | Task / Metrics | `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `WxApp Offer Participant Fields Missing` | `src/metrics/ai-docs/metrics-spec.md` | operational, behavioral | `src/metrics/constants.ts`, `src/services/task/voice/wxAppOfferObservability.ts` |
+
 ## Requires — what this repo depends on
 
 | Dependency | What is consumed | Schema / detail link | Availability assumption | Fallback on failure | Version floor |

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -2014,7 +2014,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
           {
             enableWxBetterTogether: true,
-            usersubPublished: false,
+            usersubPublished: this.webexCrossClientService.isAnswerCallsStateActive(),
             skipReason: 'user_id_unavailable',
             error: 'User ID is unavailable for cross-client publish',
           },

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -866,6 +866,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           accessBuddyTeam: this.agentConfig.accessBuddyTeam,
         },
         enableWxBetterTogether: this.isWxBetterTogetherEnabled(),
+        getWxAppUsersubPublished: () => this.webexCrossClientService.isAnswerCallsStateActive(),
       };
       this.taskManager.setConfigFlags(configFlags);
       // TODO: Make profile a singleton to make it available throughout app/sdk so we dont need to inject info everywhere
@@ -1641,7 +1642,13 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         if (sessionInitReady) {
           this.metricsManager.trackEvent(
             METRIC_EVENT_NAMES.WXAPP_SESSION_INIT_SUCCESS,
-            {loginOption, enableWxBetterTogether: true},
+            {
+              loginOption,
+              enableWxBetterTogether: true,
+              usersubPublished,
+              mercurySubscribed,
+              telephonyTaskType,
+            },
             ['operational', 'behavioral']
           );
         } else {
@@ -1650,6 +1657,9 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
             {
               loginOption,
               enableWxBetterTogether: true,
+              usersubPublished,
+              mercurySubscribed,
+              telephonyTaskType,
               skipReason: !usersubPublished ? 'usersub_not_published' : 'mercury_not_subscribed',
             },
             ['operational', 'behavioral']
@@ -1693,6 +1703,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           {
             loginOption,
             enableWxBetterTogether: true,
+            usersubPublished:
+              publishedEnable && this.webexCrossClientService.isAnswerCallsStateActive(),
+            mercurySubscribed: this.wxAppTelephonyMercurySync.isSubscribed(),
+            telephonyTaskType,
             skipReason: sessionInitFailureReason,
             error: error instanceof Error ? error.toString() : String(error),
           },
@@ -1952,7 +1966,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.WXAPP_MERCURY_SUBSCRIBE_FAILED,
-        {error: 'agentId unavailable'},
+        {error: 'agentId unavailable', mercurySubscribed: false},
         ['operational', 'behavioral']
       );
 
@@ -1971,7 +1985,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       });
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.WXAPP_MERCURY_SUBSCRIBE_FAILED,
-        {error: error instanceof Error ? error.toString() : String(error)},
+        {
+          error: error instanceof Error ? error.toString() : String(error),
+          mercurySubscribed: false,
+        },
         ['operational', 'behavioral']
       );
       this.wxAppTelephonyMercurySync.unsubscribe();
@@ -1999,6 +2016,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
           {
             enableWxBetterTogether: true,
+            usersubPublished: false,
             skipReason: 'user_id_unavailable',
             error: 'User ID is unavailable for cross-client publish',
           },

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -1703,8 +1703,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           {
             loginOption,
             enableWxBetterTogether: true,
-            usersubPublished:
-              publishedEnable && this.webexCrossClientService.isAnswerCallsStateActive(),
+            usersubPublished: this.webexCrossClientService.isAnswerCallsStateActive(),
             mercurySubscribed: this.wxAppTelephonyMercurySync.isSubscribed(),
             telephonyTaskType,
             skipReason: sessionInitFailureReason,
@@ -1717,8 +1716,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           enableWxBetterTogether: true,
           loginOption,
           wxAppHooksApplied: false,
-          usersubPublished:
-            publishedEnable && this.webexCrossClientService.isAnswerCallsStateActive(),
+          usersubPublished: this.webexCrossClientService.isAnswerCallsStateActive(),
           mercurySubscribed: this.wxAppTelephonyMercurySync.isSubscribed(),
           telephonyTaskType,
           skipReason: sessionInitFailureReason,

--- a/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
+++ b/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
@@ -332,7 +332,7 @@ Operational and business wire names are unchanged (`WXCC_SDK_WXAPP_*`).
 | `WXAPP_SESSION_INIT_SUCCESS` | `loginOption`, `enableWxBetterTogether`, `usersubPublished`, `mercurySubscribed`, `telephonyTaskType` |
 | `WXAPP_SESSION_INIT_FAILED` | above + `skipReason` (`usersub_not_published`, `mercury_not_subscribed`, `mercury_subscribe_failed`, `publish_failed`) + optional `error` |
 | `WXAPP_USERSUB_PUBLISH_SUCCESS` | `enableWxBetterTogether`, `usersubPublished` |
-| `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error` |
+| `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error`. `usersubPublished` reflects **retained session state** (`answerCallsState`), not the requested enable value — a failed disable/refresh while usersub remains active reports `true`. |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `mercurySubscribed: true` |
 | `WXAPP_MERCURY_SUBSCRIBE_FAILED` | `mercurySubscribed: false`, `error` |
 | `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available. Outdial-cancel AQM failures (`error.details`) include the same participant context fields via `getWxAppTelephonyMetricContext` merged with AQM correlation fields. |

--- a/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
+++ b/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
@@ -330,7 +330,7 @@ Operational and business wire names are unchanged (`WXCC_SDK_WXAPP_*`).
 | Event | Payload fields (booleans/enums; no raw IDs) |
 |---|---|
 | `WXAPP_SESSION_INIT_SUCCESS` | `loginOption`, `enableWxBetterTogether`, `usersubPublished`, `mercurySubscribed`, `telephonyTaskType` |
-| `WXAPP_SESSION_INIT_FAILED` | above + `skipReason` (`usersub_not_published`, `mercury_not_subscribed`, `mercury_subscribe_failed`, `publish_failed`) + optional `error` |
+| `WXAPP_SESSION_INIT_FAILED` | above + `skipReason` (`usersub_not_published`, `mercury_not_subscribed`, `mercury_subscribe_failed`, `publish_failed`) + optional `error`. `usersubPublished` reflects **retained session state** (`isAnswerCallsStateActive()` / `answerCallsState`), including on catch-path failures — not gated on the current init attempt's `publishedEnable`. |
 | `WXAPP_USERSUB_PUBLISH_SUCCESS` | `enableWxBetterTogether`, `usersubPublished` |
 | `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error`. `usersubPublished` reflects **retained session state** (`answerCallsState`), not the requested enable value — a failed disable/refresh while usersub remains active reports `true`. |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `mercurySubscribed: true` |

--- a/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
+++ b/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
@@ -335,7 +335,7 @@ Operational and business wire names are unchanged (`WXCC_SDK_WXAPP_*`).
 | `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error` |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `mercurySubscribed: true` |
 | `WXAPP_MERCURY_SUBSCRIBE_FAILED` | `mercurySubscribed: false`, `error` |
-| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available |
+| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available. Outdial-cancel AQM failures (`error.details`) include the same participant context fields via `getWxAppTelephonyMetricContext` merged with AQM correlation fields. |
 | `WXAPP_TASK_MUTE_*` / `DTMF_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`; failures add `trackingId` when available |
 | `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `taskId`, `usersubPublished`, `hasDeviceCallId`, `hasDeviceId`, `acceptReason` |
 

--- a/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
+++ b/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
@@ -246,6 +246,7 @@ All event names are defined in `METRIC_EVENT_NAMES` (`constants.ts`). Events fol
 | `WXAPP_SESSION_SKIPPED` | `'WxApp Session Skipped'` | Webex Together session skipped (`wxcc_sdk.user.webex_together_session_init.ignore`) |
 | `WXAPP_USERSUB_PUBLISH_SUCCESS` / `FAILED` | `'WxApp Usersub Publish ...'` | Cross-client usersub publish (`wxcc_sdk.user.webex_together_usersub_publish.complete\|fail`). Preflight failures (missing `userId` or device URL before HTTP publish) emit `WXAPP_USERSUB_PUBLISH_FAILED` with `skipReason` (`user_id_unavailable` / `device_url_unavailable`) and no `timeEvent` timer. Stale-generation discards (teardown or concurrent disable while HTTP publish is in flight) call `cancelTimedEvent` without emitting success/fail only when the completing publish still owns the active timer (`usersubPublishMetricsId` guard — a newer overlapping publish must not have its timer cleared). |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` / `FAILED` | `'WxApp Mercury Subscribe ...'` | Telephony Mercury mute-sync subscribe (`wxcc_sdk.user.webex_together_mercury_subscribe.complete\|fail`) |
+| `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `'WxApp Offer Participant Fields Missing'` | Read-only observability when usersub is active but inbound OFFERED participant **still** lacks valid wxApp fields after a **500 ms grace period** (orchestrated in `voice/wxAppOfferObservability.ts`; avoids false alarms from transient WS ordering). Emitted with matching `[CC wxApp] participant fields mismatch` WARN (`wxcc_sdk.user.webex_together_offer_participant_fields.fail`) |
 | `TASK_CONFERENCE_START_SUCCESS` / `FAILED` | `'Task Conference Start ...'` | Conference start result |
 | `TASK_CONFERENCE_END_SUCCESS` / `FAILED` | `'Task Conference End ...'` | Conference end result |
 | `TASK_CONFERENCE_TRANSFER_SUCCESS` / `FAILED` | `'Task Conference Transfer ...'` | Conference transfer result |
@@ -298,6 +299,7 @@ All event names are defined in `constants.ts` as `METRIC_EVENT_NAMES`. Events fo
 | WxApp Session Init     | `WXAPP_SESSION_INIT_SUCCESS`           | `WXAPP_SESSION_INIT_FAILED`            |
 | WxApp Usersub Publish  | `WXAPP_USERSUB_PUBLISH_SUCCESS`        | `WXAPP_USERSUB_PUBLISH_FAILED`         |
 | WxApp Mercury Subscribe | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS`     | `WXAPP_MERCURY_SUBSCRIBE_FAILED`       |
+| WxApp Offer Participant Fields | —                              | `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` |
 | Upload Logs            | `UPLOAD_LOGS_SUCCESS`                  | `UPLOAD_LOGS_FAILED`                   |
 | WebSocket Deregister   | `WEBSOCKET_DEREGISTER_SUCCESS`         | `WEBSOCKET_DEREGISTER_FAIL`            |
 | Device Type Update     | `AGENT_DEVICE_TYPE_UPDATE_SUCCESS`     | `AGENT_DEVICE_TYPE_UPDATE_FAILED`      |
@@ -319,8 +321,47 @@ Webex Together events (`WXAPP_*` constants) use `*_webex_together` compound targ
 | Usersub publish | `webex_together_usersub_publish` | `wxcc_sdk.user.webex_together_usersub_publish.complete` | `wxcc_sdk.user.webex_together_usersub_publish.fail` | — |
 | Mercury subscribe | `webex_together_mercury_subscribe` | `wxcc_sdk.user.webex_together_mercury_subscribe.complete` | `wxcc_sdk.user.webex_together_mercury_subscribe.fail` | — |
 | Session init | `webex_together_session_init` | `wxcc_sdk.user.webex_together_session_init.complete` | `wxcc_sdk.user.webex_together_session_init.fail` | `wxcc_sdk.user.webex_together_session_init.ignore` |
+| Offer participant fields | `webex_together_offer_participant_fields` | — | `wxcc_sdk.user.webex_together_offer_participant_fields.fail` | — |
 
 Operational and business wire names are unchanged (`WXCC_SDK_WXAPP_*`).
+
+### WxApp metric payload fields (operational / behavioral tags)
+
+| Event | Payload fields (booleans/enums; no raw IDs) |
+|---|---|
+| `WXAPP_SESSION_INIT_SUCCESS` | `loginOption`, `enableWxBetterTogether`, `usersubPublished`, `mercurySubscribed`, `telephonyTaskType` |
+| `WXAPP_SESSION_INIT_FAILED` | above + `skipReason` (`usersub_not_published`, `mercury_not_subscribed`, `mercury_subscribe_failed`, `publish_failed`) + optional `error` |
+| `WXAPP_USERSUB_PUBLISH_SUCCESS` | `enableWxBetterTogether`, `usersubPublished` |
+| `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error` |
+| `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `mercurySubscribed: true` |
+| `WXAPP_MERCURY_SUBSCRIBE_FAILED` | `mercurySubscribed: false`, `error` |
+| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available |
+| `WXAPP_TASK_MUTE_*` / `DTMF_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`; failures add `trackingId` when available |
+| `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `taskId`, `usersubPublished`, `hasDeviceCallId`, `hasDeviceId`, `acceptReason` |
+
+### Customer console log triage (MMT / support)
+
+Customers often embed with `logger.level: 'log'`. wxApp diagnostics use **`LoggerProxy.log`** / **`warn`** / **`error`** with prefix **`[CC wxApp]`** and grep-friendly `key=value` suffixes on the message string (fields also appear in structured `data`).
+
+| Search in browser console | Meaning |
+|---|---|
+| `[CC wxApp]` | All wxApp diagnostic lines (primary search) |
+| `WXCC_SDK_WXAPP` | Operational metric wire names (name only in console; payloads go to backend) |
+| `session readiness` | usersub + Mercury state after station login |
+| `offer decision` | Why Accept is visible/enabled; includes `acceptReason`, `hasDeviceCallId`, `usersubPublished` |
+| `participant fields mismatch` | usersub active but WS participant **still** missing wxApp triple after ~500 ms (transient gaps on first OFFERED tick are normal — look for `wxApp_offer_ready` within 1 s) |
+| `telephony accept failed` | REST answer failure; includes `trackingId` when available |
+
+Do **not** search `WXAPP` alone — it matches metric wire names but misses `[CC wxApp]` diagnostic lines.
+
+Example lines at `logger.level: 'log'`:
+
+```text
+PLUGIN_CC - [LOG]: ... [CC wxApp] session readiness usersubPublished=true mercurySubscribed=true loginOption=EXTENSION ...
+PLUGIN_CC - [LOG]: ... [CC wxApp] offer decision acceptReason=wxApp_offer_ready hasDeviceCallId=true usersubPublished=true interactionId=...
+PLUGIN_CC - [WARN]: ... [CC wxApp] participant fields mismatch usersubPublished=true hasDeviceCallId=false acceptReason=extension_non_wxApp_offer interactionId=...
+PLUGIN_CC - [LOG]: ... operational-events -> @submitEvent. Submit event: WXCC_SDK_WXAPP_TASK_ACCEPT_SUCCESS
+```
 
 Special events (no success/failure pair):
 
@@ -412,6 +453,7 @@ This table contains all 107 names from `src/metrics/constants.ts`; taxonomy pres
 | `WXAPP_USERSUB_PUBLISH_FAILED` | `WxApp Usersub Publish Failed` | yes |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `WxApp Mercury Subscribe Success` | yes |
 | `WXAPP_MERCURY_SUBSCRIBE_FAILED` | `WxApp Mercury Subscribe Failed` | yes |
+| `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `WxApp Offer Participant Fields Missing` | yes |
 | `UPLOAD_LOGS_SUCCESS` | `Upload Logs Success` | yes |
 | `UPLOAD_LOGS_FAILED` | `Upload Logs Failed` | yes |
 | `WEBSOCKET_DEREGISTER_SUCCESS` | `Websocket Deregister Success` | no |

--- a/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
+++ b/packages/@webex/contact-center/src/metrics/ai-docs/metrics-spec.md
@@ -335,7 +335,7 @@ Operational and business wire names are unchanged (`WXCC_SDK_WXAPP_*`).
 | `WXAPP_USERSUB_PUBLISH_FAILED` | `enableWxBetterTogether`, `usersubPublished`, optional `skipReason`, `error`. `usersubPublished` reflects **retained session state** (`answerCallsState`), not the requested enable value — a failed disable/refresh while usersub remains active reports `true`. |
 | `WXAPP_MERCURY_SUBSCRIBE_SUCCESS` | `mercurySubscribed: true` |
 | `WXAPP_MERCURY_SUBSCRIBE_FAILED` | `mercurySubscribed: false`, `error` |
-| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available. Outdial-cancel AQM failures (`error.details`) include the same participant context fields via `getWxAppTelephonyMetricContext` merged with AQM correlation fields. |
+| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`, optional `acceptReason`; failures add `trackingId` when available. Outdial-cancel AQM failures (`error.details`) include the same participant context fields via `getWxAppTelephonyMetricContext` merged with AQM correlation fields. Outdial cancel during post-accept pending phase may report `acceptReason: wxApp_answer_pending`. |
 | `WXAPP_TASK_MUTE_*` / `DTMF_*` | `taskId`, `hasDeviceCallId`, `hasDeviceId`; failures add `trackingId` when available |
 | `WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING` | `taskId`, `usersubPublished`, `hasDeviceCallId`, `hasDeviceId`, `acceptReason` |
 

--- a/packages/@webex/contact-center/src/metrics/behavioral-events.ts
+++ b/packages/@webex/contact-center/src/metrics/behavioral-events.ts
@@ -405,6 +405,12 @@ const eventTaxonomyMap: Record<string, BehavioralEventTaxonomy> = {
     target: 'webex_together_mercury_subscribe',
     verb: 'fail',
   },
+  [METRIC_EVENT_NAMES.WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING]: {
+    product,
+    agent: 'user',
+    target: 'webex_together_offer_participant_fields',
+    verb: 'fail',
+  },
 
   // Conference Tasks
   [METRIC_EVENT_NAMES.TASK_CONFERENCE_START_SUCCESS]: {

--- a/packages/@webex/contact-center/src/metrics/constants.ts
+++ b/packages/@webex/contact-center/src/metrics/constants.ts
@@ -156,6 +156,7 @@ export const METRIC_EVENT_NAMES = {
   WXAPP_USERSUB_PUBLISH_FAILED: 'WxApp Usersub Publish Failed',
   WXAPP_MERCURY_SUBSCRIBE_SUCCESS: 'WxApp Mercury Subscribe Success',
   WXAPP_MERCURY_SUBSCRIBE_FAILED: 'WxApp Mercury Subscribe Failed',
+  WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING: 'WxApp Offer Participant Fields Missing',
 
   UPLOAD_LOGS_SUCCESS: 'Upload Logs Success',
   UPLOAD_LOGS_FAILED: 'Upload Logs Failed',

--- a/packages/@webex/contact-center/src/services/AnswerCallOnWebexService.ts
+++ b/packages/@webex/contact-center/src/services/AnswerCallOnWebexService.ts
@@ -97,7 +97,7 @@ export default class AnswerCallOnWebexService {
     try {
       const uri = `${this.getTelephonyBaseUrl()}${resource}`;
 
-      LoggerProxy.info(`AnswerCallOnWebexService.${logMethod} request`, {
+      LoggerProxy.log(`AnswerCallOnWebexService.${logMethod} request`, {
         module: ANSWER_CALL_ON_WEBEX_FILE,
         method: logMethod,
         data: {uri, bodyKeys: Object.keys(body)},
@@ -110,7 +110,7 @@ export default class AnswerCallOnWebexService {
         addAuthHeader: true,
       })) as IHttpResponse;
 
-      LoggerProxy.info(`AnswerCallOnWebexService.${logMethod} success`, {
+      LoggerProxy.log(`AnswerCallOnWebexService.${logMethod} success`, {
         module: ANSWER_CALL_ON_WEBEX_FILE,
         method: logMethod,
         data: {statusCode: response.statusCode},
@@ -197,10 +197,10 @@ export default class AnswerCallOnWebexService {
     const uri = `${this.getTelephonyBaseUrl()}/${callId}${lineOwnerIdQuery}`;
 
     try {
-      LoggerProxy.info('AnswerCallOnWebexService.getCallDetails request', {
+      LoggerProxy.log('AnswerCallOnWebexService.getCallDetails request', {
         module: ANSWER_CALL_ON_WEBEX_FILE,
         method: METHODS.GET_CALL_DETAILS_ON_WEBEX,
-        data: {callId},
+        data: {callIdSuffix: callId.length <= 8 ? callId : callId.slice(-8)},
       });
 
       const response = (await this.webex.request({

--- a/packages/@webex/contact-center/src/services/WebexCrossClientService.ts
+++ b/packages/@webex/contact-center/src/services/WebexCrossClientService.ts
@@ -213,6 +213,7 @@ export default class WebexCrossClientService {
             METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
             {
               enableWxBetterTogether: enable,
+              usersubPublished: false,
               error: error instanceof Error ? error.toString() : String(error),
             },
             ['operational', 'behavioral']
@@ -243,12 +244,15 @@ export default class WebexCrossClientService {
     if (trackPublishMetrics) {
       metricsManager.trackEvent(
         METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_SUCCESS,
-        {enableWxBetterTogether: enable},
+        {
+          enableWxBetterTogether: enable,
+          usersubPublished: enable,
+        },
         ['operational', 'behavioral']
       );
     }
 
-    LoggerProxy.info(`Cross-client answer-calls-on-wxcc set to ${enable}`, {
+    LoggerProxy.log(`Cross-client answer-calls-on-wxcc set to ${enable}`, {
       module: WEBEX_CROSS_CLIENT_FILE,
       method: METHODS.SET_MANAGE_WEBEX_CALLING_IN_WXCC,
       data: {
@@ -273,6 +277,7 @@ export default class WebexCrossClientService {
       METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
       {
         enableWxBetterTogether: enable,
+        usersubPublished: false,
         skipReason,
         error,
       },

--- a/packages/@webex/contact-center/src/services/WebexCrossClientService.ts
+++ b/packages/@webex/contact-center/src/services/WebexCrossClientService.ts
@@ -213,7 +213,7 @@ export default class WebexCrossClientService {
             METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
             {
               enableWxBetterTogether: enable,
-              usersubPublished: false,
+              usersubPublished: this.answerCallsState,
               error: error instanceof Error ? error.toString() : String(error),
             },
             ['operational', 'behavioral']
@@ -277,7 +277,7 @@ export default class WebexCrossClientService {
       METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
       {
         enableWxBetterTogether: enable,
-        usersubPublished: false,
+        usersubPublished: this.answerCallsState,
         skipReason,
         error,
       },

--- a/packages/@webex/contact-center/src/services/WxAppTelephonyMercurySync.ts
+++ b/packages/@webex/contact-center/src/services/WxAppTelephonyMercurySync.ts
@@ -88,7 +88,7 @@ export default class WxAppTelephonyMercurySync {
 
       MetricsManager.getInstance().trackEvent(
         METRIC_EVENT_NAMES.WXAPP_MERCURY_SUBSCRIBE_FAILED,
-        {error: 'Mercury is unavailable for wxApp mute sync'},
+        {error: 'Mercury is unavailable for wxApp mute sync', mercurySubscribed: false},
         ['operational', 'behavioral']
       );
 
@@ -110,11 +110,11 @@ export default class WxAppTelephonyMercurySync {
 
     MetricsManager.getInstance().trackEvent(
       METRIC_EVENT_NAMES.WXAPP_MERCURY_SUBSCRIBE_SUCCESS,
-      {},
+      {mercurySubscribed: true},
       ['operational', 'behavioral']
     );
 
-    LoggerProxy.info('Subscribed to wxApp telephony Mercury mute sync', {
+    LoggerProxy.log('Subscribed to wxApp telephony Mercury mute sync', {
       module: WXAPP_TELEPHONY_MERCURY_SYNC_FILE,
       method: METHODS.SYNC_WXAPP_MUTE_FROM_MERCURY,
     });

--- a/packages/@webex/contact-center/src/services/task/TaskFactory.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskFactory.ts
@@ -31,6 +31,7 @@ export default class TaskFactory {
       isRecordingEnabled: recordingEnabled,
       enableWxBetterTogether: configFlags.enableWxBetterTogether ?? false,
       answerCallOnWebexService,
+      getUsersubPublished: configFlags.getWxAppUsersubPublished,
       consultTransferConfig: consultTransfer,
     };
     switch (mediaType) {

--- a/packages/@webex/contact-center/src/services/task/ai-docs/task-spec.md
+++ b/packages/@webex/contact-center/src/services/task/ai-docs/task-spec.md
@@ -617,6 +617,8 @@ This keeps transcript and suggestion delivery aligned on the same per-task event
 
 **wxApp consumer contract (WXCC-6026):** Hosts enable `enableWxBetterTogether` at init (Phase 1 init-only; re-init to change), bind UI to `task.uiControls` (including optional `main.keypad`), and call **`task.accept()`**, **`task.decline()`**, **`task.toggleMute({ muted? })`**, **`task.transmitDtmf({ dtmf })`**. SDK routes wxApp telephony internally on `Voice`. Shared-line `lineOwnerId` defaults from the wxApp agent participant when omitted.
 
+**wxApp OFFERED diagnostics:** `Voice.updateUiControls` delegates offer-decision logging and deferred participant-mismatch WARN/metric to `voice/wxAppOfferObservability.ts` (500 ms grace; observability only).
+
 **wxApp offer UI (`uiControlsComputer`):** `wxAppAcceptInFlight` disables accept/decline during the accept REST call. `wxAppAnswerPending` additionally disables accept and decline for **inbound** offers until ASSIGN; wxApp **outdial** keeps decline enabled during the post-accept "Calling…" phase so `cancelTask` remains available.
 
 **wxApp decline observability:** Inbound wxApp offers decline via telephony `rejectCall` (`runWxAppReject` → `WXAPP_TASK_DECLINE_*`). wxApp outdial cancellations use CC routing `cancelTask` (`runWxAppOutdialDecline` → additive `WXAPP_TASK_DECLINE_*` plus existing `TASK_DECLINE_*`).

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -2070,6 +2070,8 @@ export type VoiceUIControlOptions = {
   enableWxBetterTogether?: boolean;
   consultTransferConfig?: ConsultTransferDestinationConfig;
   answerCallOnWebexService?: import('../AnswerCallOnWebexService').default;
+  /** Read-only observability: whether usersub answer-calls-on-wxcc is active this session. */
+  getUsersubPublished?: () => boolean;
 };
 
 /**

--- a/packages/@webex/contact-center/src/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/Voice.ts
@@ -425,9 +425,14 @@ export default class Voice extends Task implements IVoice {
         METRIC_EVENT_NAMES.TASK_DECLINE_FAILED,
       ]);
 
+      const declineAcceptReason = this.wxAppAnswerPending
+        ? 'wxApp_answer_pending'
+        : 'wxApp_offer_ready';
       this.setWxAppAnswerPending(false);
-      const response = await runWxAppOutdialDecline(this.getWxAppVoiceDependencies(), () =>
-        this.contact.cancelTask({interactionId})
+      const response = await runWxAppOutdialDecline(
+        this.getWxAppVoiceDependencies(),
+        () => this.contact.cancelTask({interactionId}),
+        {acceptReason: declineAcceptReason}
       );
 
       this.metricsManager.trackEvent(

--- a/packages/@webex/contact-center/src/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/Voice.ts
@@ -48,13 +48,8 @@ import {
   WxAppVoiceDependencies,
   WxAppVoiceLifecycle,
 } from './wxAppVoiceMethods';
-import {
-  deriveWxAppAcceptReason,
-  logWxAppMercuryMuteSync,
-  logWxAppOfferDecision,
-  callIdSuffix,
-  WxAppAcceptReason,
-} from '../../wxAppDiagnosticLogging';
+import {logWxAppMercuryMuteSync, callIdSuffix} from '../../wxAppDiagnosticLogging';
+import {WxAppOfferObservability, WxAppOfferObservabilityContext} from './wxAppOfferObservability';
 
 export default class Voice extends Task implements IVoice {
   private static readonly WXAPP_MUTE_SYNC_RETRY_DELAY_MS = 50;
@@ -68,7 +63,9 @@ export default class Voice extends Task implements IVoice {
   private wxAppMuteSyncInFlight?: Promise<boolean | undefined>;
   private wxAppMuteToggleTail: Promise<void> = Promise.resolve();
   private wxAppDtmfTail: Promise<void> = Promise.resolve();
-  private lastLoggedWxAppAcceptReason?: WxAppAcceptReason;
+  /** Lazy — `super()` may call `updateUiControls` before field initializers run. */
+  private wxAppOfferObservability: WxAppOfferObservability | null = null;
+  private getUsersubPublished?: () => boolean;
 
   constructor(
     contact: ReturnType<typeof routingContact>,
@@ -98,6 +95,7 @@ export default class Voice extends Task implements IVoice {
 
     this.enableWxBetterTogether = resolvedOptions.enableWxBetterTogether;
     this.answerCallOnWebexService = callOptions?.answerCallOnWebexService;
+    this.getUsersubPublished = callOptions?.getUsersubPublished;
   }
 
   private getWxAppVoiceDependencies(): WxAppVoiceDependencies {
@@ -112,6 +110,7 @@ export default class Voice extends Task implements IVoice {
       setWxAppMuted: (muted: boolean) => {
         this.wxAppMuted = muted;
       },
+      getUsersubPublished: this.getUsersubPublished,
     };
   }
 
@@ -146,56 +145,37 @@ export default class Voice extends Task implements IVoice {
     this.updateUiControls(true);
   }
 
-  protected updateUiControls(forceEmit = false): void {
-    super.updateUiControls(forceEmit);
-    this.logWxAppOfferDecisionIfNeeded();
+  private getOrCreateWxAppOfferObservability(): WxAppOfferObservability {
+    if (!this.wxAppOfferObservability) {
+      this.wxAppOfferObservability = new WxAppOfferObservability();
+    }
+
+    return this.wxAppOfferObservability;
   }
 
-  private logWxAppOfferDecisionIfNeeded(): void {
-    if (!this.enableWxBetterTogether) {
-      return;
-    }
+  protected updateUiControls(forceEmit = false): void {
+    super.updateUiControls(forceEmit);
+    this.getOrCreateWxAppOfferObservability().handleUiControlsUpdate(
+      this.getWxAppOfferObservabilityContext()
+    );
+  }
 
-    const state = this.stateMachineService?.getSnapshot?.()?.value as TaskState | undefined;
-    if (state !== TaskState.OFFERED) {
-      return;
-    }
-
-    const accept = this.currentUiControls?.main?.accept;
-    if (!accept?.isVisible) {
-      return;
-    }
-
-    const deps = this.getWxAppVoiceDependencies();
-    const isOutdial = this.data?.interaction?.outboundType === 'OUTDIAL';
-    const isWxAppInboundOffer = this.isWebexAppInboundCallingOffer();
-    const isWxAppOutdialOffer = this.isWebexAppCallingOffer() && isOutdial;
-    const deviceDetails = getCallingDeviceDetails(deps);
-    const acceptReason = deriveWxAppAcceptReason({
-      isWxAppInboundOffer,
-      isWxAppOutdialOffer,
-      isWebrtc: this.uiControlConfig.voiceVariant === VOICE_VARIANT.WEBRTC,
-      isOutdial,
-      wxAppAcceptInFlight: this.wxAppAcceptInFlight,
-      wxAppAnswerPending: this.wxAppAnswerPending,
-      enableWxBetterTogether: this.enableWxBetterTogether,
-      hasDeviceCallId: Boolean(deviceDetails?.deviceCallId),
-    });
-
-    if (acceptReason === this.lastLoggedWxAppAcceptReason) {
-      return;
-    }
-
-    this.lastLoggedWxAppAcceptReason = acceptReason;
-
-    logWxAppOfferDecision({
-      interactionId: this.data.interactionId,
-      acceptVisible: accept.isVisible,
-      acceptEnabled: accept.isEnabled,
-      acceptReason,
-      wxAppParticipantDeviceType: deviceDetails?.deviceType,
-      hasDeviceCallId: Boolean(deviceDetails?.deviceCallId),
-    });
+  private getWxAppOfferObservabilityContext(): WxAppOfferObservabilityContext {
+    return {
+      getInteractionId: () => this.data.interactionId,
+      getTaskState: () => this.stateMachineService?.getSnapshot?.()?.value as TaskState | undefined,
+      getAcceptControl: () => this.currentUiControls?.main?.accept,
+      getVoiceVariant: () => this.uiControlConfig.voiceVariant ?? VOICE_VARIANT.PSTN,
+      isOutdial: () => this.data?.interaction?.outboundType === 'OUTDIAL',
+      isWxAppInboundOffer: () => this.isWebexAppInboundCallingOffer(),
+      isWxAppCallingOffer: () => this.isWebexAppCallingOffer(),
+      getWxAppAcceptInFlight: () => this.wxAppAcceptInFlight,
+      getWxAppAnswerPending: () => this.wxAppAnswerPending,
+      getEnableWxBetterTogether: () => this.enableWxBetterTogether,
+      getUsersubPublished: () => this.getUsersubPublished?.() ?? false,
+      getWxAppVoiceDependencies: () => this.getWxAppVoiceDependencies(),
+      getMetricsManager: () => this.metricsManager,
+    };
   }
 
   public applyWxAppMuteStateFromSync(incomingCallId: string, muted: boolean): void {

--- a/packages/@webex/contact-center/src/services/task/voice/wxAppOfferObservability.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/wxAppOfferObservability.ts
@@ -97,7 +97,7 @@ export class WxAppOfferObservability {
 
     if (participantDiagnostics.hasValidWxAppParticipant || !usersubPublished) {
       this.cancelGraceTimer();
-    } else if (!this.lastLoggedWxAppParticipantMismatch) {
+    } else if (!ctx.isOutdial() && !this.lastLoggedWxAppParticipantMismatch) {
       this.scheduleGraceTimer(ctx);
     }
   }
@@ -129,6 +129,10 @@ export class WxAppOfferObservability {
 
   private emitParticipantMismatchIfStillNeeded(ctx: WxAppOfferObservabilityContext): void {
     if (!ctx.getEnableWxBetterTogether() || this.lastLoggedWxAppParticipantMismatch) {
+      return;
+    }
+
+    if (ctx.isOutdial()) {
       return;
     }
 

--- a/packages/@webex/contact-center/src/services/task/voice/wxAppOfferObservability.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/wxAppOfferObservability.ts
@@ -1,0 +1,189 @@
+import MetricsManager from '../../../metrics/MetricsManager';
+import {METRIC_EVENT_NAMES} from '../../../metrics/constants';
+import {
+  deriveWxAppAcceptReason,
+  logWxAppOfferDecision,
+  logWxAppOfferParticipantMismatch,
+  WxAppAcceptReason,
+} from '../../wxAppDiagnosticLogging';
+import {TaskState} from '../state-machine';
+import {VoiceVariant, VOICE_VARIANT} from '../types';
+import {
+  getCallingDeviceDetails,
+  getWxAppParticipantDiagnostics,
+  WxAppVoiceDependencies,
+} from './wxAppVoiceMethods';
+
+/** Defer mismatch WARN/metric so transient WS ordering gaps (~200–300 ms) do not false-alarm. */
+export const WXAPP_PARTICIPANT_MISMATCH_GRACE_MS = 500;
+
+export type WxAppOfferObservabilityContext = {
+  getInteractionId: () => string;
+  getTaskState: () => TaskState | undefined;
+  getAcceptControl: () => {isVisible: boolean; isEnabled: boolean} | undefined;
+  getVoiceVariant: () => VoiceVariant;
+  isOutdial: () => boolean;
+  isWxAppInboundOffer: () => boolean;
+  isWxAppCallingOffer: () => boolean;
+  getWxAppAcceptInFlight: () => boolean;
+  getWxAppAnswerPending: () => boolean;
+  getEnableWxBetterTogether: () => boolean;
+  getUsersubPublished: () => boolean;
+  getWxAppVoiceDependencies: () => WxAppVoiceDependencies;
+  getMetricsManager: () => MetricsManager;
+};
+
+/**
+ * OFFERED-state wxApp offer diagnostics: acceptReason logging and deferred participant mismatch.
+ * Invoked from Voice.updateUiControls — observability only.
+ */
+export class WxAppOfferObservability {
+  private lastLoggedWxAppAcceptReason?: WxAppAcceptReason;
+  private lastLoggedWxAppParticipantMismatch = false;
+  private wxAppParticipantMismatchGraceTimer?: ReturnType<typeof setTimeout>;
+
+  public handleUiControlsUpdate(ctx: WxAppOfferObservabilityContext): void {
+    if (!ctx.getEnableWxBetterTogether()) {
+      this.cancelGraceTimer();
+
+      return;
+    }
+
+    const state = ctx.getTaskState();
+    if (state !== TaskState.OFFERED) {
+      this.cancelGraceTimer();
+
+      return;
+    }
+
+    const accept = ctx.getAcceptControl();
+    if (!accept?.isVisible) {
+      return;
+    }
+
+    const deps = ctx.getWxAppVoiceDependencies();
+    const isOutdial = ctx.isOutdial();
+    const isWxAppInboundOffer = ctx.isWxAppInboundOffer();
+    const isWxAppOutdialOffer = ctx.isWxAppCallingOffer() && isOutdial;
+    const deviceDetails = getCallingDeviceDetails(deps);
+    const participantDiagnostics = getWxAppParticipantDiagnostics(deps);
+    const usersubPublished = ctx.getUsersubPublished();
+    const acceptReason = deriveWxAppAcceptReason({
+      isWxAppInboundOffer,
+      isWxAppOutdialOffer,
+      isWebrtc: ctx.getVoiceVariant() === VOICE_VARIANT.WEBRTC,
+      isOutdial,
+      wxAppAcceptInFlight: ctx.getWxAppAcceptInFlight(),
+      wxAppAnswerPending: ctx.getWxAppAnswerPending(),
+      enableWxBetterTogether: ctx.getEnableWxBetterTogether(),
+      hasDeviceCallId: participantDiagnostics.hasDeviceCallId,
+    });
+
+    if (acceptReason !== this.lastLoggedWxAppAcceptReason) {
+      this.lastLoggedWxAppAcceptReason = acceptReason;
+
+      logWxAppOfferDecision({
+        interactionId: ctx.getInteractionId(),
+        acceptVisible: accept.isVisible,
+        acceptEnabled: accept.isEnabled,
+        acceptReason,
+        wxAppParticipantDeviceType:
+          deviceDetails?.deviceType ?? participantDiagnostics.participantDeviceType,
+        hasDeviceCallId: participantDiagnostics.hasDeviceCallId,
+        hasDeviceId: participantDiagnostics.hasDeviceId,
+        usersubPublished,
+      });
+    }
+
+    if (participantDiagnostics.hasValidWxAppParticipant || !usersubPublished) {
+      this.cancelGraceTimer();
+    } else if (!this.lastLoggedWxAppParticipantMismatch) {
+      this.scheduleGraceTimer(ctx);
+    }
+  }
+
+  public dispose(): void {
+    this.cancelGraceTimer();
+  }
+
+  private cancelGraceTimer(): void {
+    if (this.wxAppParticipantMismatchGraceTimer !== undefined) {
+      clearTimeout(this.wxAppParticipantMismatchGraceTimer);
+      this.wxAppParticipantMismatchGraceTimer = undefined;
+    }
+  }
+
+  private scheduleGraceTimer(ctx: WxAppOfferObservabilityContext): void {
+    if (
+      this.lastLoggedWxAppParticipantMismatch ||
+      this.wxAppParticipantMismatchGraceTimer !== undefined
+    ) {
+      return;
+    }
+
+    this.wxAppParticipantMismatchGraceTimer = setTimeout(() => {
+      this.wxAppParticipantMismatchGraceTimer = undefined;
+      this.emitParticipantMismatchIfStillNeeded(ctx);
+    }, WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+  }
+
+  private emitParticipantMismatchIfStillNeeded(ctx: WxAppOfferObservabilityContext): void {
+    if (!ctx.getEnableWxBetterTogether() || this.lastLoggedWxAppParticipantMismatch) {
+      return;
+    }
+
+    if (ctx.getTaskState() !== TaskState.OFFERED) {
+      return;
+    }
+
+    const accept = ctx.getAcceptControl();
+    if (!accept?.isVisible) {
+      return;
+    }
+
+    const deps = ctx.getWxAppVoiceDependencies();
+    const participantDiagnostics = getWxAppParticipantDiagnostics(deps);
+    const usersubPublished = ctx.getUsersubPublished();
+
+    if (!usersubPublished || participantDiagnostics.hasValidWxAppParticipant) {
+      return;
+    }
+
+    const isOutdial = ctx.isOutdial();
+    const acceptReason = deriveWxAppAcceptReason({
+      isWxAppInboundOffer: ctx.isWxAppInboundOffer(),
+      isWxAppOutdialOffer: ctx.isWxAppCallingOffer() && isOutdial,
+      isWebrtc: ctx.getVoiceVariant() === VOICE_VARIANT.WEBRTC,
+      isOutdial,
+      wxAppAcceptInFlight: ctx.getWxAppAcceptInFlight(),
+      wxAppAnswerPending: ctx.getWxAppAnswerPending(),
+      enableWxBetterTogether: ctx.getEnableWxBetterTogether(),
+      hasDeviceCallId: participantDiagnostics.hasDeviceCallId,
+    });
+
+    this.lastLoggedWxAppParticipantMismatch = true;
+
+    logWxAppOfferParticipantMismatch({
+      interactionId: ctx.getInteractionId(),
+      usersubPublished,
+      hasDeviceCallId: participantDiagnostics.hasDeviceCallId,
+      hasDeviceId: participantDiagnostics.hasDeviceId,
+      participantDeviceType: participantDiagnostics.participantDeviceType,
+      acceptVisible: accept.isVisible,
+      acceptEnabled: accept.isEnabled,
+      acceptReason,
+    });
+
+    ctx.getMetricsManager().trackEvent(
+      METRIC_EVENT_NAMES.WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING,
+      {
+        taskId: ctx.getInteractionId(),
+        usersubPublished,
+        hasDeviceCallId: participantDiagnostics.hasDeviceCallId,
+        hasDeviceId: participantDiagnostics.hasDeviceId,
+        acceptReason,
+      },
+      ['operational', 'behavioral']
+    );
+  }
+}

--- a/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
@@ -17,6 +17,7 @@ import {
 import {
   logWxAppTelephonyAction,
   logWxAppValidationFailure,
+  type WxAppAcceptReason,
   type WxAppTelephonyAction,
 } from '../../wxAppDiagnosticLogging';
 
@@ -454,11 +455,17 @@ export async function runWxAppReject(
   }
 }
 
+export type WxAppOutdialDeclineOptions = {
+  acceptReason?: WxAppAcceptReason;
+};
+
 export async function runWxAppOutdialDecline<T>(
   deps: WxAppVoiceDependencies,
-  executeCancel: () => Promise<T>
+  executeCancel: () => Promise<T>,
+  options?: WxAppOutdialDeclineOptions
 ): Promise<T> {
   const taskId = getInteractionId(deps);
+  const acceptReason = options?.acceptReason ?? 'wxApp_offer_ready';
 
   deps.metricsManager.timeEvent([
     METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
@@ -470,7 +477,7 @@ export async function runWxAppOutdialDecline<T>(
 
     deps.metricsManager.trackEvent(
       METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
-      {taskId, acceptReason: 'wxApp_offer_ready', ...getWxAppTelephonyMetricContext(deps)},
+      {taskId, acceptReason, ...getWxAppTelephonyMetricContext(deps)},
       ['operational', 'behavioral']
     );
 
@@ -479,7 +486,7 @@ export async function runWxAppOutdialDecline<T>(
     logWxAppOutdialDeclineFailure(deps, error);
     deps.metricsManager.trackEvent(
       METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_FAILED,
-      getWxAppOutdialDeclineFailurePayload(deps, error),
+      {acceptReason, ...getWxAppOutdialDeclineFailurePayload(deps, error)},
       ['operational', 'behavioral']
     );
     throw error;

--- a/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
@@ -35,6 +35,15 @@ export type WxAppVoiceDependencies = {
   getTaskState: () => TaskState | undefined;
   getWxAppMuted: () => boolean;
   setWxAppMuted: (muted: boolean) => void;
+  /** Read-only observability: whether usersub answer-calls-on-wxcc is active this session. */
+  getUsersubPublished?: () => boolean;
+};
+
+export type WxAppParticipantDiagnostics = {
+  participantDeviceType?: string;
+  hasDeviceCallId: boolean;
+  hasDeviceId: boolean;
+  hasValidWxAppParticipant: boolean;
 };
 
 /** @deprecated Use {@link WxAppVoiceDependencies} */
@@ -74,6 +83,34 @@ function getWxAppAgentParticipant(deps: WxAppVoiceDependencies): unknown {
   return Object.values(participants).find(
     (participant) => (participant as {id?: string})?.id === agentId
   );
+}
+
+export function getWxAppParticipantDiagnostics(
+  deps: WxAppVoiceDependencies
+): WxAppParticipantDiagnostics {
+  const participant = getWxAppAgentParticipant(deps) as WxAppParticipant | undefined;
+  const hasDeviceCallId =
+    typeof participant?.deviceCallId === 'string' && participant.deviceCallId.trim() !== '';
+  const hasDeviceId =
+    typeof participant?.deviceId === 'string' && participant.deviceId.trim() !== '';
+
+  return {
+    participantDeviceType: participant?.deviceType,
+    hasDeviceCallId,
+    hasDeviceId,
+    hasValidWxAppParticipant: isWxAppParticipant(participant),
+  };
+}
+
+function getWxAppTelephonyMetricContext(
+  deps: WxAppVoiceDependencies
+): Record<string, boolean | string> {
+  const diagnostics = getWxAppParticipantDiagnostics(deps);
+
+  return {
+    hasDeviceCallId: diagnostics.hasDeviceCallId,
+    hasDeviceId: diagnostics.hasDeviceId,
+  };
 }
 
 export function getCallingDeviceDetails(
@@ -169,11 +206,12 @@ function logTelephonyFailure(
 function getWxAppTelephonyMetricFailurePayload(
   deps: WxAppVoiceDependencies,
   error: unknown
-): Record<string, string> {
+): Record<string, string | boolean> {
   const wxError = error as WxAppTelephonyError;
-  const payload: Record<string, string> = {
+  const payload: Record<string, string | boolean> = {
     taskId: getInteractionId(deps) ?? '',
     error: error instanceof Error ? error.toString() : String(error),
+    ...getWxAppTelephonyMetricContext(deps),
   };
 
   if (wxError.trackingId) {
@@ -324,7 +362,7 @@ export async function transmitDtmfOnWebex(
     throw new Error('WxApp call ID is unavailable');
   }
 
-  LoggerProxy.info('transmitDtmf', {
+  LoggerProxy.log('transmitDtmf', {
     module: 'wxAppVoiceMethods',
     method: METHODS.TRANSMIT_DTMF,
     data: {
@@ -362,10 +400,11 @@ export async function runWxAppAccept(
     lifecycle.resetWxAppMuted();
     await lifecycle.syncWxAppMuteFromCallDetails();
 
-    deps.metricsManager.trackEvent(METRIC_EVENT_NAMES.WXAPP_TASK_ACCEPT_SUCCESS, {taskId}, [
-      'operational',
-      'behavioral',
-    ]);
+    deps.metricsManager.trackEvent(
+      METRIC_EVENT_NAMES.WXAPP_TASK_ACCEPT_SUCCESS,
+      {taskId, acceptReason: 'wxApp_offer_ready', ...getWxAppTelephonyMetricContext(deps)},
+      ['operational', 'behavioral']
+    );
   } catch (error) {
     lifecycle.setWxAppAnswerPending(false);
     logTelephonyFailure('accept', deps, error);
@@ -395,10 +434,11 @@ export async function runWxAppReject(
   try {
     await rejectOnWebex(deps, options);
 
-    deps.metricsManager.trackEvent(METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS, {taskId}, [
-      'operational',
-      'behavioral',
-    ]);
+    deps.metricsManager.trackEvent(
+      METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
+      {taskId, acceptReason: 'wxApp_offer_ready', ...getWxAppTelephonyMetricContext(deps)},
+      ['operational', 'behavioral']
+    );
   } catch (error) {
     logTelephonyFailure('decline', deps, error);
     deps.metricsManager.trackEvent(
@@ -424,10 +464,11 @@ export async function runWxAppOutdialDecline<T>(
   try {
     const result = await executeCancel();
 
-    deps.metricsManager.trackEvent(METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS, {taskId}, [
-      'operational',
-      'behavioral',
-    ]);
+    deps.metricsManager.trackEvent(
+      METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
+      {taskId, acceptReason: 'wxApp_offer_ready', ...getWxAppTelephonyMetricContext(deps)},
+      ['operational', 'behavioral']
+    );
 
     return result;
   } catch (error) {
@@ -458,7 +499,7 @@ export async function runWxAppToggleMute(
 
     deps.metricsManager.trackEvent(
       METRIC_EVENT_NAMES.WXAPP_TASK_MUTE_SUCCESS,
-      {taskId, targetMuted: deps.getWxAppMuted()},
+      {taskId, targetMuted: deps.getWxAppMuted(), ...getWxAppTelephonyMetricContext(deps)},
       ['operational', 'behavioral']
     );
   } catch (error) {
@@ -489,7 +530,7 @@ export async function runWxAppTransmitDtmf(
 
     deps.metricsManager.trackEvent(
       METRIC_EVENT_NAMES.WXAPP_TASK_DTMF_SUCCESS,
-      {taskId, dtmfLength: options.dtmf.length},
+      {taskId, dtmfLength: options.dtmf.length, ...getWxAppTelephonyMetricContext(deps)},
       ['operational', 'behavioral']
     );
   } catch (error) {

--- a/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/wxAppVoiceMethods.ts
@@ -236,7 +236,11 @@ function getWxAppOutdialDeclineFailurePayload(
   const aqmDetails = (error as AqmWrappedError).details;
 
   if (aqmDetails) {
-    return {...base, ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(aqmDetails)};
+    return {
+      ...base,
+      ...getWxAppTelephonyMetricContext(deps),
+      ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(aqmDetails),
+    };
   }
 
   return getWxAppTelephonyMetricFailurePayload(deps, error);

--- a/packages/@webex/contact-center/src/services/wxAppDiagnosticLogging.ts
+++ b/packages/@webex/contact-center/src/services/wxAppDiagnosticLogging.ts
@@ -31,16 +31,54 @@ export function callIdSuffix(callId: string | null | undefined): string | undefi
   return callId.length <= 8 ? callId : callId.slice(-8);
 }
 
-function logWxApp(message: string, method: string, data: WxAppLogData): void {
-  LoggerProxy.info(`${WXAPP_LOG_PREFIX} ${message}`, {
+function formatLogSuffix(data: WxAppLogData, keys?: string[]): string {
+  const entries = keys
+    ? keys.map((key) => [key, data[key]] as const)
+    : Object.entries(data).filter(([key]) => key !== 'feature' && key !== 'event');
+
+  const parts = entries
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${key}=${String(value)}`);
+
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function logWxApp(
+  message: string,
+  method: string,
+  data: WxAppLogData,
+  suffixKeys?: string[]
+): void {
+  const suffix = formatLogSuffix(data, suffixKeys);
+  LoggerProxy.log(`${WXAPP_LOG_PREFIX} ${message}${suffix}`, {
     module: 'wxAppDiagnosticLogging',
     method,
     data: {feature: WXAPP_LOG_FEATURE, ...data},
   });
 }
 
-function logWxAppError(message: string, method: string, data: WxAppLogData): void {
-  LoggerProxy.error(`${WXAPP_LOG_PREFIX} ${message}`, {
+function logWxAppWarn(
+  message: string,
+  method: string,
+  data: WxAppLogData,
+  suffixKeys?: string[]
+): void {
+  const suffix = formatLogSuffix(data, suffixKeys);
+  LoggerProxy.warn(`${WXAPP_LOG_PREFIX} ${message}${suffix}`, {
+    module: 'wxAppDiagnosticLogging',
+    method,
+    data: {feature: WXAPP_LOG_FEATURE, ...data},
+  });
+}
+
+function logWxAppError(
+  message: string,
+  method: string,
+  data: WxAppLogData,
+  suffixKeys?: string[]
+): void {
+  const suffix = formatLogSuffix(data, suffixKeys);
+  LoggerProxy.error(`${WXAPP_LOG_PREFIX} ${message}${suffix}`, {
     module: 'wxAppDiagnosticLogging',
     method,
     data: {feature: WXAPP_LOG_FEATURE, ...data},
@@ -56,7 +94,7 @@ export function logWxAppSessionReadiness(params: {
   telephonyTaskType: 'Voice' | 'WebRTC' | 'unknown';
   skipReason?: WxAppSessionSkipReason;
 }): void {
-  logWxApp('session readiness', 'logWxAppSessionReadiness', {
+  const data: WxAppLogData = {
     event: 'session_readiness',
     enableWxBetterTogether: params.enableWxBetterTogether,
     loginOption: params.loginOption,
@@ -65,7 +103,16 @@ export function logWxAppSessionReadiness(params: {
     mercurySubscribed: params.mercurySubscribed,
     telephonyTaskType: params.telephonyTaskType,
     skipReason: params.skipReason,
-  });
+  };
+
+  logWxApp('session readiness', 'logWxAppSessionReadiness', data, [
+    'usersubPublished',
+    'mercurySubscribed',
+    'loginOption',
+    'enableWxBetterTogether',
+    'telephonyTaskType',
+    'skipReason',
+  ]);
 }
 
 export function deriveWxAppAcceptReason(params: {
@@ -111,8 +158,10 @@ export function logWxAppOfferDecision(params: {
   acceptReason: WxAppAcceptReason;
   wxAppParticipantDeviceType?: string;
   hasDeviceCallId: boolean;
+  hasDeviceId?: boolean;
+  usersubPublished?: boolean;
 }): void {
-  logWxApp('offer decision', 'logWxAppOfferDecision', {
+  const data: WxAppLogData = {
     event: 'offer_decision',
     interactionId: params.interactionId,
     acceptVisible: params.acceptVisible,
@@ -120,7 +169,51 @@ export function logWxAppOfferDecision(params: {
     acceptReason: params.acceptReason,
     wxAppParticipantDeviceType: params.wxAppParticipantDeviceType,
     hasDeviceCallId: params.hasDeviceCallId,
-  });
+    hasDeviceId: params.hasDeviceId,
+    usersubPublished: params.usersubPublished,
+  };
+
+  logWxApp('offer decision', 'logWxAppOfferDecision', data, [
+    'acceptReason',
+    'hasDeviceCallId',
+    'hasDeviceId',
+    'usersubPublished',
+    'interactionId',
+    'acceptVisible',
+    'acceptEnabled',
+  ]);
+}
+
+export function logWxAppOfferParticipantMismatch(params: {
+  interactionId: string;
+  usersubPublished: boolean;
+  hasDeviceCallId: boolean;
+  hasDeviceId: boolean;
+  participantDeviceType?: string;
+  acceptVisible: boolean;
+  acceptEnabled: boolean;
+  acceptReason: WxAppAcceptReason;
+}): void {
+  const data: WxAppLogData = {
+    event: 'participant_fields_mismatch',
+    interactionId: params.interactionId,
+    usersubPublished: params.usersubPublished,
+    hasDeviceCallId: params.hasDeviceCallId,
+    hasDeviceId: params.hasDeviceId,
+    participantDeviceType: params.participantDeviceType ?? 'missing',
+    acceptVisible: params.acceptVisible,
+    acceptEnabled: params.acceptEnabled,
+    acceptReason: params.acceptReason,
+  };
+
+  logWxAppWarn('participant fields mismatch', 'logWxAppOfferParticipantMismatch', data, [
+    'usersubPublished',
+    'hasDeviceCallId',
+    'hasDeviceId',
+    'acceptReason',
+    'interactionId',
+    'participantDeviceType',
+  ]);
 }
 
 export function logWxAppTelephonyAction(params: {
@@ -142,18 +235,32 @@ export function logWxAppTelephonyAction(params: {
   };
 
   if (params.phase === 'failed') {
-    logWxAppError(`telephony ${params.action} ${params.phase}`, 'logWxAppTelephonyAction', payload);
+    logWxAppError(
+      `telephony ${params.action} ${params.phase}`,
+      'logWxAppTelephonyAction',
+      payload,
+      ['interactionId', 'trackingId', 'httpStatus', 'failureReason']
+    );
   } else {
-    logWxApp(`telephony ${params.action} ${params.phase}`, 'logWxAppTelephonyAction', payload);
+    logWxApp(`telephony ${params.action} ${params.phase}`, 'logWxAppTelephonyAction', payload, [
+      'interactionId',
+      'action',
+      'phase',
+    ]);
   }
 }
 
 export function logWxAppValidationFailure(reason: string, interactionId?: string): void {
-  logWxAppError('validation failed', 'logWxAppValidationFailure', {
-    event: 'validation_failed',
-    reason,
-    interactionId,
-  });
+  logWxAppError(
+    'validation failed',
+    'logWxAppValidationFailure',
+    {
+      event: 'validation_failed',
+      reason,
+      interactionId,
+    },
+    ['reason', 'interactionId']
+  );
 }
 
 export function logWxAppMercuryMuteSync(params: {
@@ -163,12 +270,17 @@ export function logWxAppMercuryMuteSync(params: {
   interactionId?: string;
   dropReason?: string;
 }): void {
-  logWxApp(`mercury mute sync ${params.phase}`, 'logWxAppMercuryMuteSync', {
-    event: 'mercury_mute_sync',
-    phase: params.phase,
-    muted: params.muted,
-    callIdSuffix: params.callIdSuffix,
-    interactionId: params.interactionId,
-    dropReason: params.dropReason,
-  });
+  logWxApp(
+    `mercury mute sync ${params.phase}`,
+    'logWxAppMercuryMuteSync',
+    {
+      event: 'mercury_mute_sync',
+      phase: params.phase,
+      muted: params.muted,
+      callIdSuffix: params.callIdSuffix,
+      interactionId: params.interactionId,
+      dropReason: params.dropReason,
+    },
+    ['phase', 'muted', 'callIdSuffix', 'interactionId', 'dropReason']
+  );
 }

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -614,6 +614,8 @@ export type ConfigFlags = {
   isRecordingEnabled?: boolean;
   /** Whether wxApp thick-client answer controls/APIs are enabled (WXCC-6026) */
   enableWxBetterTogether?: boolean;
+  /** Read-only observability: live usersub answer-calls-on-wxcc state for wxApp offer diagnostics. */
+  getWxAppUsersubPublished?: () => boolean;
 };
 
 /**

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -1209,7 +1209,57 @@ describe('webex.cc', () => {
 
       expect(metricSpy).toHaveBeenCalledWith(
         METRIC_EVENT_NAMES.WXAPP_SESSION_INIT_FAILED,
-        expect.objectContaining({skipReason: 'publish_failed'}),
+        expect.objectContaining({skipReason: 'publish_failed', usersubPublished: false}),
+        ['operational', 'behavioral']
+      );
+      expect(webex.cc.isWxBetterTogetherEnabled()).toBe(false);
+    });
+
+    it('should report retained usersub state when publish fails during re-init', async () => {
+      webex.cc.$config = {...webex.cc.$config, enableWxBetterTogether: true};
+      webex.internal.device = {userId: 'user-123', url: 'https://wdm.example.com/devices/dev-1'};
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        webRtcEnabled: false,
+        loginVoiceOptions: ['EXTENSION'],
+      };
+      webex.cc.webCallingService.loginOption = LoginOption.EXTENSION;
+      mockTaskManager.applyEnableWxBetterTogether(true);
+
+      jest.spyOn(webex.cc as any, 'ensureWxAppMercuryConnected').mockResolvedValue(undefined);
+      jest
+        .spyOn(webex.cc['wxAppTelephonyMercurySync'], 'subscribe')
+        .mockImplementation(() => {});
+      jest.spyOn(webex.cc['wxAppTelephonyMercurySync'], 'isSubscribed').mockReturnValue(true);
+      jest
+        .spyOn(webex.cc['webexCrossClientService'], 'isAnswerCallsStateActive')
+        .mockReturnValue(true);
+      jest
+        .spyOn(webex.cc['webexCrossClientService'], 'setManageWebexCallingInWxcc')
+        .mockRejectedValue(new Error('publish failed'));
+      jest
+        .spyOn(webex.cc as any, 'releaseWxAppMercuryResources')
+        .mockResolvedValue(undefined);
+      const metricSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+
+      jest.spyOn(webex.cc.services.agent, 'stationLogin').mockResolvedValue({
+        data: {
+          agentId: 'agentId',
+          teamId: 'teamId',
+          channelsMap: {chat: [], email: [], social: [], telephony: []},
+        },
+        trackingId: 'track-1',
+      } as StationLoginSuccess);
+
+      await webex.cc.stationLogin({
+        teamId: 'teamId',
+        loginOption: LoginOption.EXTENSION,
+        dialNumber: '1001',
+      });
+
+      expect(metricSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.WXAPP_SESSION_INIT_FAILED,
+        expect.objectContaining({skipReason: 'publish_failed', usersubPublished: true}),
         ['operational', 'behavioral']
       );
       expect(webex.cc.isWxBetterTogetherEnabled()).toBe(false);

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -404,20 +404,23 @@ describe('webex.cc', () => {
         module: CC_FILE,
         method: 'connectWebsocket',
       });
-      expect(mockTaskManager.setConfigFlags).toHaveBeenCalledWith({
-        isEndTaskEnabled: mockAgentProfile.isEndTaskEnabled,
-        isEndConsultEnabled: mockAgentProfile.isEndConsultEnabled,
-        webRtcEnabled: mockAgentProfile.webRtcEnabled,
-        autoWrapup: mockAgentProfile.wrapUpData.wrapUpProps.autoWrapup ?? false,
-        aiFeature: mockAgentProfile.aiFeature,
-        consultTransfer: {
-          allowConsultToQueue: mockAgentProfile.allowConsultToQueue,
-          accessQueue: mockAgentProfile.accessQueue,
-          accessEntryPoint: mockAgentProfile.accessEntryPoint,
-          accessBuddyTeam: mockAgentProfile.accessBuddyTeam,
-        },
-        enableWxBetterTogether: false,
-      });
+      expect(mockTaskManager.setConfigFlags).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isEndTaskEnabled: mockAgentProfile.isEndTaskEnabled,
+          isEndConsultEnabled: mockAgentProfile.isEndConsultEnabled,
+          webRtcEnabled: mockAgentProfile.webRtcEnabled,
+          autoWrapup: mockAgentProfile.wrapUpData.wrapUpProps.autoWrapup ?? false,
+          aiFeature: mockAgentProfile.aiFeature,
+          consultTransfer: {
+            allowConsultToQueue: mockAgentProfile.allowConsultToQueue,
+            accessQueue: mockAgentProfile.accessQueue,
+            accessEntryPoint: mockAgentProfile.accessEntryPoint,
+            accessBuddyTeam: mockAgentProfile.accessBuddyTeam,
+          },
+          enableWxBetterTogether: false,
+          getWxAppUsersubPublished: expect.any(Function),
+        })
+      );
       expect(reloadSpy).toHaveBeenCalled();
       expect(result).toEqual(mockAgentProfile);
       expect(mockMetricsManager.timeEvent).toHaveBeenCalledWith([

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -1671,7 +1671,61 @@ describe('webex.cc', () => {
       );
       expect(metricSpy).toHaveBeenCalledWith(
         METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
-        expect.objectContaining({skipReason: 'user_id_unavailable'}),
+        expect.objectContaining({skipReason: 'user_id_unavailable', usersubPublished: false}),
+        ['operational', 'behavioral']
+      );
+      expect(webex.cc.isWxBetterTogetherEnabled()).toBe(true);
+    });
+
+    it('should report retained usersub state when userId is missing during re-init', async () => {
+      webex.cc.$config = {...webex.cc.$config, enableWxBetterTogether: true};
+      webex.internal.device = {
+        url: 'https://wdm.example.com/devices/dev-1',
+        registered: true,
+        register: jest.fn().mockResolvedValue(undefined),
+      };
+      webex.internal.mercury = {
+        connected: true,
+        connect: jest.fn().mockResolvedValue(undefined),
+        on: jest.fn(),
+        off: jest.fn(),
+      };
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        webRtcEnabled: false,
+        loginVoiceOptions: ['EXTENSION'],
+      };
+      webex.cc.webCallingService.loginOption = LoginOption.EXTENSION;
+      mockTaskManager.applyEnableWxBetterTogether(true);
+
+      jest
+        .spyOn(webex.cc['webexCrossClientService'], 'isAnswerCallsStateActive')
+        .mockReturnValue(true);
+      const publishSpy = jest
+        .spyOn(webex.cc['webexCrossClientService'], 'setManageWebexCallingInWxcc')
+        .mockResolvedValue(undefined);
+      jest.spyOn(webex.cc['wxAppTelephonyMercurySync'], 'isSubscribed').mockReturnValue(true);
+      const metricSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+
+      jest.spyOn(webex.cc.services.agent, 'stationLogin').mockResolvedValue({
+        data: {
+          agentId: 'agentId',
+          teamId: 'teamId',
+          channelsMap: {chat: [], email: [], social: [], telephony: []},
+        },
+        trackingId: 'track-1',
+      } as StationLoginSuccess);
+
+      await webex.cc.stationLogin({
+        teamId: 'teamId',
+        loginOption: LoginOption.EXTENSION,
+        dialNumber: '1001',
+      });
+
+      expect(publishSpy).not.toHaveBeenCalledWith(true, expect.anything());
+      expect(metricSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
+        expect.objectContaining({skipReason: 'user_id_unavailable', usersubPublished: true}),
         ['operational', 'behavioral']
       );
       expect(webex.cc.isWxBetterTogetherEnabled()).toBe(true);

--- a/packages/@webex/contact-center/test/unit/spec/services/WebexCrossClientService.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/WebexCrossClientService.ts
@@ -160,9 +160,51 @@ describe('WebexCrossClientService', () => {
 
     expect(trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
-      expect.objectContaining({enableWxBetterTogether: true}),
+      expect.objectContaining({enableWxBetterTogether: true, usersubPublished: false}),
       ['operational', 'behavioral']
     );
+  });
+
+  it('reports retained usersub state when disable publish fails after successful enable', async () => {
+    await service.setManageWebexCallingInWxcc(true, {trackPublishMetrics: true});
+    trackEvent.mockClear();
+
+    webex.request = jest.fn().mockRejectedValue(new Error('disable failed'));
+
+    await expect(
+      service.setManageWebexCallingInWxcc(false, {trackPublishMetrics: true})
+    ).rejects.toThrow('disable failed');
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
+      expect.objectContaining({
+        enableWxBetterTogether: false,
+        usersubPublished: true,
+      }),
+      ['operational', 'behavioral']
+    );
+    expect(service.isAnswerCallsStateActive()).toBe(true);
+  });
+
+  it('reports retained usersub state when re-enable publish fails after successful enable', async () => {
+    await service.setManageWebexCallingInWxcc(true);
+    trackEvent.mockClear();
+
+    webex.request = jest.fn().mockRejectedValue(new Error('refresh failed'));
+
+    await expect(
+      service.setManageWebexCallingInWxcc(true, {trackPublishMetrics: true})
+    ).rejects.toThrow('refresh failed');
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_FAILED,
+      expect.objectContaining({
+        enableWxBetterTogether: true,
+        usersubPublished: true,
+      }),
+      ['operational', 'behavioral']
+    );
+    expect(service.isAnswerCallsStateActive()).toBe(true);
   });
 
   it('tracks usersub publish success when trackPublishMetrics is enabled', async () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/WebexCrossClientService.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/WebexCrossClientService.ts
@@ -174,7 +174,7 @@ describe('WebexCrossClientService', () => {
     ]);
     expect(trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_SUCCESS,
-      {enableWxBetterTogether: true},
+      {enableWxBetterTogether: true, usersubPublished: true},
       ['operational', 'behavioral']
     );
   });
@@ -243,7 +243,7 @@ describe('WebexCrossClientService', () => {
     expect(cancelTimedEvent).not.toHaveBeenCalled();
     expect(trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_USERSUB_PUBLISH_SUCCESS,
-      {enableWxBetterTogether: false},
+      {enableWxBetterTogether: false, usersubPublished: false},
       ['operational', 'behavioral']
     );
   });

--- a/packages/@webex/contact-center/test/unit/spec/services/WxAppTelephonyMercurySync.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/WxAppTelephonyMercurySync.ts
@@ -42,7 +42,7 @@ describe('WxAppTelephonyMercurySync', () => {
     expect(sync.isSubscribed()).toBe(true);
     expect(trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_MERCURY_SUBSCRIBE_SUCCESS,
-      {},
+      {mercurySubscribed: true},
       ['operational', 'behavioral']
     );
   });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/Voice.ts
@@ -848,69 +848,28 @@ describe('Voice Task', () => {
     });
   });
 
-  describe('wxApp offer decision logging', () => {
-    const wxAppParticipant = {
-      deviceType: 'wxApp',
-      deviceId: 'device-id-1',
-      deviceCallId: 'call-id-1',
-    };
-
-    const makeWxAppOfferTaskData = () =>
-      createBaseData({
+  describe('wxApp offer observability integration', () => {
+    it('delegates OFFERED ui control updates to wxApp offer observability', () => {
+      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
+      const taskData = createBaseData({
         agentId: 'agent-1',
         interaction: {
           participants: {
-            'agent-1': {id: 'agent-1', ...wxAppParticipant},
+            'agent-1': {
+              id: 'agent-1',
+              deviceType: 'wxApp',
+              deviceId: 'device-id-1',
+              deviceCallId: 'call-id-1',
+            },
           },
         } as any,
       });
-
-    it('logs evolving accept reasons through the normal wxApp accept flow', () => {
-      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
-      const taskData = makeWxAppOfferTaskData();
       const voice = new Voice(dummyContact, taskData, {enableWxBetterTogether: true});
 
       voice.stateMachineService?.send({type: TaskEvent.TASK_INCOMING, taskData});
 
       expect(logSpy).toHaveBeenCalledWith(
         expect.objectContaining({acceptReason: 'wxApp_offer_ready'})
-      );
-
-      logSpy.mockClear();
-      voice['setWxAppAcceptInFlight'](true);
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.objectContaining({acceptReason: 'wxApp_accept_in_flight'})
-      );
-
-      logSpy.mockClear();
-      voice['setWxAppAcceptInFlight'](false);
-      voice['setWxAppAnswerPending'](true);
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.objectContaining({acceptReason: 'wxApp_answer_pending'})
-      );
-    });
-
-    it('logs browser_webrtc_offer when voice variant is WebRTC on a non-wxApp inbound offer', () => {
-      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
-      const taskData = createBaseData({
-        agentId: 'agent-1',
-        interaction: {
-          participants: {
-            'agent-1': {id: 'agent-1', deviceType: 'phone', deviceId: 'device-id-1'},
-          },
-        } as any,
-      });
-      const voice = new Voice(dummyContact, taskData, {
-        enableWxBetterTogether: true,
-        voiceVariant: VOICE_VARIANT.WEBRTC,
-      });
-
-      voice.stateMachineService?.send({type: TaskEvent.TASK_INCOMING, taskData});
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.objectContaining({acceptReason: 'browser_webrtc_offer'})
       );
     });
   });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppOfferObservability.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppOfferObservability.ts
@@ -52,6 +52,7 @@ function makeContext(
     wxAppAnswerPending?: boolean;
     voiceVariant?: typeof VOICE_VARIANT.PSTN;
     acceptEnabled?: boolean;
+    isOutdial?: boolean;
   } = {}
 ): WxAppOfferObservabilityContext & {setTaskData: (data: TaskData) => void; setTaskState: (s: TaskState) => void} {
   let taskData = overrides.taskData ?? makeTaskDataWithoutWxAppFields();
@@ -77,7 +78,7 @@ function makeContext(
       isEnabled: overrides.acceptEnabled ?? false,
     }),
     getVoiceVariant: () => overrides.voiceVariant ?? VOICE_VARIANT.PSTN,
-    isOutdial: () => false,
+    isOutdial: () => overrides.isOutdial ?? false,
     isWxAppInboundOffer: () => {
       const p = taskData.interaction?.participants?.['agent-1'] as
         | {deviceType?: string; deviceCallId?: string; deviceId?: string}
@@ -258,6 +259,22 @@ describe('WxAppOfferObservability', () => {
       jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn or emit metric for outdial offers with missing wxApp fields', () => {
+      const warnSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferParticipantMismatch');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext({isOutdial: true});
+
+      observability.handleUiControlsUpdate(ctx);
+      jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(ctx.getMetricsManager().trackEvent).not.toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING,
+        expect.anything(),
+        expect.anything()
+      );
     });
   });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppOfferObservability.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppOfferObservability.ts
@@ -1,0 +1,263 @@
+import MetricsManager from '../../../../../../src/metrics/MetricsManager';
+import {METRIC_EVENT_NAMES} from '../../../../../../src/metrics/constants';
+import {TaskState} from '../../../../../../src/services/task/state-machine';
+import {TaskData, VOICE_VARIANT} from '../../../../../../src/services/task/types';
+import {
+  WxAppOfferObservability,
+  WxAppOfferObservabilityContext,
+  WXAPP_PARTICIPANT_MISMATCH_GRACE_MS,
+} from '../../../../../../src/services/task/voice/wxAppOfferObservability';
+import {WxAppVoiceDependencies} from '../../../../../../src/services/task/voice/wxAppVoiceMethods';
+import * as wxAppDiagnosticLogging from '../../../../../../src/services/wxAppDiagnosticLogging';
+import {createTaskData} from '../taskTestUtils';
+
+const wxAppParticipant = {
+  deviceType: 'wxApp',
+  deviceId: 'device-id-1',
+  deviceCallId: 'call-id-1',
+};
+
+function makeTaskDataWithoutWxAppFields(): TaskData {
+  return createTaskData({
+    agentId: 'agent-1',
+    interaction: {
+      participants: {
+        'agent-1': {id: 'agent-1'},
+      },
+    } as TaskData['interaction'],
+  });
+}
+
+function makeTaskDataWithWxAppFields(): TaskData {
+  return createTaskData({
+    agentId: 'agent-1',
+    interaction: {
+      participants: {
+        'agent-1': {id: 'agent-1', ...wxAppParticipant},
+      },
+    } as TaskData['interaction'],
+  });
+}
+
+function makeMockMetricsManager(): jest.Mocked<Pick<MetricsManager, 'trackEvent'>> {
+  return {trackEvent: jest.fn()};
+}
+
+function makeContext(
+  overrides: {
+    taskData?: TaskData;
+    taskState?: TaskState;
+    usersubPublished?: boolean;
+    wxAppAcceptInFlight?: boolean;
+    wxAppAnswerPending?: boolean;
+    voiceVariant?: typeof VOICE_VARIANT.PSTN;
+    acceptEnabled?: boolean;
+  } = {}
+): WxAppOfferObservabilityContext & {setTaskData: (data: TaskData) => void; setTaskState: (s: TaskState) => void} {
+  let taskData = overrides.taskData ?? makeTaskDataWithoutWxAppFields();
+  let taskState = overrides.taskState ?? TaskState.OFFERED;
+  const metricsManager = makeMockMetricsManager() as unknown as MetricsManager;
+
+  const deps = (): WxAppVoiceDependencies => ({
+    enableWxBetterTogether: true,
+    agentId: 'agent-1',
+    metricsManager,
+    getTaskData: () => taskData,
+    getTaskState: () => taskState,
+    getWxAppMuted: () => false,
+    setWxAppMuted: jest.fn(),
+    getUsersubPublished: () => overrides.usersubPublished ?? true,
+  });
+
+  return {
+    getInteractionId: () => taskData.interactionId,
+    getTaskState: () => taskState,
+    getAcceptControl: () => ({
+      isVisible: true,
+      isEnabled: overrides.acceptEnabled ?? false,
+    }),
+    getVoiceVariant: () => overrides.voiceVariant ?? VOICE_VARIANT.PSTN,
+    isOutdial: () => false,
+    isWxAppInboundOffer: () => {
+      const p = taskData.interaction?.participants?.['agent-1'] as
+        | {deviceType?: string; deviceCallId?: string; deviceId?: string}
+        | undefined;
+      return (
+        p?.deviceType === 'wxApp' &&
+        typeof p.deviceCallId === 'string' &&
+        p.deviceCallId.trim() !== '' &&
+        typeof p.deviceId === 'string' &&
+        p.deviceId.trim() !== ''
+      );
+    },
+    isWxAppCallingOffer: () => {
+      const p = taskData.interaction?.participants?.['agent-1'] as
+        | {deviceType?: string; deviceCallId?: string; deviceId?: string}
+        | undefined;
+      return (
+        p?.deviceType === 'wxApp' &&
+        typeof p.deviceCallId === 'string' &&
+        p.deviceCallId.trim() !== '' &&
+        typeof p.deviceId === 'string' &&
+        p.deviceId.trim() !== ''
+      );
+    },
+    getWxAppAcceptInFlight: () => overrides.wxAppAcceptInFlight ?? false,
+    getWxAppAnswerPending: () => overrides.wxAppAnswerPending ?? false,
+    getEnableWxBetterTogether: () => true,
+    getUsersubPublished: () => overrides.usersubPublished ?? true,
+    getWxAppVoiceDependencies: deps,
+    getMetricsManager: () => metricsManager,
+    setTaskData: (data: TaskData) => {
+      taskData = data;
+    },
+    setTaskState: (state: TaskState) => {
+      taskState = state;
+    },
+  };
+}
+
+describe('WxAppOfferObservability', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('offer decision logging', () => {
+    it('logs wxApp_offer_ready when participant fields are present', () => {
+      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext({taskData: makeTaskDataWithWxAppFields(), acceptEnabled: true});
+
+      observability.handleUiControlsUpdate(ctx);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({acceptReason: 'wxApp_offer_ready'})
+      );
+    });
+
+    it('logs accept reason transitions only once per reason', () => {
+      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext({
+        taskData: makeTaskDataWithWxAppFields(),
+        wxAppAcceptInFlight: true,
+      });
+
+      observability.handleUiControlsUpdate(ctx);
+      observability.handleUiControlsUpdate(ctx);
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({acceptReason: 'wxApp_accept_in_flight'})
+      );
+    });
+
+    it('logs browser_webrtc_offer for WebRTC variant without wxApp participant', () => {
+      const logSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferDecision');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext({
+        taskData: createTaskData({
+          agentId: 'agent-1',
+          interaction: {
+            participants: {
+              'agent-1': {id: 'agent-1', deviceType: 'phone', deviceId: 'device-id-1'},
+            },
+          } as TaskData['interaction'],
+        }),
+        voiceVariant: VOICE_VARIANT.WEBRTC,
+      });
+
+      observability.handleUiControlsUpdate(ctx);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({acceptReason: 'browser_webrtc_offer'})
+      );
+    });
+  });
+
+  describe('deferred participant mismatch', () => {
+    it('does not warn when wxApp fields arrive before grace period elapses', () => {
+      const warnSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferParticipantMismatch');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext();
+
+      observability.handleUiControlsUpdate(ctx);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      ctx.setTaskData(makeTaskDataWithWxAppFields());
+      observability.handleUiControlsUpdate(ctx);
+
+      jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(ctx.getMetricsManager().trackEvent).not.toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING,
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('warns and emits metric when fields remain missing after grace period', () => {
+      const warnSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferParticipantMismatch');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext();
+
+      observability.handleUiControlsUpdate(ctx);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interactionId: 'interaction-1',
+          usersubPublished: true,
+          hasDeviceCallId: false,
+          hasDeviceId: false,
+          acceptReason: 'extension_non_wxApp_offer',
+        })
+      );
+      expect(ctx.getMetricsManager().trackEvent).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING,
+        expect.objectContaining({
+          taskId: 'interaction-1',
+          usersubPublished: true,
+          hasDeviceCallId: false,
+          hasDeviceId: false,
+          acceptReason: 'extension_non_wxApp_offer',
+        }),
+        ['operational', 'behavioral']
+      );
+    });
+
+    it('cancels pending mismatch when task leaves OFFERED before grace period', () => {
+      const warnSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferParticipantMismatch');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext();
+
+      observability.handleUiControlsUpdate(ctx);
+      ctx.setTaskState(TaskState.TERMINATED);
+      observability.handleUiControlsUpdate(ctx);
+
+      jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('clears grace timer on dispose', () => {
+      const warnSpy = jest.spyOn(wxAppDiagnosticLogging, 'logWxAppOfferParticipantMismatch');
+      const observability = new WxAppOfferObservability();
+      const ctx = makeContext();
+
+      observability.handleUiControlsUpdate(ctx);
+      observability.dispose();
+
+      jest.advanceTimersByTime(WXAPP_PARTICIPANT_MISMATCH_GRACE_MS);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
@@ -570,6 +570,8 @@ describe('runWxAppOutdialDecline', () => {
         trackingId: 'aqm-track-1',
         failureReason: 'TASK_NOT_FOUND',
         reasonCode: 404,
+        hasDeviceCallId: true,
+        hasDeviceId: true,
       }),
       ['operational', 'behavioral']
     );

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
@@ -431,7 +431,12 @@ describe('runWxAppAccept', () => {
     ]);
     expect(deps.metricsManager.trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_TASK_ACCEPT_SUCCESS,
-      {taskId: 'interaction-1'},
+      expect.objectContaining({
+        taskId: 'interaction-1',
+        acceptReason: 'wxApp_offer_ready',
+        hasDeviceCallId: true,
+        hasDeviceId: true,
+      }),
       ['operational', 'behavioral']
     );
     expect(lifecycle.setWxAppAcceptInFlight).toHaveBeenNthCalledWith(1, true);
@@ -473,7 +478,12 @@ describe('runWxAppReject', () => {
 
     expect(deps.metricsManager.trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
-      {taskId: 'interaction-1'},
+      expect.objectContaining({
+        taskId: 'interaction-1',
+        acceptReason: 'wxApp_offer_ready',
+        hasDeviceCallId: true,
+        hasDeviceId: true,
+      }),
       ['operational', 'behavioral']
     );
   });
@@ -509,7 +519,12 @@ describe('runWxAppOutdialDecline', () => {
     ]);
     expect(deps.metricsManager.trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
-      {taskId: 'interaction-1'},
+      expect.objectContaining({
+        taskId: 'interaction-1',
+        acceptReason: 'wxApp_offer_ready',
+        hasDeviceCallId: true,
+        hasDeviceId: true,
+      }),
       ['operational', 'behavioral']
     );
   });
@@ -596,7 +611,12 @@ describe('runWxAppTransmitDtmf metrics', () => {
 
     expect(deps.metricsManager.trackEvent).toHaveBeenCalledWith(
       METRIC_EVENT_NAMES.WXAPP_TASK_DTMF_SUCCESS,
-      {taskId: 'interaction-1', dtmfLength: 3},
+      expect.objectContaining({
+        taskId: 'interaction-1',
+        dtmfLength: 3,
+        hasDeviceCallId: true,
+        hasDeviceId: true,
+      }),
       ['operational', 'behavioral']
     );
   });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/wxAppVoiceMethods.ts
@@ -529,6 +529,24 @@ describe('runWxAppOutdialDecline', () => {
     );
   });
 
+  it('tracks post-accept acceptReason on outdial cancel when provided', async () => {
+    const deps = makeDeps();
+    const cancelResult = {type: 'RoutingMessage', trackingId: 'track-1', data: {}};
+
+    await runWxAppOutdialDecline(deps, async () => cancelResult, {
+      acceptReason: 'wxApp_answer_pending',
+    });
+
+    expect(deps.metricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.WXAPP_TASK_DECLINE_SUCCESS,
+      expect.objectContaining({
+        taskId: 'interaction-1',
+        acceptReason: 'wxApp_answer_pending',
+      }),
+      ['operational', 'behavioral']
+    );
+  });
+
   it('tracks wxApp decline failed metric and rethrows when cancel fails', async () => {
     const deps = makeDeps();
     const error = new Error('cancel failed');

--- a/packages/@webex/contact-center/test/unit/spec/services/wxAppDiagnosticLogging.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/wxAppDiagnosticLogging.ts
@@ -3,13 +3,15 @@ import {
   callIdSuffix,
   deriveWxAppAcceptReason,
   logWxAppOfferDecision,
+  logWxAppOfferParticipantMismatch,
   logWxAppSessionReadiness,
   logWxAppTelephonyAction,
   WXAPP_LOG_PREFIX,
 } from '../../../../src/services/wxAppDiagnosticLogging';
 
 jest.mock('../../../../src/logger-proxy', () => ({
-  info: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
   error: jest.fn(),
 }));
 
@@ -76,7 +78,7 @@ describe('wxAppDiagnosticLogging', () => {
   });
 
   describe('log helpers', () => {
-    it('logs session readiness with feature prefix', () => {
+    it('logs session readiness at log level with grep-friendly suffix', () => {
       logWxAppSessionReadiness({
         enableWxBetterTogether: true,
         loginOption: 'EXTENSION',
@@ -86,8 +88,8 @@ describe('wxAppDiagnosticLogging', () => {
         telephonyTaskType: 'Voice',
       });
 
-      expect(LoggerProxy.info).toHaveBeenCalledWith(
-        `${WXAPP_LOG_PREFIX} session readiness`,
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        expect.stringContaining(`${WXAPP_LOG_PREFIX} session readiness`),
         expect.objectContaining({
           module: 'wxAppDiagnosticLogging',
           method: 'logWxAppSessionReadiness',
@@ -95,27 +97,61 @@ describe('wxAppDiagnosticLogging', () => {
             feature: 'wxApp',
             event: 'session_readiness',
             loginOption: 'EXTENSION',
+            usersubPublished: true,
+            mercurySubscribed: true,
           }),
         })
       );
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        expect.stringContaining('usersubPublished=true'),
+        expect.anything()
+      );
     });
 
-    it('logs offer decision with acceptReason', () => {
+    it('logs offer decision at log level with acceptReason suffix', () => {
       logWxAppOfferDecision({
         interactionId: 'task-1',
         acceptVisible: true,
         acceptEnabled: false,
         acceptReason: 'extension_non_wxApp_offer',
         hasDeviceCallId: false,
+        hasDeviceId: false,
+        usersubPublished: true,
       });
 
-      expect(LoggerProxy.info).toHaveBeenCalledWith(
-        `${WXAPP_LOG_PREFIX} offer decision`,
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        expect.stringContaining('acceptReason=extension_non_wxApp_offer'),
         expect.objectContaining({
           data: expect.objectContaining({
             event: 'offer_decision',
             acceptReason: 'extension_non_wxApp_offer',
             interactionId: 'task-1',
+            usersubPublished: true,
+          }),
+        })
+      );
+    });
+
+    it('logs participant mismatch at warn level', () => {
+      logWxAppOfferParticipantMismatch({
+        interactionId: 'task-1',
+        usersubPublished: true,
+        hasDeviceCallId: false,
+        hasDeviceId: false,
+        participantDeviceType: 'wxApp',
+        acceptVisible: true,
+        acceptEnabled: false,
+        acceptReason: 'extension_non_wxApp_offer',
+      });
+
+      expect(LoggerProxy.warn).toHaveBeenCalledWith(
+        expect.stringContaining('participant fields mismatch'),
+        expect.objectContaining({
+          method: 'logWxAppOfferParticipantMismatch',
+          data: expect.objectContaining({
+            event: 'participant_fields_mismatch',
+            usersubPublished: true,
+            hasDeviceCallId: false,
           }),
         })
       );
@@ -131,7 +167,7 @@ describe('wxAppDiagnosticLogging', () => {
       });
 
       expect(LoggerProxy.error).toHaveBeenCalledWith(
-        `${WXAPP_LOG_PREFIX} telephony accept failed`,
+        expect.stringContaining('telephony accept failed'),
         expect.objectContaining({
           data: expect.objectContaining({
             trackingId: 'track-abc',


### PR DESCRIPTION
# COMPLETES https://jira-eng-sjc12.cisco.com/jira/browse/CAI-8583

**Follow-up to:** [webex-js-sdk#5186](https://github.com/webex/webex-js-sdk/pull/5186) (merged wxApp diagnostic logging + behavioral metrics)

## This pull request addresses

After #5186 merged, manual testing on the **widgets side** (cc-widgets sample app with `logger.level: 'log'`) showed that **wxApp diagnostic fields were not visible in browser console logs**. Only operational metric **wire names** (`WXCC_SDK_WXAPP_*`) appeared — not the triage fields needed to root-cause wxApp failures (`usersubPublished`, `acceptReason`, `hasDeviceCallId`, `trackingId`).

**Root causes:**

1. wxApp diagnostics used `LoggerProxy.info`, which is **suppressed** when embeds use the common default `logger.level: 'log'`.
2. Metric console output shows event names only; enriched payload fields go to the backend, not DevTools.
3. Searching `WXAPP` alone matches metric wire names but misses `[CC wxApp]` diagnostic lines.
4. Transient WS ordering on first OFFERED tick (~200–300 ms before wxApp participant fields arrive) caused **false-positive** `participant fields mismatch` WARN on healthy calls.

**Scope constraint:** Observability-only — no business logic changes (no uiControls, accept routing, telephony REST behavior, or validation rules). SDK-only; no widgets changes.

## by making the following changes

### Phase 1 — Log visibility at customer-default level

- **`wxAppDiagnosticLogging.ts`** — routine diagnostics use `LoggerProxy.log` / `warn` / `error` with `[CC wxApp]` prefix and grep-friendly `key=value` suffixes on the message string (fields also in structured `data`).
- Same `info` → `log` change in `AnswerCallOnWebexService.ts`, `WebexCrossClientService.ts`, `WxAppTelephonyMercurySync.ts`, `wxAppVoiceMethods.ts`.

### Phase 2 — Metric payload enrichment

Enrich existing `WXAPP_*` `trackEvent` payload objects only (no new tracking paths):

| Area | Payload fields added |
|------|---------------------|
| `WXAPP_SESSION_INIT_*` | `usersubPublished`, `mercurySubscribed`, `telephonyTaskType` |
| `WXAPP_USERSUB_PUBLISH_*` | `usersubPublished` |
| `WXAPP_MERCURY_SUBSCRIBE_*` | `mercurySubscribed` |
| `WXAPP_TASK_ACCEPT_*` / `DECLINE_*` | `hasDeviceCallId`, `hasDeviceId`, `acceptReason`; failures add `trackingId` |
| `WXAPP_TASK_MUTE_*` / `DTMF_*` | `hasDeviceCallId`, `hasDeviceId`; failures add `trackingId` |

### Phase 3 — Customer diagnostics (read-only)

- Enriched **`logWxAppOfferDecision`** with `hasDeviceId`, `usersubPublished`.
- Added **`logWxAppOfferParticipantMismatch()`** (WARN) + metric **`WXAPP_OFFER_PARTICIPANT_FIELDS_MISSING`** when usersub is active but WS participant **still** lacks valid wxApp fields after a **500 ms grace period** (avoids false alarms from transient WS ordering).
- Wired **`getWxAppUsersubPublished`** on `ConfigFlags` → `TaskFactory` → `Voice` for offer diagnostics.

### Refactor — Extract offer observability from Voice.ts

- **New:** `packages/@webex/contact-center/src/services/task/voice/wxAppOfferObservability.ts`
  - Class `WxAppOfferObservability` with `handleUiControlsUpdate(ctx)`, `dispose()`
  - `WXAPP_PARTICIPANT_MISMATCH_GRACE_MS = 500`
- **`Voice.ts`** — thin delegate via lazy `getOrCreateWxAppOfferObservability()` (required because `super()` may call `updateUiControls` before field initializers run).

### Documentation

- **`metrics-spec.md`** — wxApp metric payload table, customer console log search cheat sheet, pointer to `wxAppOfferObservability.ts`.
- **`task-spec.md`** — one line on OFFERED diagnostics delegation.

### Customer console search cheat sheet

| Search in browser console | Meaning |
|---|---|
| `[CC wxApp]` | All wxApp diagnostic lines (primary search) |
| `WXCC_SDK_WXAPP` | Operational metric wire names |
| `session readiness` | usersub + Mercury state after station login |
| `offer decision` | Why Accept is visible/enabled; includes `acceptReason`, `hasDeviceCallId`, `usersubPublished` |
| `participant fields mismatch` | usersub active but WS participant still missing wxApp triple after ~500 ms |
| `telephony accept failed` | REST answer failure; includes `trackingId` when available |

Do **not** search `WXAPP` alone — it matches metric wire names but misses `[CC wxApp]` diagnostic lines.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

**Automated (unit):**

- `yarn workspace @webex/contact-center test:unit` — **1097/1097 tests passed**
- New: `test/unit/spec/services/task/voice/wxAppOfferObservability.ts` (7 tests — offer decision logging, deferred mismatch grace, timer cancel on field recovery / task leave OFFERED / dispose)
- Updated: `wxAppDiagnosticLogging.ts`, `Voice.ts`, `wxAppVoiceMethods.ts`, `WebexCrossClientService.ts`, `WxAppTelephonyMercurySync.ts`, `cc.ts` specs

**Manual (`logger.level: 'log'`, widgets sample app):**

- Extension login + `enableWxBetterTogether: true` → `[CC wxApp] session readiness usersubPublished=true mercurySubscribed=true` visible in console
- Inbound wxApp offer → `[CC wxApp] offer decision acceptReason=wxApp_offer_ready hasDeviceCallId=true` visible after fields arrive (~200–300 ms)
- Accept success → `WXCC_SDK_WXAPP_TASK_ACCEPT_SUCCESS` + telephony success logs
- **No false mismatch WARN** on healthy calls when wxApp fields arrive within ~500 ms (grace period verified)
- First accept failure with `ERR_CONNECTION_RESET` / `status: 0` confirmed as network/transport (not missing wxApp fields); second accept succeeded with 204

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [x] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.